### PR TITLE
feat: admin delete-person with kebab menu

### DIFF
--- a/e2e/specs/delete-person.spec.ts
+++ b/e2e/specs/delete-person.spec.ts
@@ -72,8 +72,10 @@ test.describe.serial("delete person", () => {
     await expect(bobRow).toBeVisible();
     await bobRow.click();
 
-    // Right panel should show Bob's emails.
-    await expect(page.locator("text=bob@customers.test")).toBeVisible();
+    // Right panel should show Bob's detail heading (Bob Brown is the seeded name).
+    await expect(
+      page.getByRole("heading", { name: "Bob Brown" }),
+    ).toBeVisible();
 
     // Open the kebab for Bob.
     await bobRow.hover();

--- a/e2e/specs/delete-person.spec.ts
+++ b/e2e/specs/delete-person.spec.ts
@@ -1,0 +1,126 @@
+// e2e/specs/delete-person.spec.ts
+// Covers: admin-only kebab menu on person rows, delete-person confirmation
+// flow, right-panel clearing on deletion, and non-admin users not seeing the
+// kebab at all.
+//
+// Seed gives us Alice (p_alice) and Bob (p_bob) in the person list.
+import { test, expect } from "../fixtures/test";
+import { truncateAndReseed } from "../support/reset-db";
+import { TEST_IDS } from "../support/selectors";
+import { resolve } from "node:path";
+
+const AUTH_DIR = resolve(process.cwd(), "e2e/.auth");
+
+test.describe.serial("delete person", () => {
+  test.beforeAll(() => truncateAndReseed());
+
+  test("admin sees kebab menu on hover and can open it", async ({ page }) => {
+    await page.goto("/");
+
+    const aliceRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_alice"]`,
+    );
+    await expect(aliceRow).toBeVisible();
+
+    // Kebab is opacity-0 until hover — force hover so it becomes interactive.
+    const kebab = page.locator(
+      `[data-testid="${TEST_IDS.personKebabMenu}"][data-person-id="p_alice"]`,
+    );
+    await aliceRow.hover();
+    await expect(kebab).toBeVisible();
+
+    await kebab.click();
+
+    // Delete option should appear in the portal dropdown.
+    const deleteBtn = page.getByTestId(TEST_IDS.personDeleteButton);
+    await expect(deleteBtn).toBeVisible();
+    await expect(deleteBtn).toHaveText(/delete person/i);
+  });
+
+  test("cancelling the confirm dialog keeps person in list", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const aliceRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_alice"]`,
+    );
+    await aliceRow.hover();
+
+    const kebab = page.locator(
+      `[data-testid="${TEST_IDS.personKebabMenu}"][data-person-id="p_alice"]`,
+    );
+    await kebab.click();
+
+    // Intercept the browser confirm dialog and dismiss it.
+    page.once("dialog", (dialog) => dialog.dismiss());
+    await page.getByTestId(TEST_IDS.personDeleteButton).click();
+
+    // Alice should still be in the list.
+    await expect(aliceRow).toBeVisible();
+  });
+
+  test("confirming deletion removes person from list and clears right panel", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // First select Bob so the right panel is open for him.
+    const bobRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_bob"]`,
+    );
+    await expect(bobRow).toBeVisible();
+    await bobRow.click();
+
+    // Right panel should show Bob's emails.
+    await expect(page.locator("text=bob@customers.test")).toBeVisible();
+
+    // Open the kebab for Bob.
+    await bobRow.hover();
+    const kebab = page.locator(
+      `[data-testid="${TEST_IDS.personKebabMenu}"][data-person-id="p_bob"]`,
+    );
+    await kebab.click();
+
+    // Accept the confirm dialog.
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.getByTestId(TEST_IDS.personDeleteButton).click();
+
+    // Bob should be gone from the list.
+    await expect(bobRow).not.toBeVisible();
+
+    // Right panel should revert to the empty state.
+    await expect(
+      page.locator("text=Select a person to view emails"),
+    ).toBeVisible();
+  });
+
+  test("deletion persists after page reload", async ({ page }) => {
+    await page.goto("/");
+
+    // Bob was deleted in the previous test; reload to verify persistence.
+    await page.reload();
+
+    const bobRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_bob"]`,
+    );
+    await expect(bobRow).not.toBeVisible();
+  });
+
+  test("non-admin user does not see kebab menu", async ({ browser }) => {
+    // Open a fresh browser context with member credentials.
+    const memberCtx = await browser.newContext({
+      storageState: resolve(AUTH_DIR, "member.json"),
+    });
+    const mp = await memberCtx.newPage();
+
+    await mp.goto("/");
+
+    // Members have no inbox assignments so they see the "no inboxes" screen,
+    // but regardless, no kebab button should ever be rendered.
+    const anyKebab = mp.getByTestId(TEST_IDS.personKebabMenu);
+    await expect(anyKebab).toHaveCount(0);
+
+    await memberCtx.close();
+  });
+});

--- a/e2e/support/selectors.ts
+++ b/e2e/support/selectors.ts
@@ -32,6 +32,8 @@ export const TEST_IDS = {
   // Person list
   personRow: "person-row",
   personUnreadBadge: "person-unread-badge",
+  personKebabMenu: "person-kebab-menu",
+  personDeleteButton: "person-delete-button",
 
   // Compose
   composeSendButton: "compose-send-button",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -156,6 +156,10 @@ export async function deleteEmail(
   return apiFetch(`/api/emails/${id}`, { method: "DELETE" });
 }
 
+export async function deletePerson(id: string): Promise<{ success: boolean }> {
+  return apiFetch(`/api/people/${id}`, { method: "DELETE" });
+}
+
 export async function sendEmail(data: {
   to: string;
   fromAddress: string;

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -85,7 +85,11 @@ export default function InboxPage() {
           setPeople={setPeople}
           selectedPersonId={selectedPerson?.id ?? null}
           onSelectPerson={setSelectedPerson}
+          onPersonDeleted={(id) => {
+            if (selectedPerson?.id === id) setSelectedPerson(null);
+          }}
           refreshKey={refreshKey}
+          isAdmin={isAdmin}
         />
       </div>
 

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -1,7 +1,18 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { ChevronLeft, ChevronRight, Paperclip } from "lucide-react";
-import { fetchGroupedPeople, type GroupedPerson } from "@/lib/api";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Paperclip,
+  MoreHorizontal,
+  Trash2,
+} from "lucide-react";
+import {
+  fetchGroupedPeople,
+  deletePerson,
+  type GroupedPerson,
+} from "@/lib/api";
 
 const PAGE_SIZE = 50;
 
@@ -10,7 +21,9 @@ interface PersonListProps {
   setPeople: (people: GroupedPerson[]) => void;
   selectedPersonId: string | null;
   onSelectPerson: (person: GroupedPerson) => void;
+  onPersonDeleted?: (personId: string) => void;
   refreshKey?: number;
+  isAdmin?: boolean;
 }
 
 export default function PersonList({
@@ -18,12 +31,19 @@ export default function PersonList({
   setPeople,
   selectedPersonId,
   onSelectPerson,
+  onPersonDeleted,
   refreshKey,
+  isAdmin,
 }: PersonListProps) {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(
+    null,
+  );
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -49,6 +69,36 @@ export default function PersonList({
     }, 200);
     return () => clearTimeout(timeout);
   }, [search, page, refreshKey]);
+
+  // Close menu when clicking outside or scrolling
+  useEffect(() => {
+    if (!menuOpenId) return;
+    function handleClose(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    }
+    document.addEventListener("mousedown", handleClose);
+    document.addEventListener("scroll", () => setMenuOpenId(null), true);
+    return () => {
+      document.removeEventListener("mousedown", handleClose);
+      document.removeEventListener("scroll", () => setMenuOpenId(null), true);
+    };
+  }, [menuOpenId]);
+
+  async function handleDeletePerson(person: GroupedPerson) {
+    setMenuOpenId(null);
+    if (
+      !confirm(
+        `Permanently delete ${person.name || person.email} and all ${person.totalCount} email${person.totalCount !== 1 ? "s" : ""}? This cannot be undone.`,
+      )
+    )
+      return;
+    await deletePerson(person.id);
+    setPeople(people.filter((p) => p.id !== person.id));
+    setTotal((t) => t - 1);
+    onPersonDeleted?.(person.id);
+  }
 
   function formatTime(ts: number) {
     const date = new Date(ts * 1000);
@@ -85,57 +135,112 @@ export default function PersonList({
         ) : (
           people.map((person) => {
             const isSelected = selectedPersonId === person.id;
+            const menuOpen = menuOpenId === person.id;
             return (
-              <button
+              <div
                 key={person.id}
-                data-testid="person-row"
-                data-person-id={person.id}
-                onClick={() => onSelectPerson(person)}
-                className={`w-full border-b border-border px-4 py-2.5 text-left transition-colors hover:bg-bg-muted ${
+                className={`group relative border-b border-border transition-colors hover:bg-bg-muted ${
                   isSelected ? "bg-bg-muted" : ""
                 }`}
               >
-                <div className="flex items-center justify-between">
-                  <span
-                    className={`truncate text-xs ${
-                      person.unreadCount > 0
-                        ? "font-semibold text-text-primary"
-                        : "text-text-secondary"
+                <button
+                  data-testid="person-row"
+                  data-person-id={person.id}
+                  onClick={() => onSelectPerson(person)}
+                  className={`w-full px-4 py-2.5 text-left ${isAdmin ? "pr-8" : ""}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span
+                      className={`truncate text-xs ${
+                        person.unreadCount > 0
+                          ? "font-semibold text-text-primary"
+                          : "text-text-secondary"
+                      }`}
+                    >
+                      {person.name || person.email}
+                    </span>
+                    <span className="ml-2 shrink-0 text-[11px] text-text-tertiary">
+                      {formatTime(person.lastEmailAt)}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex items-center justify-between">
+                    <span className="truncate text-[11px] text-text-tertiary">
+                      {person.totalCount} email
+                      {person.totalCount !== 1 ? "s" : ""}
+                      {person.recipientCount > 1
+                        ? ` · ${person.recipientCount} inboxes`
+                        : ""}
+                    </span>
+                    <div className="ml-2 flex shrink-0 items-center gap-1.5">
+                      {person.hasAttachment === 1 && (
+                        <Paperclip size={10} className="text-text-tertiary" />
+                      )}
+                      {person.unreadCount > 0 && (
+                        <span
+                          data-testid="person-unread-badge"
+                          className="flex h-4 min-w-4 items-center justify-center rounded-full bg-unread px-1 text-[10px] font-semibold text-white"
+                        >
+                          {person.unreadCount}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+
+                {/* Kebab menu button — admin only, visible on hover or when menu is open */}
+                {isAdmin && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (menuOpen) {
+                        setMenuOpenId(null);
+                      } else {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setMenuPos({
+                          top: rect.bottom + 4,
+                          right: window.innerWidth - rect.right,
+                        });
+                        setMenuOpenId(person.id);
+                      }
+                    }}
+                    className={`absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-text-tertiary transition-opacity hover:bg-bg-subtle hover:text-text-secondary ${
+                      menuOpen
+                        ? "opacity-100"
+                        : "opacity-0 group-hover:opacity-100"
                     }`}
                   >
-                    {person.name || person.email}
-                  </span>
-                  <span className="ml-2 shrink-0 text-[11px] text-text-tertiary">
-                    {formatTime(person.lastEmailAt)}
-                  </span>
-                </div>
-                <div className="mt-0.5 flex items-center justify-between">
-                  <span className="truncate text-[11px] text-text-tertiary">
-                    {person.totalCount} email
-                    {person.totalCount !== 1 ? "s" : ""}
-                    {person.recipientCount > 1
-                      ? ` · ${person.recipientCount} inboxes`
-                      : ""}
-                  </span>
-                  <div className="ml-2 flex shrink-0 items-center gap-1.5">
-                    {person.hasAttachment === 1 && (
-                      <Paperclip size={10} className="text-text-tertiary" />
-                    )}
-                    {person.unreadCount > 0 && (
-                      <span
-                        data-testid="person-unread-badge"
-                        className="flex h-4 min-w-4 items-center justify-center rounded-full bg-unread px-1 text-[10px] font-semibold text-white"
-                      >
-                        {person.unreadCount}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </button>
+                    <MoreHorizontal size={14} />
+                  </button>
+                )}
+              </div>
             );
           })
         )}
       </ScrollArea>
+
+      {/* Dropdown rendered in a portal so it escapes ScrollArea's overflow clipping */}
+      {menuOpenId &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={{ top: menuPos.top, right: menuPos.right }}
+            className="fixed z-50 w-40 rounded-md border border-border bg-white py-1 shadow-md"
+          >
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                const person = people.find((p) => p.id === menuOpenId);
+                if (person) handleDeletePerson(person);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-red-600 hover:bg-bg-muted"
+            >
+              <Trash2 size={12} />
+              Delete person
+            </button>
+          </div>,
+          document.body,
+        )}
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between border-t border-border px-3 py-2">

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -190,6 +190,8 @@ export default function PersonList({
                 {/* Kebab menu button — admin only, visible on hover or when menu is open */}
                 {isAdmin && (
                   <button
+                    data-testid="person-kebab-menu"
+                    data-person-id={person.id}
                     onClick={(e) => {
                       e.stopPropagation();
                       if (menuOpen) {
@@ -228,6 +230,7 @@ export default function PersonList({
             className="fixed z-50 w-40 rounded-md border border-border bg-white py-1 shadow-md"
           >
             <button
+              data-testid="person-delete-button"
               onClick={(e) => {
                 e.stopPropagation();
                 const person = people.find((p) => p.id === menuOpenId);

--- a/worker/src/__tests__/delete-person.test.ts
+++ b/worker/src/__tests__/delete-person.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  createTestPerson,
+  createTestEmail,
+  authFetch,
+  getDb,
+} from "./helpers";
+import { attachments } from "../db/attachments.schema";
+import { emails } from "../db/emails.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { people } from "../db/people.schema";
+import { eq } from "drizzle-orm";
+
+describe("DELETE /api/people/:id", () => {
+  let adminKey: string;
+  let memberKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey: adminKey } = await createTestUser({
+      id: "admin-1",
+      role: "admin",
+    }));
+    ({ apiKey: memberKey } = await createTestUser({
+      id: "member-1",
+      role: "member",
+      email: "member@example.com",
+    }));
+  });
+
+  it("deletes a person and all their emails", async () => {
+    await createTestPerson({ id: "p1", email: "alice@test.com" });
+    await createTestEmail({ id: "e1", personId: "p1" });
+    await createTestEmail({
+      id: "e2",
+      personId: "p1",
+      messageId: "msg-2@test.com",
+    });
+
+    const res = await authFetch("/api/people/p1", {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+
+    const db = getDb();
+    const personRows = await db
+      .select()
+      .from(people)
+      .where(eq(people.id, "p1"));
+    expect(personRows).toHaveLength(0);
+
+    const emailRows = await db
+      .select()
+      .from(emails)
+      .where(eq(emails.personId, "p1"));
+    expect(emailRows).toHaveLength(0);
+  });
+
+  it("cascades to attachment DB records", async () => {
+    await createTestPerson({ id: "p1", email: "alice@test.com" });
+    await createTestEmail({ id: "e1", personId: "p1", isRead: 1 });
+
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+    await db.insert(attachments).values({
+      id: "att-1",
+      emailId: "e1",
+      filename: "file.pdf",
+      contentType: "application/pdf",
+      size: 512,
+      r2Key: "attachments/e1/file.pdf",
+      contentId: null,
+      createdAt: now,
+    });
+
+    const res = await authFetch("/api/people/p1", {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+
+    const attRows = await db
+      .select()
+      .from(attachments)
+      .where(eq(attachments.emailId, "e1"));
+    expect(attRows).toHaveLength(0);
+  });
+
+  it("cascades to sent emails", async () => {
+    await createTestPerson({ id: "p1", email: "alice@test.com" });
+
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+    await db.insert(sentEmails).values({
+      id: "se1",
+      personId: "p1",
+      fromAddress: "us@saasmail.test",
+      toAddress: "alice@test.com",
+      subject: "Hello",
+      bodyHtml: "<p>Hi</p>",
+      bodyText: "Hi",
+      status: "sent",
+      sentAt: now,
+      createdAt: now,
+    });
+
+    await authFetch("/api/people/p1", { apiKey: adminKey, method: "DELETE" });
+
+    const seRows = await db
+      .select()
+      .from(sentEmails)
+      .where(eq(sentEmails.personId, "p1"));
+    expect(seRows).toHaveLength(0);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    await createTestPerson({ id: "p1", email: "alice@test.com" });
+    await createTestEmail({ id: "e1", personId: "p1" });
+
+    const res = await authFetch("/api/people/p1", {
+      apiKey: memberKey,
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+
+    // Person should still exist
+    const db = getDb();
+    const rows = await db.select().from(people).where(eq(people.id, "p1"));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("returns 404 for unknown person", async () => {
+    const res = await authFetch("/api/people/nonexistent", {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("does not affect other people's emails", async () => {
+    await createTestPerson({ id: "p1", email: "alice@test.com" });
+    await createTestPerson({ id: "p2", email: "bob@test.com" });
+    await createTestEmail({ id: "e1", personId: "p1" });
+    await createTestEmail({
+      id: "e2",
+      personId: "p2",
+      messageId: "msg-2@test.com",
+    });
+
+    await authFetch("/api/people/p1", { apiKey: adminKey, method: "DELETE" });
+
+    const db = getDb();
+    const bobEmails = await db
+      .select()
+      .from(emails)
+      .where(eq(emails.personId, "p2"));
+    expect(bobEmails).toHaveLength(1);
+
+    const bobPerson = await db.select().from(people).where(eq(people.id, "p2"));
+    expect(bobPerson).toHaveLength(1);
+  });
+});

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -3,6 +3,7 @@ import { desc, like, or, eq, sql, and, inArray } from "drizzle-orm";
 import { people } from "../db/people.schema";
 import { emails } from "../db/emails.schema";
 import { attachments } from "../db/attachments.schema";
+import { sentEmails } from "../db/sent-emails.schema";
 import { json200Response, escapeLike } from "../lib/helpers";
 import type { Variables } from "../variables";
 import type { AllowedInboxes } from "../lib/inbox-permissions";
@@ -296,4 +297,69 @@ peopleRouter.openapi(getPersonRoute, async (c) => {
   }
 
   return c.json(rows[0], 200);
+});
+
+const deletePersonRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["People"],
+  description:
+    "Hard delete a person and all their received emails, sent emails, and R2 attachments.",
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: { description: "Person deleted" },
+    403: { description: "Forbidden" },
+    404: { description: "Person not found" },
+  },
+});
+
+peopleRouter.openapi(deletePersonRoute, async (c) => {
+  const db = c.get("db");
+  const r2 = c.env.R2;
+  const { id } = c.req.valid("param");
+  const allowed = c.get("allowedInboxes")!;
+
+  if (!allowed.isAdmin) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const person = await db
+    .select({ id: people.id })
+    .from(people)
+    .where(eq(people.id, id))
+    .limit(1);
+
+  if (person.length === 0) {
+    return c.json({ error: "Person not found" }, 404);
+  }
+
+  // Delete R2 attachments for all received emails belonging to this person
+  const atts = await db
+    .select({ r2Key: attachments.r2Key })
+    .from(attachments)
+    .innerJoin(emails, eq(attachments.emailId, emails.id))
+    .where(eq(emails.personId, id));
+
+  for (const att of atts) {
+    await r2.delete(att.r2Key);
+  }
+
+  await db
+    .delete(attachments)
+    .where(
+      inArray(
+        attachments.emailId,
+        db
+          .select({ id: emails.id })
+          .from(emails)
+          .where(eq(emails.personId, id)),
+      ),
+    );
+  await db.delete(emails).where(eq(emails.personId, id));
+  await db.delete(sentEmails).where(eq(sentEmails.personId, id));
+  await db.delete(people).where(eq(people.id, id));
+
+  return c.json({ success: true }, 200);
 });


### PR DESCRIPTION
## Summary

- Adds a `DELETE /api/people/:id` endpoint (admin-only, returns 403 for non-admins) that hard-deletes a person and cascades through their R2 attachments, attachment DB records, received emails, sent emails, and the person record itself
- Adds `deletePerson()` to the frontend API client
- Shows a hover kebab (⋯) button on each person row — visible only to admins — with a "Delete person" action and confirmation dialog
- Dropdown is rendered via `createPortal` into `document.body` to escape `ScrollArea`'s overflow clipping
- Non-admin users see no button and no extra right padding on person rows (fixes visual alignment)
- Selecting a deleted person in the right panel is automatically cleared

## Test plan

- [x] As admin: hover a person row → `⋯` appears → click → "Delete person" → confirm → person and all emails removed
- [x] As admin: dismiss the dropdown by clicking outside or scrolling
- [x] As non-admin: no `⋯` button visible, row padding is symmetric
- [ ] `DELETE /api/people/:id` returns 403 for non-admin session
- [ ] `DELETE /api/people/:id` returns 404 for unknown ID
- [x] Deleting the currently-selected person clears the right panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)