### PR TITLE
fix: correctly handle email attachments end-to-end

### DIFF
--- a/src/components/EmailHtmlModal.tsx
+++ b/src/components/EmailHtmlModal.tsx
@@ -1,4 +1,5 @@
 import DOMPurify from "dompurify";
+import { Paperclip } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -20,6 +21,10 @@ export default function EmailHtmlModal({
 }: EmailHtmlModalProps) {
   if (!email) return null;
 
+  const downloadableAttachments = (email.attachments ?? []).filter(
+    (att) => !att.contentId,
+  );
+
   const senderLabel =
     email.type === "sent"
       ? `You → ${email.toAddress}`
@@ -37,6 +42,20 @@ export default function EmailHtmlModal({
             {new Date(email.timestamp * 1000).toLocaleString()}
           </p>
         </DialogHeader>
+        {downloadableAttachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 border-b border-border px-6 py-3">
+            {downloadableAttachments.map((att) => (
+              <a
+                key={att.id}
+                href={`/api/attachments/${att.id}`}
+                className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-text-secondary hover:bg-bg-muted"
+              >
+                <Paperclip size={10} />
+                {att.filename}
+              </a>
+            ))}
+          </div>
+        )}
         <div
           className="overflow-auto"
           style={{ maxHeight: "calc(90vh - 120px)" }}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,6 +17,7 @@ export interface GroupedPerson {
   unreadCount: number;
   totalCount: number;
   recipientCount: number;
+  hasAttachment: number;
 }
 
 export interface Email {

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Paperclip } from "lucide-react";
 import { fetchGroupedPeople, type GroupedPerson } from "@/lib/api";
 
 const PAGE_SIZE = 50;
@@ -110,11 +110,16 @@ export default function PersonList({
                       ? ` · ${person.recipientCount} inboxes`
                       : ""}
                   </span>
-                  {person.unreadCount > 0 && (
-                    <span className="ml-2 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-unread px-1 text-[10px] font-semibold text-white">
-                      {person.unreadCount}
-                    </span>
-                  )}
+                  <div className="ml-2 flex shrink-0 items-center gap-1.5">
+                    {person.hasAttachment === 1 && (
+                      <Paperclip size={10} className="text-text-tertiary" />
+                    )}
+                    {person.unreadCount > 0 && (
+                      <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-unread px-1 text-[10px] font-semibold text-white">
+                        {person.unreadCount}
+                      </span>
+                    )}
+                  </div>
                 </div>
               </button>
             );

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -112,6 +112,8 @@ export async function handleEmail(
       httpMetadata: { contentType: att.contentType },
     });
 
+    const isInline = att.disposition === "inline" && !!att.contentId;
+
     await db.insert(attachments).values({
       id: attachmentId,
       emailId,
@@ -119,11 +121,11 @@ export async function handleEmail(
       contentType: att.contentType,
       size: att.content.byteLength,
       r2Key,
-      contentId: att.contentId,
+      contentId: isInline ? att.contentId : null,
       createdAt: now,
     });
 
-    if (att.contentId) {
+    if (isInline && att.contentId) {
       const cleanCid = att.contentId.replace(/^<|>$/g, "");
       cidMap[cleanCid] = attachmentId;
     }

--- a/worker/src/lib/email-parser.ts
+++ b/worker/src/lib/email-parser.ts
@@ -23,6 +23,7 @@ export interface ParsedAttachment {
   contentType: string;
   content: ArrayBuffer;
   contentId: string | null;
+  disposition: string | null;
 }
 
 /**
@@ -146,6 +147,7 @@ export async function parseEmail(
       contentType: att.mimeType || "application/octet-stream",
       content: att.content,
       contentId: att.contentId || null,
+      disposition: att.disposition || null,
     })),
     auth: parseAuthResults(headers),
   };

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { desc, like, or, eq, sql, and, inArray } from "drizzle-orm";
 import { people } from "../db/people.schema";
 import { emails } from "../db/emails.schema";
+import { attachments } from "../db/attachments.schema";
 import { json200Response, escapeLike } from "../lib/helpers";
 import type { Variables } from "../variables";
 import type { AllowedInboxes } from "../lib/inbox-permissions";
@@ -38,6 +39,7 @@ const GroupedPersonSchema = z.object({
   unreadCount: z.number(),
   totalCount: z.number(),
   recipientCount: z.number(),
+  hasAttachment: z.number(),
 });
 
 const listGroupedPeopleRoute = createRoute({
@@ -98,6 +100,7 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
     unreadCount: number;
     totalCount: number;
     recipientCount: number;
+    hasAttachment: number;
   }>(sql`
     SELECT
       s.id,
@@ -106,7 +109,13 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
       MAX(e.received_at) AS lastEmailAt,
       SUM(CASE WHEN e.is_read = 0 THEN 1 ELSE 0 END) AS unreadCount,
       COUNT(*) AS totalCount,
-      COUNT(DISTINCT e.recipient) AS recipientCount
+      COUNT(DISTINCT e.recipient) AS recipientCount,
+      EXISTS(
+        SELECT 1 FROM ${attachments} a
+        JOIN ${emails} e2 ON e2.id = a.email_id
+        WHERE e2.person_id = s.id
+        AND a.content_id IS NULL
+      ) AS hasAttachment
     FROM ${emails} e
     JOIN ${people} s ON s.id = e.person_id
     ${whereClause}


### PR DESCRIPTION
- Fix inline vs downloadable attachment distinction: only treat an attachment as inline when both Content-ID and Content-Disposition: inline are present; previously any attachment with a Content-ID (common in many email clients) was hidden from the download list
- Show downloadable attachments in the full email modal (EmailHtmlModal), not just in the message preview
- Add paperclip indicator to person list rows for threads that have any attachment across their email history