### PR TITLE
initial user onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useSession } from "@/lib/auth-client";
 import LoginPage from "@/pages/LoginPage";
+import OnboardingPage from "@/pages/OnboardingPage";
 import InboxPage from "@/pages/InboxPage";
 
 const queryClient = new QueryClient();
@@ -30,6 +31,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/onboarding" element={<OnboardingPage />} />
           <Route
             path="/*"
             element={

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import { signIn } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,6 +11,35 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [setupRequired, setSetupRequired] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/setup/status");
+        const data = (await res.json()) as { setupRequired: boolean };
+        if (!cancelled) setSetupRequired(data.setupRequired);
+      } catch {
+        if (!cancelled) setSetupRequired(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (setupRequired === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-neutral-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (setupRequired) {
+    return <Navigate to="/onboarding" replace />;
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { signIn } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+
+type Status = "checking" | "available" | "unavailable";
+
+export default function OnboardingPage() {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<Status>("checking");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/setup/status");
+        const data = (await res.json()) as { setupRequired: boolean };
+        if (cancelled) return;
+        setStatus(data.setupRequired ? "available" : "unavailable");
+      } catch {
+        if (!cancelled) setStatus("unavailable");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, password }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error || "Setup failed");
+        if (res.status === 403) setStatus("unavailable");
+        return;
+      }
+      const result = await signIn.emailAndPassword({ email, password });
+      if (result.error) {
+        // Account created but auto sign-in failed — send to login.
+        navigate("/login", { replace: true });
+        return;
+      }
+      window.location.href = "/";
+    } catch {
+      setError("Setup failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (status === "checking") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-neutral-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (status === "unavailable") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-neutral-50">
+        <Card className="w-full max-w-sm">
+          <CardHeader>
+            <CardTitle className="text-2xl">Setup complete</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-neutral-600">
+              An administrator account already exists for this instance. Please
+              sign in instead.
+            </p>
+            <Button className="w-full" onClick={() => navigate("/login")}>
+              Go to sign in
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Welcome to cmail</CardTitle>
+          <p className="text-sm text-neutral-500">
+            Create the first administrator account to get started.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                autoComplete="name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+                autoComplete="new-password"
+              />
+              <p className="text-xs text-neutral-500">
+                At least 8 characters.
+              </p>
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Creating account..." : "Create administrator"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -10,6 +10,7 @@ import { emailsRouter } from "./routers/emails-router";
 import { sendRouter } from "./routers/send-router";
 import { attachmentsRouter } from "./routers/attachments-router";
 import { statsRouter } from "./routers/stats-router";
+import { setupRouter } from "./routers/setup-router";
 import type { Variables } from "./variables";
 
 const app = new OpenAPIHono<{
@@ -36,7 +37,11 @@ app.all("/api/auth/*", (c) => {
 
 // Session resolution for all API routes
 app.use("/api/*", async (c, next) => {
-  if (c.req.path.startsWith("/api/auth") || c.req.path === "/api/health") {
+  if (
+    c.req.path.startsWith("/api/auth") ||
+    c.req.path.startsWith("/api/setup") ||
+    c.req.path === "/api/health"
+  ) {
     return next();
   }
   const auth = createAuth(c.env);
@@ -56,6 +61,7 @@ app.route("/api/emails", emailsRouter);
 app.route("/api/send", sendRouter);
 app.route("/api/attachments", attachmentsRouter);
 app.route("/api/stats", statsRouter);
+app.route("/api/setup", setupRouter);
 
 // Health check (no auth)
 app.get("/api/health", (c) => c.json({ status: "ok" }));

--- a/worker/src/routers/setup-router.ts
+++ b/worker/src/routers/setup-router.ts
@@ -1,0 +1,112 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
+import { users } from "../db/auth.schema";
+import { createAuth } from "../auth";
+import { json200Response } from "../lib/helpers";
+import type { Variables } from "../variables";
+
+export const setupRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const StatusSchema = z.object({
+  setupRequired: z.boolean(),
+});
+
+const SetupRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email(),
+  password: z.string().min(8).max(128),
+});
+
+const SetupResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+const ErrorSchema = z.object({
+  error: z.string(),
+});
+
+async function countUsers(db: Variables["db"]): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(users);
+  return result[0]?.count ?? 0;
+}
+
+const statusRoute = createRoute({
+  method: "get",
+  path: "/status",
+  tags: ["Setup"],
+  description: "Check whether initial setup is required (no users exist).",
+  responses: {
+    ...json200Response(StatusSchema, "Setup status"),
+  },
+});
+
+setupRouter.openapi(statusRoute, async (c) => {
+  const db = c.get("db");
+  const count = await countUsers(db);
+  return c.json({ setupRequired: count === 0 }, 200);
+});
+
+const createRouteDef = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Setup"],
+  description:
+    "Create the first administrator user. Only available when no users exist.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SetupRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    ...json200Response(SetupResponseSchema, "First user created"),
+    403: {
+      description: "Setup has already been completed",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+setupRouter.openapi(createRouteDef, async (c) => {
+  const db = c.get("db");
+
+  // Guard: reject if any users already exist.
+  const count = await countUsers(db);
+  if (count > 0) {
+    return c.json({ error: "Setup has already been completed" }, 403);
+  }
+
+  const { name, email, password } = c.req.valid("json");
+
+  const auth = createAuth(c.env);
+
+  try {
+    await auth.api.signUpEmail({
+      body: { name, email, password },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Signup failed";
+    return c.json({ error: message }, 400);
+  }
+
+  // Promote the freshly created user to admin so they can manage future users.
+  await db
+    .update(users)
+    .set({ role: "admin" })
+    .where(eq(users.email, email));
+
+  return c.json({ success: true }, 200);
+});


### PR DESCRIPTION
Adds a zero-user setup flow so the first deploy can bootstrap an
administrator without exposing public signup. A new /api/setup router
is gated by a user-count check: GET /api/setup/status reports whether
setup is required, POST /api/setup creates the first user via
Better-Auth and promotes them to admin. Both endpoints 403 once any
user exists. On the frontend, /onboarding hosts the setup form and
LoginPage redirects there while setupRequired is true.