### PR TITLE
Fix HKDF key derivation for RFC 8291 web push encryption

### DIFF
--- a/worker/src/__tests__/web-push.test.ts
+++ b/worker/src/__tests__/web-push.test.ts
@@ -104,4 +104,28 @@ describe("web-push: aes128gcm", () => {
       JSON.stringify({ hello: "world" }),
     );
   });
+
+  // RFC 8291 §5 known-answer vector. A round-trip test only proves self-
+  // consistency — this proves our key derivation matches what the browser
+  // computes, so real pushes actually decrypt on the receiving end.
+  it("decrypts the RFC 8291 §5 test vector", async () => {
+    const ciphertext = b64urlDecode(
+      "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN",
+    );
+    const recipientPublicRaw = b64urlDecode(
+      "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4",
+    );
+    const recipientPrivateD = "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94";
+    const authSecret = b64urlDecode("BTBZMqHH6r4Tts7J_aSIgg");
+
+    const plaintext = await decryptAes128Gcm({
+      body: ciphertext,
+      recipientPrivateJwkD: recipientPrivateD,
+      recipientPublicRaw,
+      authSecret,
+    });
+    expect(new TextDecoder().decode(plaintext)).toBe(
+      "When I grow up, I want to be a watermelon",
+    );
+  });
 });

--- a/worker/src/lib/web-push.ts
+++ b/worker/src/lib/web-push.ts
@@ -154,33 +154,26 @@ async function deriveAes128GcmKeys(args: {
   sharedSecret: Uint8Array; // ECDH bits
   authSecret: Uint8Array;
 }): Promise<{ contentEncryptionKey: Uint8Array; nonce: Uint8Array }> {
-  // RFC 8291 §3.4
+  // RFC 8291 §3.4. Note: hkdfExpand already appends the HKDF counter byte
+  // (0x01 for the first block), so the info args here must NOT include it —
+  // otherwise the HMAC sees `info || 0x01 || 0x01` and the derived key won't
+  // match what the browser computes (browser decryption fails silently).
   const keyInfo = concatBytes(
     new TextEncoder().encode("WebPush: info\0"),
     args.recipientPublicRaw,
     args.senderPublicRaw,
   );
   const prkKey = await hkdfExtract(args.authSecret, args.sharedSecret);
-  const ikm = await hkdfExpand(
-    prkKey,
-    concatBytes(keyInfo, new Uint8Array([0x01])),
-    32,
-  );
+  const ikm = await hkdfExpand(prkKey, keyInfo, 32);
   const prk = await hkdfExtract(args.salt, ikm);
   const cek = await hkdfExpand(
     prk,
-    concatBytes(
-      new TextEncoder().encode("Content-Encoding: aes128gcm\0"),
-      new Uint8Array([0x01]),
-    ),
+    new TextEncoder().encode("Content-Encoding: aes128gcm\0"),
     16,
   );
   const nonce = await hkdfExpand(
     prk,
-    concatBytes(
-      new TextEncoder().encode("Content-Encoding: nonce\0"),
-      new Uint8Array([0x01]),
-    ),
+    new TextEncoder().encode("Content-Encoding: nonce\0"),
     12,
   );
   return { contentEncryptionKey: cek, nonce };


### PR DESCRIPTION
## Summary

Fixes a bug in the HKDF key derivation for AES-128-GCM web push encryption where the counter byte (0x01) was being manually appended to the info parameter, but `hkdfExpand` already appends it automatically. This caused derived keys to not match browser implementations, breaking real push decryption. The fix removes the manual counter byte concatenations and adds a test vector from RFC 8291 to verify correctness.

## Changes

- Fixed `deriveAes128GcmKeys` to not manually append the HKDF counter byte (0x01) to info parameters, since `hkdfExpand` already does this
- Updated comments to clarify the HKDF counter byte behavior
- Added RFC 8291 §5 test vector to verify key derivation matches browser implementations

## Test plan

- [x] `yarn test` — New test case validates decryption of RFC 8291 known-answer vector, proving key derivation now matches browser implementations

## Notes for reviewers

The bug was subtle: HKDF-Expand (RFC 5869) automatically prepends a counter byte to each info block during expansion. Our code was manually concatenating `info || 0x01`, which meant the HMAC was computing over `info || 0x01 || 0x01` instead of just `info || 0x01`. This caused the derived content encryption key and nonce to be incorrect, making real push messages fail to decrypt silently in browsers.

The RFC 8291 §5 test vector provides a known-answer test that proves our implementation now matches what browsers compute, ensuring real pushes will decrypt correctly on the receiving end.

https://claude.ai/code/session_01AUS9sNWiA8puwtSTwcj32V