### PR TITLE
chore: release v0.2.0 — browser push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VAPID configuration step added to the onboarding and update skills.
 - `VAPID_SUBJECT` added to `wrangler.jsonc.example` and regenerated `worker-configuration.d.ts`.
 - E2E smoke test covering the notifications settings page.
+- Admin delete-person action: admins can delete a person and all associated emails from the person list via a new kebab menu, with a confirmation dialog and `DELETE /api/people/:id` endpoint.
 
 ### Fixed
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `NotificationsHub` Durable Object now captures `env` in its constructor so the `/deliver` handler can access bindings without passing them per-call.
+- `/deliver` path on `NotificationsHub` now logs missing VAPID config, empty subscription lists, non-2xx push responses, and thrown `sendPush` errors instead of silently swallowing them, and warns if `VAPID_SUBJECT` is not a valid `mailto:`/`https:` URL.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-24
+
+### Added
+
+- Browser push notifications: users can now receive push alerts for new emails without the tab being open, powered by the Web Push Protocol (VAPID).
+- `push_subscriptions` table stores per-user browser subscriptions.
+- `GET /api/notifications/config` returns the server's VAPID public key so the frontend can subscribe.
+- `POST/DELETE /api/notifications/subscriptions` for managing push subscriptions.
+- `/deliver` endpoint on `NotificationsHub` Durable Object fans out new-email events to active WebSocket connections and falls back to Web Push when no WebSocket is present.
+- Service worker (`sw.js`) that handles incoming push events and displays system notifications.
+- Push orchestration library in the frontend (`usePush`) that manages subscription lifecycle, permission requests, and server sync.
+- Contextual opt-in banner shown in the inbox when push permission has not yet been granted.
+- Notifications settings page where users can subscribe or unsubscribe from push alerts.
+- "Settings" entry added to the user dropdown in the sidebar for quick access to the new page.
+- `vapid:generate` script (`scripts/generate-vapid.ts`) to generate a VAPID keypair for new deployments.
+- VAPID configuration step added to the onboarding and update skills.
+- `VAPID_SUBJECT` added to `wrangler.jsonc.example` and regenerated `worker-configuration.d.ts`.
+- E2E smoke test covering the notifications settings page.
+
+### Fixed
+
+- Web push is now always attempted when a new email is delivered; the previous logic skipped push if any WebSocket was open, even for other users.
+- Push subscription UI in settings now surfaces errors, shows a loading state, and prevents double-clicks while a request is in-flight.
+
+### Changed
+
+- `NotificationsHub` Durable Object now captures `env` in its constructor so the `/deliver` handler can access bindings without passing them per-call.
+
+### Dependencies
+
+- Bumped `actions/setup-node` from 4 to 6.
+- Bumped `github/codeql-action` from 3 to 4.
+- Bumped `actions/upload-artifact` from 4 to 7.
+- Bumped `@codemirror/view` (codemirror group).
+- Bumped the tiptap group (4 packages).
+
 ## [0.1.2] - 2026-04-23
 
 ### Added
@@ -80,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/choyiny/saasmail/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/choyiny/saasmail/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/choyiny/saasmail/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/choyiny/saasmail/compare/v0.0.1...v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Updates `CHANGELOG.md` with all commits since v0.1.2, covering the full browser push notifications feature shipped on 2026-04-23/24, plus follow-up changes landed on main since this PR was opened
- Bumps `package.json` version from `0.1.2` → `0.2.0` (minor bump for new feature set)

## Changes included (since v0.1.2)

- Browser push notifications end-to-end: VAPID key generation, `push_subscriptions` DB table, Web Push encoding, subscription CRUD API, `/deliver` DO endpoint with WS-present / push-fallback routing, service worker, frontend push orchestration library, inbox opt-in banner, notifications settings page, Settings sidebar entry
- Admin delete-person action with kebab menu, confirmation dialog, and `DELETE /api/people/:id` endpoint
- Fixed: web push always attempted on delivery; push settings UI error/loading/busy states
- Refactored: `NotificationsHub` captures `env` in constructor; `/deliver` now logs VAPID/push failures instead of swallowing them (plus `VAPID_SUBJECT` validity warning)
- Dependency bumps: `actions/setup-node` 4→6, `codeql-action` 3→4, `upload-artifact` 4→7, `@codemirror/view`, tiptap group (4 packages)
- E2E smoke tests for notifications settings page and delete-person flow

https://claude.ai/code/session_01RZpRAKSxzH8jozZyfXCMpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZpRAKSxzH8jozZyfXCMpz)_