### PR TITLE
fix(email-sender): build MIME for Cloudflare send_email to pass custom headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.14",
     "lucide-react": "^1.8.0",
+    "mimetext": "^3.0.28",
     "nanoid": "^5.1.5",
     "postal-mime": "^2.4.1",
     "react": "^18.3.1",

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -39,7 +39,7 @@ describe("createEmailSender", () => {
 });
 
 describe("CloudflareSender", () => {
-  it("returns messageId on success", async () => {
+  it("sends a raw MIME message with custom headers embedded", async () => {
     const fakeBinding = {
       send: vi.fn().mockResolvedValue({ messageId: "msg-123" }),
     };
@@ -48,24 +48,32 @@ describe("CloudflareSender", () => {
     } as unknown as CloudflareBindings);
 
     const result = await sender.send({
-      from: "a@b.com",
+      from: '"Alice" <a@b.com>',
       to: "c@d.com",
       subject: "hello",
       html: "<p>hi</p>",
       text: "hi",
-      headers: { "In-Reply-To": "<orig@msg>" },
+      headers: {
+        "Message-ID": "<new@msg>",
+        "In-Reply-To": "<orig@msg>",
+      },
     });
 
     expect(result.id).toBe("msg-123");
     expect(result.error).toBeNull();
-    expect(fakeBinding.send).toHaveBeenCalledWith({
-      from: "a@b.com",
-      to: "c@d.com",
-      subject: "hello",
-      html: "<p>hi</p>",
-      text: "hi",
-      headers: { "In-Reply-To": "<orig@msg>" },
-    });
+    expect(fakeBinding.send).toHaveBeenCalledTimes(1);
+    const sent = fakeBinding.send.mock.calls[0][0] as {
+      from: string;
+      to: string;
+    };
+    // EmailMessage uses the bare address as the envelope sender.
+    expect(sent.from).toBe("a@b.com");
+    expect(sent.to).toBe("c@d.com");
+    const serialized = JSON.stringify(sent);
+    expect(serialized).toContain("Message-ID: <new@msg>");
+    expect(serialized).toContain("In-Reply-To: <orig@msg>");
+    expect(serialized).toContain("text/plain");
+    expect(serialized).toContain("text/html");
   });
 
   it("catches thrown errors and returns normalized result", async () => {

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -1,6 +1,17 @@
 import { Resend } from "resend";
 import { nanoid } from "nanoid";
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage } from "mimetext";
 import { isDemoMode } from "./is-dev";
+
+function parseFrom(input: string): { name?: string; address: string } {
+  const match = input.match(/^\s*(.*)\s*<([^>]+)>\s*$/);
+  if (match && match[2]) {
+    const name = match[1].replace(/^"|"$/g, "").trim();
+    return { name: name || undefined, address: match[2].trim() };
+  }
+  return { address: input.trim() };
+}
 
 export interface SendEmailParams {
   from: string;
@@ -54,15 +65,25 @@ class CloudflareSender implements EmailSender {
 
   async send(params: SendEmailParams): Promise<SendEmailResult> {
     try {
-      const result = await this.binding.send({
-        from: params.from,
-        to: params.to,
-        subject: params.subject,
-        html: params.html,
-        text: params.text,
-        headers: params.headers,
-      });
-      return { id: result.messageId, error: null };
+      const { name, address } = parseFrom(params.from);
+      const msg = createMimeMessage();
+      msg.setSender(name ? { name, addr: address } : { addr: address });
+      msg.setRecipient(params.to);
+      msg.setSubject(params.subject);
+      if (params.text) {
+        msg.addMessage({ contentType: "text/plain", data: params.text });
+      }
+      if (params.html) {
+        msg.addMessage({ contentType: "text/html", data: params.html });
+      }
+      if (params.headers) {
+        for (const [key, value] of Object.entries(params.headers)) {
+          msg.setHeader(key, value);
+        }
+      }
+      const message = new EmailMessage(address, params.to, msg.asRaw());
+      const result = await this.binding.send(message);
+      return { id: result?.messageId ?? null, error: null };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       return { id: null, error: { message } };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,18 @@
   dependencies:
     openapi3-ts "^4.1.2"
 
+"@babel/runtime-corejs3@^7.26.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz#cb86ad06e7a1d39224afb12a874301085e071846"
+  integrity sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==
+  dependencies:
+    core-js-pure "^3.48.0"
+
+"@babel/runtime@^7.26.0":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@better-auth/core@1.6.3":
   version "1.6.3"
   resolved "https://registry.npmjs.org/@better-auth/core/-/core-1.6.3.tgz"
@@ -2546,6 +2558,11 @@ cookie@^1.0.2:
   resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
+core-js-pure@^3.48.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.49.0.tgz#ff8436b7251a3832f5fdbbe3e10f7f2e58e51fb1"
+  integrity sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==
+
 crelt@^1.0.0, crelt@^1.0.5, crelt@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz"
@@ -2861,6 +2878,11 @@ jose@^6.1.3:
   resolved "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz"
   integrity sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==
 
+js-base64@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.8.tgz#af44496bc09fa178ed9c4adf67eb2b46f5c6d2a4"
+  integrity sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -3032,6 +3054,28 @@ mdurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mimetext@^3.0.28:
+  version "3.0.28"
+  resolved "https://registry.yarnpkg.com/mimetext/-/mimetext-3.0.28.tgz#ffa6292cd13c0913b0783161cd93018203debc09"
+  integrity sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@babel/runtime-corejs3" "^7.26.0"
+    js-base64 "^3.7.7"
+    mime-types "^2.1.35"
 
 mimic-function@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
The Cloudflare Email Sending binding's builder form (env.EMAIL.send({from, to, subject, html, headers})) rejects any non-whitelisted custom header with:

  "custom header 'Message-ID' is not allowed. Only whitelisted headers
   and X-* headers are accepted."

saasmail always attaches Message-ID (and In-Reply-To on replies) for Gmail/Outlook threading, so every outbound email over the Cloudflare provider currently fails. The Resend provider is unaffected.

Rewrite CloudflareSender.send() to construct a raw MIME message via mimetext.createMimeMessage() and hand it to new EmailMessage(from, to, raw) — the raw-MIME path accepts arbitrary headers. Added a parseFrom() helper that splits "Name <addr>" into name/address for EmailMessage's envelope sender, and added mimetext as a runtime dependency. The Resend path is unchanged.

Repro: configure the EMAIL binding (no RESEND_API_KEY) and call any endpoint that sends mail — the binding throws the header-rejection error above. With this change, Message-ID / In-Reply-To ride inside the MIME body and the send succeeds.