### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-21
+
+### Added
+
+- Reply action is now available on sent messages, allowing you to continue outbound conversations from the person detail view.
+- `/reply/{emailId}` endpoint accepts sent-email IDs in addition to received-email IDs.
+- `message_id` column on `sent_emails` table; a standards-compliant Message-ID header is generated and persisted on every send, reply, and sequence delivery.
+- `generateMessageId` helper in the worker for consistent Message-ID generation.
+- Saasmail logo adopted as the default app branding; `APP_NAME` and `APP_LOGO_LETTER` environment variables removed.
+- Email links inside message bodies open in a new tab.
+
+### Changed
+
+- Compose editor simplified to plain rich-text format with an enlarged modal.
+
+### Fixed
+
+- Reply endpoint now rejects sent-email IDs belonging to inboxes the caller does not own.
+- Person detail header displays the contact's email address inline beside their name.
+- Compose editor padding restored after accidental removal.
+- Email attachments are now handled correctly end-to-end.
+
 ## [0.0.1] - 2026-04-18
 
 ### Added
@@ -27,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/cmail/compare/v0.0.1...HEAD
-[0.0.1]: https://github.com/choyiny/cmail/releases/tag/v0.0.1
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/choyiny/saasmail/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/choyiny/saasmail/releases/tag/v0.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Updates `CHANGELOG.md` with all changes from 2026-04-21 grouped by Added / Changed / Fixed
- Bumps `package.json` version from `0.0.1` → `0.1.0` (new features warrant a minor bump)
- Fixes changelog comparison URLs to point to `choyiny/saasmail` (were pointing to `choyiny/cmail`)

## Highlights in v0.1.0

- Reply on sent messages — full outbound conversation support
- `message_id` generated and persisted across send, reply, and sequence flows
- Saasmail logo as default branding; deprecated `APP_NAME`/`APP_LOGO_LETTER` vars removed
- Email links open in new tab
- Compose editor simplified with enlarged modal
- Several bug fixes (attachment handling, reply ownership check, person detail header)

## Test plan

- [ ] Verify `CHANGELOG.md` renders correctly on GitHub
- [ ] Verify `package.json` version is `0.1.0`

https://claude.ai/code/session_01EAF6xmQsXDmvQmRMoz4moL