### PR TITLE
chore: release v0.1.1 — update CHANGELOG and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-23
+
+### Added
+
+- Issue and pull-request templates, Code of Conduct, Dependabot config, CodeQL scanning, and `.editorconfig` for open-source community hygiene.
+- Type-check step added to the CI test workflow.
+- CI, license, and Cloudflare badges added to the README.
+
+### Fixed
+
+- Cloudflare Email Sending binding now works with custom headers (Message-ID, In-Reply-To): the sender rewrites outbound messages as raw MIME via `mimetext` instead of the object-form builder, which rejects non-whitelisted headers.
+- Sidebar unread and total counts now update immediately when an email is read or deleted, instead of remaining stale until the next refetch.
+
 ## [0.1.0] - 2026-04-21
 
 ### Added
@@ -49,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/choyiny/saasmail/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/choyiny/saasmail/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/choyiny/saasmail/releases/tag/v0.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Updates `CHANGELOG.md` with a new `[0.1.1] - 2026-04-23` entry covering the changes landed since v0.1.0
- Bumps `package.json` version from `0.1.0` to `0.1.1`

### What's in 0.1.1

**Fixed**
- Cloudflare Email Sending binding now correctly passes custom headers (Message-ID, In-Reply-To) by building raw MIME via `mimetext` instead of the object-form builder which rejects non-whitelisted headers.
- Sidebar unread/total counts sync immediately when an email is read or deleted.

**Added** (infrastructure)
- Open-source community files: issue/PR templates, Code of Conduct, Dependabot config, CodeQL scanning, `.editorconfig`.
- Type-check step in the CI test workflow.
- CI, license, and Cloudflare badges in the README.

## Test plan

- [ ] `CHANGELOG.md` has a `[0.1.1]` section with the correct date and entries.
- [ ] `package.json` `version` field reads `0.1.1`.
- [ ] Comparison links at the bottom of the changelog are updated.

https://claude.ai/code/session_01F6fSSUm35NTUVjiWkRFRJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6fSSUm35NTUVjiWkRFRJc)_