### PR TITLE
[WIP] feat: AI agents — intent classification & draft auto-replies

### DIFF
--- a/migrations/0020_agent_tables.sql
+++ b/migrations/0020_agent_tables.sql
@@ -1,0 +1,62 @@
+CREATE TABLE `agent_definitions` (
+  `id`                  TEXT    NOT NULL PRIMARY KEY,
+  `name`                TEXT    NOT NULL,
+  `description`         TEXT,
+  `model_id`            TEXT    NOT NULL,
+  `system_prompt`       TEXT    NOT NULL,
+  `output_schema_json`  TEXT    NOT NULL,
+  `max_runs_per_hour`   INTEGER NOT NULL DEFAULT 10,
+  `is_active`           INTEGER NOT NULL DEFAULT 1,
+  `created_at`          INTEGER NOT NULL,
+  `updated_at`          INTEGER NOT NULL
+);
+
+CREATE TABLE `agent_assignments` (
+  `id`            TEXT    NOT NULL PRIMARY KEY,
+  `agent_id`      TEXT    NOT NULL REFERENCES `agent_definitions`(`id`) ON DELETE CASCADE,
+  `mailbox`       TEXT,
+  `person_id`     TEXT,
+  `template_slug` TEXT    NOT NULL,
+  `mode`          TEXT    NOT NULL,
+  `is_active`     INTEGER NOT NULL DEFAULT 1,
+  `created_at`    INTEGER NOT NULL,
+  `updated_at`    INTEGER NOT NULL
+);
+CREATE INDEX `assignments_agent_idx`          ON `agent_assignments`(`agent_id`);
+CREATE INDEX `assignments_mailbox_person_idx` ON `agent_assignments`(`mailbox`, `person_id`);
+
+CREATE TABLE `agent_runs` (
+  `id`             TEXT    NOT NULL PRIMARY KEY,
+  `assignment_id`  TEXT    NOT NULL REFERENCES `agent_assignments`(`id`),
+  `email_id`       TEXT    NOT NULL REFERENCES `emails`(`id`),
+  `person_id`      TEXT    NOT NULL REFERENCES `people`(`id`),
+  `status`         TEXT    NOT NULL,
+  `action`         TEXT,
+  `sent_email_id`  TEXT    REFERENCES `sent_emails`(`id`),
+  `draft_id`       TEXT,
+  `model_id`       TEXT,
+  `input_tokens`   INTEGER,
+  `output_tokens`  INTEGER,
+  `error_message`  TEXT,
+  `created_at`     INTEGER NOT NULL,
+  `updated_at`     INTEGER NOT NULL
+);
+CREATE INDEX `runs_assignment_person_created_idx`
+  ON `agent_runs`(`assignment_id`, `person_id`, `created_at`);
+CREATE INDEX `runs_email_idx`          ON `agent_runs`(`email_id`);
+CREATE INDEX `runs_status_created_idx` ON `agent_runs`(`status`, `created_at`);
+
+CREATE TABLE `drafts` (
+  `id`            TEXT    NOT NULL PRIMARY KEY,
+  `person_id`     TEXT    NOT NULL REFERENCES `people`(`id`),
+  `agent_run_id`  TEXT    NOT NULL REFERENCES `agent_runs`(`id`),
+  `from_address`  TEXT    NOT NULL,
+  `to_address`    TEXT    NOT NULL,
+  `subject`       TEXT    NOT NULL,
+  `body_html`     TEXT,
+  `in_reply_to`   TEXT,
+  `created_at`    INTEGER NOT NULL,
+  `updated_at`    INTEGER NOT NULL
+);
+CREATE INDEX `drafts_person_created_idx` ON `drafts`(`person_id`, `created_at`);
+CREATE INDEX `drafts_agent_run_idx`      ON `drafts`(`agent_run_id`);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@types/dompurify": "^3.2.0",
+    "ai": "^6.0.168",
     "better-auth": "^1.6.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -71,6 +72,7 @@
     "react-router-dom": "^6.30.1",
     "resend": "^6.9.2",
     "tailwind-merge": "^3.0.2",
+    "workers-ai-provider": "^3.1.12",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/seeds/demo.sql
+++ b/seeds/demo.sql
@@ -16,6 +16,10 @@ DELETE FROM api_keys;
 DELETE FROM email_templates;
 DELETE FROM invitations;
 DELETE FROM attachments;
+DELETE FROM drafts;
+DELETE FROM agent_runs;
+DELETE FROM agent_assignments;
+DELETE FROM agent_definitions;
 DELETE FROM sent_emails;
 DELETE FROM emails;
 DELETE FROM people;
@@ -716,6 +720,69 @@ INSERT OR REPLACE INTO sent_emails (id, person_id, from_address, to_address, sub
     NULL, 'resend_inv_kim_apr', 'sent',
     (CAST(strftime('%s','now') AS INTEGER) - 86400 * 11 - 3600 * 20),
     (CAST(strftime('%s','now') AS INTEGER) - 86400 * 11 - 3600 * 20));
+
+-- ----------------------------------------------------------------------------
+-- Agent: Support Intent Classifier
+--
+-- Reads each inbound support email, classifies intent into one of three
+-- categories, and outputs the exact pre-approved reply phrase.
+--
+-- Intent → reply mapping:
+--   didn''t receive email  → "We''re looking into it!"
+--   cannot connect to network → "follow this guide on lotsotravel"
+--   do you have discount? → "yes, here''s the link"
+--
+-- The agent runs in "draft" mode so a human reviews before sending.
+-- ----------------------------------------------------------------------------
+
+-- Reply template — uses {{reply}} variable filled by the agent.
+INSERT OR REPLACE INTO email_templates (id, slug, name, subject, body_html, from_address, created_at, updated_at) VALUES (
+  'tpl_support_autoreply',
+  'support-auto-reply',
+  'Support Auto-Reply',
+  'Re: Your inquiry',
+  '<p>{{reply}}</p>',
+  'support@example.com',
+  CAST(strftime('%s','now') AS INTEGER),
+  CAST(strftime('%s','now') AS INTEGER)
+);
+
+-- Agent definition — @cf/meta/llama-3.3-70b-instruct-fp8-fast is a good
+-- structured-output model available on Cloudflare Workers AI.
+INSERT OR REPLACE INTO agent_definitions (id, name, description, model_id, system_prompt, output_schema_json, max_runs_per_hour, is_active, created_at, updated_at) VALUES (
+  'agent_support_classifier',
+  'Support Intent Classifier',
+  'Reads inbound support emails, classifies intent into one of three categories, and outputs the exact pre-approved reply phrase. Runs in draft mode for human review.',
+  '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  'You are a customer support agent for lotsotravel, a travel service.
+
+Read the incoming email and classify the customer''s intent. Based on that intent, set the "reply" field to EXACTLY one of the following three phrases — copy the text verbatim with no changes, no greeting, no sign-off:
+
+• If the customer says they did not receive an email or confirmation → reply: "We''re looking into it!"
+• If the customer reports they cannot connect to the network or has connectivity problems → reply: "follow this guide on lotsotravel"
+• If the customer is asking about discounts, promotions, or offers → reply: "yes, here''s the link"
+
+Output only the reply field. Do not add any other text.',
+  '{"type":"object","properties":{"reply":{"type":"string","description":"The exact pre-approved reply phrase for the classified intent"}},"required":["reply"]}',
+  20,
+  1,
+  CAST(strftime('%s','now') AS INTEGER),
+  CAST(strftime('%s','now') AS INTEGER)
+);
+
+-- Assignment — wires the classifier to the support inbox.
+-- mailbox = support@example.com, person = any (*), mode = draft.
+INSERT OR REPLACE INTO agent_assignments (id, agent_id, mailbox, person_id, template_slug, mode, is_active, created_at, updated_at) VALUES (
+  'asgn_support_classifier',
+  'agent_support_classifier',
+  'support@example.com',
+  NULL,
+  'support-auto-reply',
+  'draft',
+  1,
+  CAST(strftime('%s','now') AS INTEGER),
+  CAST(strftime('%s','now') AS INTEGER)
+);
 
 -- ----------------------------------------------------------------------------
 -- Recompute people.last_email_at / unread_count / total_count from the emails

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,11 @@ import SequenceDetailPage from "@/pages/SequenceDetailPage";
 import SequenceEditorPage from "@/pages/SequenceEditorPage";
 import InboxesPage from "./pages/InboxesPage";
 import NotificationsSettingsPage from "@/pages/NotificationsSettingsPage";
+import AgentsPage from "./pages/AgentsPage";
+import AgentEditorPage from "./pages/AgentEditorPage";
+import AgentDetailPage from "./pages/AgentDetailPage";
+import AgentRunsPage from "./pages/AgentRunsPage";
+import DraftsPage from "./pages/DraftsPage";
 
 const queryClient = new QueryClient();
 
@@ -109,6 +114,12 @@ function App() {
                   path="/settings"
                   element={<NotificationsSettingsPage />}
                 />
+                <Route path="/agents" element={<AgentsPage />} />
+                <Route path="/agents/new" element={<AgentEditorPage />} />
+                <Route path="/agents/runs" element={<AgentRunsPage />} />
+                <Route path="/agents/:id" element={<AgentDetailPage />} />
+                <Route path="/agents/:id/edit" element={<AgentEditorPage />} />
+                <Route path="/drafts" element={<DraftsPage />} />
                 <Route path="/*" element={<InboxPage />} />
               </Route>
             </Route>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,6 +10,8 @@ import {
   ListOrdered,
   ChevronsLeft,
   ChevronsRight,
+  Bot,
+  FilePen,
 } from "lucide-react";
 import { signOut, useSession } from "@/lib/auth-client";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
@@ -29,8 +31,10 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { icon: Mail, label: "Inbox", path: "/" },
+  { icon: FilePen, label: "Drafts", path: "/drafts" },
   { icon: FileText, label: "Templates", path: "/templates" },
   { icon: ListOrdered, label: "Sequences", path: "/sequences" },
+  { icon: Bot, label: "Agents", path: "/agents" },
   { icon: Key, label: "API", path: "/api-keys" },
   { icon: Settings, label: "Inboxes", path: "/inboxes", adminOnly: true },
   { icon: Users, label: "Users", path: "/admin/users", adminOnly: true },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -561,3 +561,183 @@ export interface AdminUser {
 export async function fetchAdminUsers(): Promise<AdminUser[]> {
   return apiFetch("/api/admin/users");
 }
+
+// ── Agent types ────────────────────────────────────────────────────────────
+
+export interface OutputField {
+  name: string;
+  description: string;
+}
+
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  description: string | null;
+  modelId: string;
+  systemPrompt: string;
+  outputFields: OutputField[];
+  maxRunsPerHour: number;
+  isActive: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface AgentAssignment {
+  id: string;
+  agentId: string;
+  mailbox: string | null;
+  personId: string | null;
+  templateSlug: string;
+  mode: "first_thread_reply" | "every_mail_reply" | "draft_only";
+  isActive: boolean;
+  createdAt: number;
+  updatedAt: number;
+  agentName: string;
+  templateName: string;
+}
+
+export interface AgentRun {
+  id: string;
+  assignmentId: string;
+  emailId: string;
+  personId: string;
+  status: string;
+  action: string | null;
+  sentEmailId: string | null;
+  draftId: string | null;
+  modelId: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  errorMessage: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Draft {
+  id: string;
+  personId: string;
+  agentRunId: string;
+  fromAddress: string;
+  toAddress: string;
+  subject: string;
+  bodyHtml: string | null;
+  inReplyTo: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ── Agent Definitions ──────────────────────────────────────────────────────
+
+export const fetchAgentDefinitions = () =>
+  apiFetch<AgentDefinition[]>("/api/agents/definitions");
+
+export const fetchAgentDefinition = (id: string) =>
+  apiFetch<AgentDefinition>(`/api/agents/definitions/${id}`);
+
+export const createAgentDefinition = (data: {
+  name: string;
+  description?: string;
+  modelId: string;
+  systemPrompt: string;
+  outputFields: OutputField[];
+  maxRunsPerHour: number;
+  isActive: boolean;
+}) =>
+  apiFetch<AgentDefinition>("/api/agents/definitions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+export const updateAgentDefinition = (
+  id: string,
+  data: Partial<{
+    name: string;
+    description: string | null;
+    modelId: string;
+    systemPrompt: string;
+    outputFields: OutputField[];
+    maxRunsPerHour: number;
+    isActive: boolean;
+  }>,
+) =>
+  apiFetch<AgentDefinition>(`/api/agents/definitions/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+export const deleteAgentDefinition = (id: string) =>
+  apiFetch<void>(`/api/agents/definitions/${id}`, { method: "DELETE" });
+
+// ── Agent Assignments ──────────────────────────────────────────────────────
+
+export const fetchAgentAssignments = (agentId?: string) =>
+  apiFetch<AgentAssignment[]>(
+    `/api/agents/assignments${agentId ? `?agentId=${agentId}` : ""}`,
+  );
+
+export const createAgentAssignment = (data: {
+  agentId: string;
+  mailbox?: string | null;
+  personId?: string | null;
+  templateSlug: string;
+  mode: AgentAssignment["mode"];
+  isActive: boolean;
+}) =>
+  apiFetch<AgentAssignment>("/api/agents/assignments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+export const updateAgentAssignment = (
+  id: string,
+  data: Partial<{
+    templateSlug: string;
+    mode: AgentAssignment["mode"];
+    isActive: boolean;
+    mailbox: string | null;
+    personId: string | null;
+  }>,
+) =>
+  apiFetch<AgentAssignment>(`/api/agents/assignments/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+export const deleteAgentAssignment = (id: string) =>
+  apiFetch<void>(`/api/agents/assignments/${id}`, { method: "DELETE" });
+
+// ── Agent Runs ─────────────────────────────────────────────────────────────
+
+export const fetchAgentRuns = (params?: {
+  assignmentId?: string;
+  personId?: string;
+  status?: string;
+  limit?: number;
+  offset?: number;
+}) => {
+  const qs = new URLSearchParams(
+    Object.entries(params ?? {})
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => [k, String(v)]),
+  ).toString();
+  return apiFetch<{ runs: AgentRun[]; total: number }>(
+    `/api/agents/runs${qs ? `?${qs}` : ""}`,
+  );
+};
+
+// ── Drafts ─────────────────────────────────────────────────────────────────
+
+export const fetchDrafts = (personId?: string) =>
+  apiFetch<Draft[]>(`/api/drafts${personId ? `?personId=${personId}` : ""}`);
+
+export const sendDraft = (id: string) =>
+  apiFetch<{ sentEmailId: string }>(`/api/drafts/${id}/send`, {
+    method: "POST",
+  });
+
+export const deleteDraft = (id: string) =>
+  apiFetch<void>(`/api/drafts/${id}`, { method: "DELETE" });

--- a/src/pages/AgentDetailPage.tsx
+++ b/src/pages/AgentDetailPage.tsx
@@ -1,0 +1,396 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  fetchAgentDefinition,
+  fetchAgentAssignments,
+  fetchTemplates,
+  createAgentAssignment,
+  updateAgentAssignment,
+  deleteAgentAssignment,
+  type AgentDefinition,
+  type AgentAssignment,
+  type EmailTemplate,
+} from "@/lib/api";
+
+const MODE_LABELS: Record<string, string> = {
+  first_thread_reply: "First reply",
+  every_mail_reply: "Every reply",
+  draft_only: "Draft only",
+};
+
+interface AssignmentForm {
+  mailbox: string;
+  personId: string;
+  templateSlug: string;
+  mode: AgentAssignment["mode"];
+  isActive: boolean;
+}
+
+const DEFAULT_FORM: AssignmentForm = {
+  mailbox: "",
+  personId: "",
+  templateSlug: "",
+  mode: "every_mail_reply",
+  isActive: true,
+};
+
+export default function AgentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [agent, setAgent] = useState<AgentDefinition | null>(null);
+  const [assignments, setAssignments] = useState<AgentAssignment[]>([]);
+  const [templates, setTemplates] = useState<EmailTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showDialog, setShowDialog] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<AssignmentForm>(DEFAULT_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    Promise.all([
+      fetchAgentDefinition(id),
+      fetchAgentAssignments(id),
+      fetchTemplates(),
+    ])
+      .then(([agentData, assignmentData, templateData]) => {
+        setAgent(agentData);
+        setAssignments(assignmentData);
+        setTemplates(templateData);
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  function openCreate() {
+    setEditingId(null);
+    setForm(DEFAULT_FORM);
+    setFormError(null);
+    setShowDialog(true);
+  }
+
+  function openEdit(a: AgentAssignment) {
+    setEditingId(a.id);
+    setForm({
+      mailbox: a.mailbox ?? "",
+      personId: a.personId ?? "",
+      templateSlug: a.templateSlug,
+      mode: a.mode,
+      isActive: a.isActive,
+    });
+    setFormError(null);
+    setShowDialog(true);
+  }
+
+  async function handleSave() {
+    if (!form.templateSlug) {
+      setFormError("Template is required");
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const payload = {
+        agentId: id!,
+        mailbox: form.mailbox || null,
+        personId: form.personId || null,
+        templateSlug: form.templateSlug,
+        mode: form.mode,
+        isActive: form.isActive,
+      };
+      if (editingId) {
+        const updated = await updateAgentAssignment(editingId, payload);
+        setAssignments((prev) =>
+          prev.map((a) => (a.id === editingId ? updated : a)),
+        );
+      } else {
+        const created = await createAgentAssignment(payload);
+        setAssignments((prev) => [...prev, created]);
+      }
+      setShowDialog(false);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("409"))
+        setFormError("An active assignment already exists for this scope.");
+      else if (msg.includes("422"))
+        setFormError("Template variables don't match agent output fields.");
+      else setFormError("Failed to save assignment.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDeleteAssignment(aId: string) {
+    if (!confirm("Delete this assignment?")) return;
+    await deleteAgentAssignment(aId);
+    setAssignments((prev) => prev.filter((a) => a.id !== aId));
+  }
+
+  if (loading)
+    return <div className="p-6 text-xs text-text-tertiary">Loading...</div>;
+  if (!agent)
+    return (
+      <div className="p-6 text-xs text-text-tertiary">Agent not found.</div>
+    );
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-3xl space-y-6">
+        {/* Agent definition card */}
+        <div className="rounded-lg border border-border bg-white px-5 py-4 ring-1 ring-gray-200">
+          <div className="mb-3 flex items-start justify-between">
+            <div>
+              <h1 className="text-sm font-semibold text-text-primary">
+                {agent.name}
+              </h1>
+              {agent.description && (
+                <p className="mt-0.5 text-[11px] text-text-tertiary">
+                  {agent.description}
+                </p>
+              )}
+            </div>
+            <div className="flex gap-1">
+              <button
+                onClick={() => navigate(`/agents/${agent.id}/edit`)}
+                className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => navigate("/agents")}
+                className="rounded-md px-2.5 py-1 text-[11px] text-text-tertiary hover:bg-bg-muted"
+              >
+                ← Back
+              </button>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-[11px]">
+            <div>
+              <span className="text-text-tertiary">Model: </span>
+              <span className="font-mono text-text-primary">
+                {agent.modelId}
+              </span>
+            </div>
+            <div>
+              <span className="text-text-tertiary">Max runs/hr: </span>
+              <span className="text-text-primary">{agent.maxRunsPerHour}</span>
+            </div>
+            <div>
+              <span className="text-text-tertiary">Status: </span>
+              <span
+                className={agent.isActive ? "text-green-600" : "text-gray-400"}
+              >
+                {agent.isActive ? "Active" : "Inactive"}
+              </span>
+            </div>
+          </div>
+          <div className="mt-3">
+            <p className="mb-1 text-[11px] text-text-tertiary">
+              Output fields:
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {agent.outputFields.map((f) => (
+                <span
+                  key={f.name}
+                  title={f.description}
+                  className="rounded-full bg-accent/10 px-2 py-0.5 font-mono text-[10px] text-accent"
+                >
+                  {`{{${f.name}}}`}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="mt-3">
+            <p className="mb-1 text-[11px] text-text-tertiary">
+              System prompt:
+            </p>
+            <pre className="rounded-md bg-bg-subtle px-3 py-2 text-[11px] text-text-primary whitespace-pre-wrap">
+              {agent.systemPrompt}
+            </pre>
+          </div>
+        </div>
+
+        {/* Assignments section */}
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-xs font-semibold text-text-primary">
+              Assignments
+            </h2>
+            <button
+              onClick={openCreate}
+              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
+            >
+              New Assignment
+            </button>
+          </div>
+
+          {assignments.length === 0 ? (
+            <p className="text-xs text-text-tertiary">No assignments yet.</p>
+          ) : (
+            <div className="space-y-1">
+              {assignments.map((a) => (
+                <div
+                  key={a.id}
+                  className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 ring-1 ring-gray-200"
+                >
+                  <div>
+                    <p className="text-xs font-medium text-text-primary">
+                      {a.mailbox ?? "*"} / {a.personId ?? "*"}
+                    </p>
+                    <p className="text-[11px] text-text-tertiary">
+                      {a.templateName} &middot; {MODE_LABELS[a.mode] ?? a.mode}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                        a.isActive
+                          ? "bg-green-50 text-green-700"
+                          : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      {a.isActive ? "Active" : "Inactive"}
+                    </span>
+                    <button
+                      onClick={() => openEdit(a)}
+                      className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDeleteAssignment(a.id)}
+                      className="rounded-md px-2.5 py-1 text-[11px] text-destructive hover:bg-bg-muted"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Assignment dialog */}
+      {showDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+            <h3 className="mb-4 text-sm font-semibold text-text-primary">
+              {editingId ? "Edit Assignment" : "New Assignment"}
+            </h3>
+            {formError && (
+              <p className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-600">
+                {formError}
+              </p>
+            )}
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-[11px] font-medium text-text-primary">
+                  Mailbox{" "}
+                  <span className="font-normal text-text-tertiary">
+                    (leave blank for any)
+                  </span>
+                </label>
+                <input
+                  value={form.mailbox}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, mailbox: e.target.value }))
+                  }
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+                  placeholder="inbox@example.com"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] font-medium text-text-primary">
+                  Person ID{" "}
+                  <span className="font-normal text-text-tertiary">
+                    (leave blank for any)
+                  </span>
+                </label>
+                <input
+                  value={form.personId}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, personId: e.target.value }))
+                  }
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+                  placeholder="person ID"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] font-medium text-text-primary">
+                  Template
+                </label>
+                <select
+                  value={form.templateSlug}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, templateSlug: e.target.value }))
+                  }
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+                >
+                  <option value="">Select a template…</option>
+                  {templates.map((t) => (
+                    <option key={t.slug} value={t.slug}>
+                      {t.name} ({t.slug})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-[11px] font-medium text-text-primary">
+                  Mode
+                </label>
+                <select
+                  value={form.mode}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      mode: e.target.value as AgentAssignment["mode"],
+                    }))
+                  }
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+                >
+                  <option value="first_thread_reply">First reply</option>
+                  <option value="every_mail_reply">Every reply</option>
+                  <option value="draft_only">Draft only</option>
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="asgn-active"
+                  checked={form.isActive}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, isActive: e.target.checked }))
+                  }
+                  className="h-4 w-4 accent-accent"
+                />
+                <label
+                  htmlFor="asgn-active"
+                  className="text-xs font-medium text-text-primary"
+                >
+                  Active
+                </label>
+              </div>
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setShowDialog(false)}
+                className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/AgentEditorPage.tsx
+++ b/src/pages/AgentEditorPage.tsx
@@ -1,0 +1,286 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  fetchAgentDefinition,
+  createAgentDefinition,
+  updateAgentDefinition,
+  type OutputField,
+} from "@/lib/api";
+
+export default function AgentEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = !!id;
+  const navigate = useNavigate();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [modelId, setModelId] = useState("@cf/meta/llama-3.3-70b-instruct");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [outputFields, setOutputFields] = useState<OutputField[]>([
+    { name: "", description: "" },
+  ]);
+  const [maxRunsPerHour, setMaxRunsPerHour] = useState(10);
+  const [isActive, setIsActive] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(isEdit);
+
+  useEffect(() => {
+    if (!id) return;
+    fetchAgentDefinition(id)
+      .then((a) => {
+        setName(a.name);
+        setDescription(a.description ?? "");
+        setModelId(a.modelId);
+        setSystemPrompt(a.systemPrompt);
+        setOutputFields(
+          a.outputFields.length > 0
+            ? a.outputFields
+            : [{ name: "", description: "" }],
+        );
+        setMaxRunsPerHour(a.maxRunsPerHour);
+        setIsActive(a.isActive);
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  function updateField(index: number, key: keyof OutputField, value: string) {
+    setOutputFields((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, [key]: value } : f)),
+    );
+  }
+
+  function addField() {
+    setOutputFields((prev) => [...prev, { name: "", description: "" }]);
+  }
+
+  function removeField(index: number) {
+    setOutputFields((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (!systemPrompt.trim()) {
+      setError("System prompt is required");
+      return;
+    }
+    if (outputFields.length === 0) {
+      setError("At least one output field is required");
+      return;
+    }
+    const invalidField = outputFields.find(
+      (f) => !f.name.trim() || !/^\w+$/.test(f.name),
+    );
+    if (invalidField) {
+      setError("Field names must be alphanumeric/underscore with no spaces");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      if (isEdit && id) {
+        await updateAgentDefinition(id, {
+          name,
+          description: description || undefined,
+          modelId,
+          systemPrompt,
+          outputFields,
+          maxRunsPerHour,
+          isActive,
+        });
+      } else {
+        await createAgentDefinition({
+          name,
+          description: description || undefined,
+          modelId,
+          systemPrompt,
+          outputFields,
+          maxRunsPerHour,
+          isActive,
+        });
+      }
+      navigate("/agents");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(
+        msg.includes("422")
+          ? "Template mismatch — check that your output fields cover all template variables in existing assignments."
+          : "Failed to save agent.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading)
+    return <div className="p-6 text-xs text-text-tertiary">Loading...</div>;
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-6 text-sm font-semibold text-text-primary">
+          {isEdit ? "Edit Agent" : "New Agent"}
+        </h1>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-600">
+              {error}
+            </p>
+          )}
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-primary">
+              Name
+            </label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+              placeholder="e.g. Welcome Reply Agent"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-primary">
+              Description{" "}
+              <span className="font-normal text-text-tertiary">(optional)</span>
+            </label>
+            <input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-primary">
+              Model ID
+            </label>
+            <input
+              value={modelId}
+              onChange={(e) => setModelId(e.target.value)}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+              placeholder="@cf/meta/llama-3.3-70b-instruct"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-primary">
+              System Prompt
+            </label>
+            <textarea
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              rows={8}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+              placeholder="You are a helpful assistant that replies to customer emails..."
+            />
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-xs font-medium text-text-primary">
+                Output Fields
+              </label>
+              <button
+                type="button"
+                onClick={addField}
+                className="text-[11px] text-accent hover:underline"
+              >
+                + Add Field
+              </button>
+            </div>
+            <div className="space-y-2">
+              {outputFields.map((field, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <input
+                    value={field.name}
+                    onChange={(e) => updateField(i, "name", e.target.value)}
+                    className="w-32 rounded-md border border-border px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-accent/30"
+                    placeholder="fieldName"
+                  />
+                  <input
+                    value={field.description}
+                    onChange={(e) =>
+                      updateField(i, "description", e.target.value)
+                    }
+                    className="flex-1 rounded-md border border-border px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+                    placeholder="What this field contains"
+                  />
+                  {outputFields.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeField(i)}
+                      className="text-[11px] text-destructive hover:text-red-700"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <p className="mt-1 text-[11px] text-text-tertiary">
+              Field names become template variables:{" "}
+              <code>{"{{fieldName}}"}</code>
+            </p>
+          </div>
+
+          <div className="flex gap-6">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-primary">
+                Max Runs / Hour
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={maxRunsPerHour}
+                onChange={(e) => setMaxRunsPerHour(Number(e.target.value))}
+                className="w-24 rounded-md border border-border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-accent/30"
+              />
+            </div>
+            <div className="flex items-end gap-2">
+              <input
+                type="checkbox"
+                id="isActive"
+                checked={isActive}
+                onChange={(e) => setIsActive(e.target.checked)}
+                className="h-4 w-4 accent-accent"
+              />
+              <label
+                htmlFor="isActive"
+                className="text-xs font-medium text-text-primary"
+              >
+                Active
+              </label>
+            </div>
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => navigate("/agents")}
+              className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AgentRunsPage.tsx
+++ b/src/pages/AgentRunsPage.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect } from "react";
+import { fetchAgentRuns, type AgentRun } from "@/lib/api";
+
+const STATUS_COLORS: Record<string, string> = {
+  succeeded: "bg-green-50 text-green-700",
+  failed: "bg-red-50 text-red-700",
+  running: "bg-blue-50 text-blue-700",
+  queued: "bg-yellow-50 text-yellow-700",
+};
+
+function statusColor(status: string) {
+  if (status.startsWith("skipped_")) return "bg-gray-100 text-gray-500";
+  return STATUS_COLORS[status] ?? "bg-gray-100 text-gray-500";
+}
+
+export default function AgentRunsPage() {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [total, setTotal] = useState(0);
+  const [status, setStatus] = useState("");
+  const [limit] = useState(50);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchAgentRuns({ status: status || undefined, limit, offset })
+      .then((data) => {
+        setRuns(data.runs);
+        setTotal(data.total);
+      })
+      .finally(() => setLoading(false));
+  }, [status, limit, offset]);
+
+  function formatTs(ts: number) {
+    return new Date(ts * 1000).toLocaleString();
+  }
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-sm font-semibold text-text-primary">
+            Agent Runs
+          </h1>
+          <select
+            value={status}
+            onChange={(e) => {
+              setStatus(e.target.value);
+              setOffset(0);
+            }}
+            className="rounded-md border border-border px-2 py-1 text-xs focus:outline-none"
+          >
+            <option value="">All statuses</option>
+            <option value="queued">Queued</option>
+            <option value="running">Running</option>
+            <option value="succeeded">Succeeded</option>
+            <option value="failed">Failed</option>
+            <option value="skipped_inactive">Skipped (inactive)</option>
+            <option value="skipped_mode">Skipped (mode)</option>
+            <option value="skipped_loop">Skipped (loop)</option>
+            <option value="skipped_rate_limit">Skipped (rate limit)</option>
+          </select>
+        </div>
+
+        {loading ? (
+          <p className="text-xs text-text-tertiary">Loading...</p>
+        ) : runs.length === 0 ? (
+          <p className="text-xs text-text-tertiary">No runs yet.</p>
+        ) : (
+          <>
+            <div className="space-y-1">
+              {runs.map((r) => (
+                <div key={r.id}>
+                  <div
+                    className="flex cursor-pointer items-center justify-between rounded-lg border border-border bg-white px-4 py-3 ring-1 ring-gray-200 hover:bg-bg-subtle"
+                    onClick={() =>
+                      setExpandedId(expandedId === r.id ? null : r.id)
+                    }
+                  >
+                    <div>
+                      <p className="text-[11px] font-medium text-text-primary">
+                        {formatTs(r.createdAt)}
+                      </p>
+                      <p className="text-[10px] text-text-tertiary">
+                        Person: {r.personId.slice(0, 12)}…
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {r.action && (
+                        <span className="text-[10px] text-text-tertiary">
+                          {r.action}
+                        </span>
+                      )}
+                      {(r.inputTokens || r.outputTokens) && (
+                        <span className="text-[10px] text-text-tertiary">
+                          {r.inputTokens ?? 0}↑ {r.outputTokens ?? 0}↓
+                        </span>
+                      )}
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${statusColor(r.status)}`}
+                      >
+                        {r.status}
+                      </span>
+                    </div>
+                  </div>
+                  {expandedId === r.id && (
+                    <div className="rounded-b-lg border border-t-0 border-border bg-bg-subtle px-4 py-3 text-[11px] text-text-secondary space-y-1">
+                      <p>
+                        <span className="text-text-tertiary">Run ID:</span>{" "}
+                        {r.id}
+                      </p>
+                      <p>
+                        <span className="text-text-tertiary">Email ID:</span>{" "}
+                        {r.emailId}
+                      </p>
+                      <p>
+                        <span className="text-text-tertiary">Assignment:</span>{" "}
+                        {r.assignmentId}
+                      </p>
+                      {r.modelId && (
+                        <p>
+                          <span className="text-text-tertiary">Model:</span>{" "}
+                          {r.modelId}
+                        </p>
+                      )}
+                      {r.errorMessage && (
+                        <p className="text-red-600">
+                          <span className="text-text-tertiary">Error:</span>{" "}
+                          {r.errorMessage}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex items-center justify-between text-[11px] text-text-tertiary">
+              <span>
+                Showing {offset + 1}–{Math.min(offset + limit, total)} of{" "}
+                {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  disabled={offset === 0}
+                  onClick={() => setOffset((o) => Math.max(0, o - limit))}
+                  className="rounded-md border border-border px-2.5 py-1 disabled:opacity-40 hover:bg-bg-muted"
+                >
+                  ← Prev
+                </button>
+                <button
+                  disabled={offset + limit >= total}
+                  onClick={() => setOffset((o) => o + limit)}
+                  className="rounded-md border border-border px-2.5 py-1 disabled:opacity-40 hover:bg-bg-muted"
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  fetchAgentDefinitions,
+  deleteAgentDefinition,
+  type AgentDefinition,
+} from "@/lib/api";
+
+export default function AgentsPage() {
+  const [agents, setAgents] = useState<AgentDefinition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchAgentDefinitions()
+      .then(setAgents)
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id: string) {
+    if (!confirm("Delete this agent?")) return;
+    try {
+      await deleteAgentDefinition(id);
+      setAgents((prev) => prev.filter((a) => a.id !== id));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("409") || msg.includes("assignment")) {
+        alert("Deactivate or delete all assignments for this agent first.");
+      } else {
+        alert("Failed to delete agent.");
+      }
+    }
+  }
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-sm font-semibold text-text-primary">Agents</h1>
+          <button
+            onClick={() => navigate("/agents/new")}
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
+          >
+            New Agent
+          </button>
+        </div>
+
+        {loading ? (
+          <p className="text-xs text-text-tertiary">Loading...</p>
+        ) : agents.length === 0 ? (
+          <p className="text-xs text-text-tertiary">
+            No agents yet. Create one to automate email replies.
+          </p>
+        ) : (
+          <div className="space-y-1">
+            {agents.map((a) => (
+              <div
+                key={a.id}
+                className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 ring-1 ring-gray-200"
+              >
+                <div>
+                  <p className="text-xs font-medium text-text-primary">
+                    {a.name}
+                  </p>
+                  <p className="text-[11px] text-text-tertiary">
+                    {a.modelId} &middot; {a.outputFields.length} field
+                    {a.outputFields.length !== 1 ? "s" : ""}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                      a.isActive
+                        ? "bg-green-50 text-green-700"
+                        : "bg-gray-100 text-gray-500"
+                    }`}
+                  >
+                    {a.isActive ? "Active" : "Inactive"}
+                  </span>
+                  <button
+                    onClick={() => navigate(`/agents/${a.id}/edit`)}
+                    className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => navigate(`/agents/${a.id}`)}
+                    className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                  >
+                    Assignments
+                  </button>
+                  <button
+                    onClick={() => handleDelete(a.id)}
+                    className="rounded-md px-2.5 py-1 text-[11px] text-destructive hover:bg-bg-muted"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/DraftsPage.tsx
+++ b/src/pages/DraftsPage.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from "react";
+import { fetchDrafts, sendDraft, deleteDraft, type Draft } from "@/lib/api";
+import { sanitizeHtml } from "@/lib/sanitize-html";
+
+export default function DraftsPage() {
+  const [draftList, setDraftList] = useState<Draft[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sendingId, setSendingId] = useState<string | null>(null);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchDrafts()
+      .then(setDraftList)
+      .finally(() => setLoading(false));
+  }, []);
+
+  function formatTs(ts: number) {
+    return new Date(ts * 1000).toLocaleString();
+  }
+
+  async function handleSend(id: string) {
+    if (!confirm("Send this draft?")) return;
+    setSendingId(id);
+    try {
+      await sendDraft(id);
+      setDraftList((prev) => prev.filter((d) => d.id !== id));
+    } catch {
+      alert("Failed to send draft.");
+    } finally {
+      setSendingId(null);
+    }
+  }
+
+  async function handleDiscard(id: string) {
+    if (!confirm("Discard this draft?")) return;
+    await deleteDraft(id);
+    setDraftList((prev) => prev.filter((d) => d.id !== id));
+  }
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-6 text-sm font-semibold text-text-primary">Drafts</h1>
+
+        {loading ? (
+          <p className="text-xs text-text-tertiary">Loading...</p>
+        ) : draftList.length === 0 ? (
+          <p className="text-xs text-text-tertiary">
+            No pending drafts. Agents with "Draft only" mode will place replies
+            here for review.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {draftList.map((d) => (
+              <div
+                key={d.id}
+                className="rounded-lg border border-border bg-white ring-1 ring-gray-200"
+              >
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div>
+                    <p className="text-xs font-medium text-text-primary">
+                      {d.toAddress}
+                    </p>
+                    <p className="text-[11px] text-text-tertiary">
+                      {d.subject} &middot; {d.fromAddress} &middot;{" "}
+                      {formatTs(d.createdAt)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() =>
+                        setPreviewId(previewId === d.id ? null : d.id)
+                      }
+                      className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted"
+                    >
+                      {previewId === d.id ? "Hide" : "Preview"}
+                    </button>
+                    <button
+                      disabled={sendingId === d.id}
+                      onClick={() => handleSend(d.id)}
+                      className="rounded-md bg-accent px-2.5 py-1 text-[11px] font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+                    >
+                      {sendingId === d.id ? "Sending…" : "Send"}
+                    </button>
+                    <button
+                      disabled={sendingId === d.id}
+                      onClick={() => handleDiscard(d.id)}
+                      className="rounded-md px-2.5 py-1 text-[11px] text-destructive hover:bg-bg-muted disabled:opacity-50"
+                    >
+                      Discard
+                    </button>
+                  </div>
+                </div>
+                {previewId === d.id && d.bodyHtml && (
+                  <div
+                    className="border-t border-border px-4 py-3 text-xs"
+                    dangerouslySetInnerHTML={{
+                      __html: sanitizeHtml(d.bodyHtml),
+                    }}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -29,6 +29,8 @@ export default defineConfig({
           VAPID_PRIVATE_KEY: "test-vapid-private",
           VAPID_PUBLIC_KEY: "test-vapid-public",
           VAPID_SUBJECT: "mailto:test@example.com",
+          AI_GATEWAY_SLUG: "test-gateway",
+          AGENTS_ENABLED: "true",
         },
       },
     }),

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -10,6 +10,10 @@ declare namespace Cloudflare {
 		R2: R2Bucket;
 		DB: D1Database;
 		EMAIL_QUEUE: Queue;
+		/** Agent runs queue — added for AI agents feature. */
+		AGENT_QUEUE: Queue;
+		/** Workers AI binding for running Cloudflare-hosted models. */
+		AI: Ai;
 		ASSETS: Fetcher;
 		BASE_URL: "<your-deployed-url>";
 		TRUSTED_ORIGINS: "http://localhost:8080,http://localhost:8788,<your-deployed-url>";
@@ -19,6 +23,10 @@ declare namespace Cloudflare {
 		/** Secret: set via `wrangler secret put VAPID_PRIVATE_KEY`. Not emitted by `wrangler types`; added manually. */
 		VAPID_PRIVATE_KEY?: string;
 		NOTIFICATIONS_HUB: DurableObjectNamespace<import("./worker/src/index").NotificationsHub>;
+		/** AI Gateway slug — create at dash.cloudflare.com → AI → AI Gateway. */
+		AI_GATEWAY_SLUG: string;
+		/** Set to "false" to disable all agent processing globally. */
+		AGENTS_ENABLED?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/worker/src/__tests__/agent-assignments-router.test.ts
+++ b/worker/src/__tests__/agent-assignments-router.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  createTestAgentDefinition,
+  createTestAgentAssignment,
+  createTestTemplate,
+  authFetch,
+} from "./helpers";
+
+describe("agent assignments router", () => {
+  let apiKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey } = await createTestUser());
+  });
+
+  describe("POST /api/agents/assignments", () => {
+    it("creates an assignment", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hello {{greeting}}",
+        bodyHtml: "<p>{{greeting}}</p>",
+      });
+
+      const res = await authFetch("/api/agents/assignments", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          agentId: "def-1",
+          mailbox: "inbox@test.com",
+          templateSlug: "welcome",
+          mode: "every_mail_reply",
+          isActive: true,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.agentId).toBe("def-1");
+      expect(data.templateSlug).toBe("welcome");
+      expect(data.mode).toBe("every_mail_reply");
+      expect(data.isActive).toBe(true);
+    });
+
+    it("returns 422 when template uses vars not in outputSchema", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      // Template uses {{unknownVar}} but agent only has {{greeting}} in schema
+      await createTestTemplate({
+        slug: "bad-template",
+        subject: "Hello {{unknownVar}}",
+        bodyHtml: "<p>test</p>",
+      });
+
+      const res = await authFetch("/api/agents/assignments", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          agentId: "def-1",
+          mailbox: "inbox@test.com",
+          templateSlug: "bad-template",
+          mode: "every_mail_reply",
+          isActive: true,
+        }),
+      });
+      expect(res.status).toBe(422);
+      const data = await res.json();
+      expect(data.missing).toContain("unknownVar");
+    });
+
+    it("returns 409 on duplicate active scope", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hi",
+        bodyHtml: "<p>hi</p>",
+      });
+      await createTestAgentAssignment({
+        id: "asgn-1",
+        agentId: "def-1",
+        mailbox: "inbox@test.com",
+        personId: null,
+        templateSlug: "welcome",
+      });
+
+      const res = await authFetch("/api/agents/assignments", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          agentId: "def-1",
+          mailbox: "inbox@test.com",
+          templateSlug: "welcome",
+          mode: "every_mail_reply",
+          isActive: true,
+        }),
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 404 when agent not found", async () => {
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hi",
+        bodyHtml: "<p>hi</p>",
+      });
+      const res = await authFetch("/api/agents/assignments", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          agentId: "nonexistent",
+          templateSlug: "welcome",
+          mode: "every_mail_reply",
+          isActive: true,
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/agents/assignments", () => {
+    it("lists assignments with agent and template names", async () => {
+      await createTestAgentDefinition({ id: "def-1", name: "My Agent" });
+      await createTestTemplate({ slug: "welcome", name: "Welcome" });
+      await createTestAgentAssignment({
+        id: "asgn-1",
+        agentId: "def-1",
+        templateSlug: "welcome",
+      });
+
+      const res = await authFetch("/api/agents/assignments", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].agentName).toBe("My Agent");
+      expect(data[0].templateName).toBe("Welcome");
+    });
+
+    it("filters by agentId", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      await createTestAgentDefinition({ id: "def-2", name: "Other Agent" });
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hi",
+        bodyHtml: "<p>hi</p>",
+      });
+      await createTestAgentAssignment({
+        id: "asgn-1",
+        agentId: "def-1",
+        templateSlug: "welcome",
+      });
+      await createTestAgentAssignment({
+        id: "asgn-2",
+        agentId: "def-2",
+        mailbox: "other@test.com",
+        templateSlug: "welcome",
+      });
+
+      const res = await authFetch("/api/agents/assignments?agentId=def-1", {
+        apiKey,
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].agentId).toBe("def-1");
+    });
+  });
+
+  describe("DELETE /api/agents/assignments/:id", () => {
+    it("deletes an assignment", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hi",
+        bodyHtml: "<p>hi</p>",
+      });
+      await createTestAgentAssignment({
+        id: "asgn-1",
+        agentId: "def-1",
+        templateSlug: "welcome",
+      });
+
+      const res = await authFetch("/api/agents/assignments/asgn-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+
+    it("returns 404 for missing assignment", async () => {
+      const res = await authFetch("/api/agents/assignments/nonexistent", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/worker/src/__tests__/agent-definitions-router.test.ts
+++ b/worker/src/__tests__/agent-definitions-router.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  createTestAgentDefinition,
+  createTestAgentAssignment,
+  authFetch,
+} from "./helpers";
+
+describe("agent definitions router", () => {
+  let apiKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey } = await createTestUser());
+  });
+
+  describe("POST /api/agents/definitions", () => {
+    it("creates an agent definition", async () => {
+      const res = await authFetch("/api/agents/definitions", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          name: "Welcome Agent",
+          modelId: "@cf/meta/llama-3.3-70b-instruct",
+          systemPrompt: "You are a helpful assistant.",
+          outputFields: [{ name: "greeting", description: "A greeting" }],
+          maxRunsPerHour: 5,
+          isActive: true,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.name).toBe("Welcome Agent");
+      expect(data.outputFields).toEqual([
+        { name: "greeting", description: "A greeting" },
+      ]);
+      expect(data.isActive).toBe(true);
+      expect(data.maxRunsPerHour).toBe(5);
+    });
+
+    it("rejects empty outputFields", async () => {
+      const res = await authFetch("/api/agents/definitions", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          name: "Bad Agent",
+          systemPrompt: "You are helpful.",
+          outputFields: [],
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects outputField name with spaces", async () => {
+      const res = await authFetch("/api/agents/definitions", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          name: "Bad Agent",
+          systemPrompt: "You are helpful.",
+          outputFields: [{ name: "bad name", description: "x" }],
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/agents/definitions", () => {
+    it("lists agent definitions", async () => {
+      await createTestAgentDefinition({ id: "def-1", name: "Agent One" });
+      await createTestAgentDefinition({ id: "def-2", name: "Agent Two" });
+      const res = await authFetch("/api/agents/definitions", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(2);
+      expect(data[0].outputFields).toBeDefined();
+    });
+
+    it("returns empty array when no definitions", async () => {
+      const res = await authFetch("/api/agents/definitions", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual([]);
+    });
+  });
+
+  describe("GET /api/agents/definitions/:id", () => {
+    it("returns a definition by id", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      const res = await authFetch("/api/agents/definitions/def-1", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.id).toBe("def-1");
+      expect(data.outputFields).toBeInstanceOf(Array);
+    });
+
+    it("returns 404 for missing id", async () => {
+      const res = await authFetch("/api/agents/definitions/nonexistent", {
+        apiKey,
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /api/agents/definitions/:id", () => {
+    it("updates a definition", async () => {
+      await createTestAgentDefinition({ id: "def-1", name: "Original" });
+      const res = await authFetch("/api/agents/definitions/def-1", {
+        apiKey,
+        method: "PUT",
+        body: JSON.stringify({ name: "Updated", isActive: false }),
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.name).toBe("Updated");
+      expect(data.isActive).toBe(false);
+    });
+
+    it("returns 404 for missing id", async () => {
+      const res = await authFetch("/api/agents/definitions/nonexistent", {
+        apiKey,
+        method: "PUT",
+        body: JSON.stringify({ name: "X" }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/agents/definitions/:id", () => {
+    it("deletes a definition with no assignments", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      const res = await authFetch("/api/agents/definitions/def-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("returns 409 when assignments exist", async () => {
+      await createTestAgentDefinition({ id: "def-1" });
+      await createTestAgentAssignment({ id: "asgn-1", agentId: "def-1" });
+      const res = await authFetch("/api/agents/definitions/def-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 404 for missing id", async () => {
+      const res = await authFetch("/api/agents/definitions/nonexistent", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/worker/src/__tests__/agent-runs-router.test.ts
+++ b/worker/src/__tests__/agent-runs-router.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  createTestAgentDefinition,
+  createTestAgentAssignment,
+  createTestAgentRun,
+  createTestPerson,
+  createTestEmail,
+  authFetch,
+} from "./helpers";
+
+describe("agent runs router", () => {
+  let apiKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey } = await createTestUser());
+    await createTestPerson({ id: "sender-1" });
+    await createTestEmail({ id: "email-1", personId: "sender-1" });
+    await createTestAgentDefinition({ id: "def-1" });
+    await createTestAgentAssignment({ id: "asgn-1", agentId: "def-1" });
+  });
+
+  describe("GET /api/agents/runs", () => {
+    it("lists runs", async () => {
+      await createTestAgentRun({
+        id: "run-1",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+      });
+      const res = await authFetch("/api/agents/runs", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.runs).toHaveLength(1);
+      expect(data.total).toBe(1);
+    });
+
+    it("filters by status", async () => {
+      await createTestAgentRun({
+        id: "run-1",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+        status: "succeeded",
+      });
+      await createTestAgentRun({
+        id: "run-2",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+        status: "failed",
+      });
+
+      const res = await authFetch("/api/agents/runs?status=failed", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.runs).toHaveLength(1);
+      expect(data.runs[0].status).toBe("failed");
+    });
+
+    it("paginates results", async () => {
+      await createTestAgentRun({
+        id: "run-1",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+      });
+      await createTestAgentRun({
+        id: "run-2",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+      });
+
+      const res = await authFetch("/api/agents/runs?limit=1&offset=0", {
+        apiKey,
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.runs).toHaveLength(1);
+      expect(data.total).toBe(2);
+    });
+  });
+
+  describe("GET /api/agents/runs/:id", () => {
+    it("returns a single run", async () => {
+      await createTestAgentRun({
+        id: "run-1",
+        assignmentId: "asgn-1",
+        emailId: "email-1",
+        personId: "sender-1",
+      });
+      const res = await authFetch("/api/agents/runs/run-1", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.id).toBe("run-1");
+    });
+
+    it("returns 404 for missing run", async () => {
+      const res = await authFetch("/api/agents/runs/nonexistent", { apiKey });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/worker/src/__tests__/drafts-router.test.ts
+++ b/worker/src/__tests__/drafts-router.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { getDb } from "./helpers";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  createTestAgentDefinition,
+  createTestAgentAssignment,
+  createTestAgentRun,
+  createTestPerson,
+  createTestEmail,
+  authFetch,
+} from "./helpers";
+import { drafts } from "../db/drafts.schema";
+
+async function createTestDraft(
+  opts: {
+    id?: string;
+    personId?: string;
+    agentRunId?: string;
+  } = {},
+) {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const draft = {
+    id: opts.id ?? "draft-1",
+    personId: opts.personId ?? "sender-1",
+    agentRunId: opts.agentRunId ?? "run-1",
+    fromAddress: "inbox@saasmail.test",
+    toAddress: "alice@example.com",
+    subject: "Hello from agent",
+    bodyHtml: "<p>Hi there!</p>",
+    inReplyTo: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(drafts).values(draft);
+  return draft;
+}
+
+describe("drafts router", () => {
+  let apiKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey } = await createTestUser());
+    await createTestPerson({ id: "sender-1" });
+    await createTestEmail({ id: "email-1", personId: "sender-1" });
+    await createTestAgentDefinition({ id: "def-1" });
+    await createTestAgentAssignment({ id: "asgn-1", agentId: "def-1" });
+    await createTestAgentRun({
+      id: "run-1",
+      assignmentId: "asgn-1",
+      emailId: "email-1",
+      personId: "sender-1",
+    });
+  });
+
+  describe("GET /api/drafts", () => {
+    it("lists drafts", async () => {
+      await createTestDraft({ id: "draft-1" });
+      const res = await authFetch("/api/drafts", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].subject).toBe("Hello from agent");
+    });
+
+    it("filters by personId", async () => {
+      await createTestPerson({ id: "sender-2", email: "bob@example.com" });
+      await createTestEmail({
+        id: "email-2",
+        personId: "sender-2",
+        recipient: "inbox@saasmail.test",
+        messageId: "msg-2@example.com",
+      });
+      await createTestAgentRun({
+        id: "run-2",
+        assignmentId: "asgn-1",
+        emailId: "email-2",
+        personId: "sender-2",
+      });
+      await createTestDraft({
+        id: "draft-1",
+        personId: "sender-1",
+        agentRunId: "run-1",
+      });
+      await createTestDraft({
+        id: "draft-2",
+        personId: "sender-2",
+        agentRunId: "run-2",
+      });
+
+      const res = await authFetch("/api/drafts?personId=sender-1", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].personId).toBe("sender-1");
+    });
+  });
+
+  describe("GET /api/drafts/:id", () => {
+    it("returns a draft", async () => {
+      await createTestDraft({ id: "draft-1" });
+      const res = await authFetch("/api/drafts/draft-1", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.id).toBe("draft-1");
+    });
+
+    it("returns 404 for missing draft", async () => {
+      const res = await authFetch("/api/drafts/nonexistent", { apiKey });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/drafts/:id", () => {
+    it("deletes a draft", async () => {
+      await createTestDraft({ id: "draft-1" });
+      const res = await authFetch("/api/drafts/draft-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+
+    it("returns 404 for missing draft", async () => {
+      const res = await authFetch("/api/drafts/nonexistent", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -21,6 +21,9 @@ import {
   oauthRefreshTokens,
 } from "../db/auth.schema";
 import { hashKey } from "../lib/crypto";
+import { agentDefinitions } from "../db/agent-definitions.schema";
+import { agentAssignments } from "../db/agent-assignments.schema";
+import { agentRuns } from "../db/agent-runs.schema";
 
 export function getDb() {
   return drizzle(env.DB, { schema });
@@ -71,6 +74,17 @@ export async function applyMigrations() {
     `CREATE TABLE IF NOT EXISTS push_subscriptions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, endpoint TEXT NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, user_agent TEXT, created_at INTEGER NOT NULL, last_used_at INTEGER)`,
     `CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_endpoint_idx ON push_subscriptions(endpoint)`,
     `CREATE INDEX IF NOT EXISTS push_subscriptions_user_idx ON push_subscriptions(user_id)`,
+    `CREATE TABLE IF NOT EXISTS agent_definitions (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, model_id TEXT NOT NULL, system_prompt TEXT NOT NULL, output_schema_json TEXT NOT NULL, max_runs_per_hour INTEGER NOT NULL DEFAULT 10, is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS agent_assignments (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL REFERENCES agent_definitions(id) ON DELETE CASCADE, mailbox TEXT, person_id TEXT, template_slug TEXT NOT NULL, mode TEXT NOT NULL, is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS assignments_agent_idx ON agent_assignments(agent_id)`,
+    `CREATE INDEX IF NOT EXISTS assignments_mailbox_person_idx ON agent_assignments(mailbox, person_id)`,
+    `CREATE TABLE IF NOT EXISTS agent_runs (id TEXT PRIMARY KEY, assignment_id TEXT NOT NULL, email_id TEXT NOT NULL, person_id TEXT NOT NULL, status TEXT NOT NULL, action TEXT, sent_email_id TEXT, draft_id TEXT, model_id TEXT, input_tokens INTEGER, output_tokens INTEGER, error_message TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS runs_assignment_person_created_idx ON agent_runs(assignment_id, person_id, created_at)`,
+    `CREATE INDEX IF NOT EXISTS runs_email_idx ON agent_runs(email_id)`,
+    `CREATE INDEX IF NOT EXISTS runs_status_created_idx ON agent_runs(status, created_at)`,
+    `CREATE TABLE IF NOT EXISTS drafts (id TEXT PRIMARY KEY, person_id TEXT NOT NULL, agent_run_id TEXT NOT NULL, from_address TEXT NOT NULL, to_address TEXT NOT NULL, subject TEXT NOT NULL, body_html TEXT, in_reply_to TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS drafts_person_created_idx ON drafts(person_id, created_at)`,
+    `CREATE INDEX IF NOT EXISTS drafts_agent_run_idx ON drafts(agent_run_id)`,
   ];
 
   for (const sql of statements) {
@@ -221,6 +235,10 @@ export async function authFetch(
 export async function cleanDb() {
   const db = env.DB;
   await db.exec(`
+    DELETE FROM drafts;
+    DELETE FROM agent_runs;
+    DELETE FROM agent_assignments;
+    DELETE FROM agent_definitions;
     DELETE FROM push_subscriptions;
     DELETE FROM inbox_permissions;
     DELETE FROM sender_identities;
@@ -245,4 +263,104 @@ export async function cleanDb() {
     DELETE FROM jwkss;
     DELETE FROM users;
   `);
+}
+
+/** Create a test agent definition. */
+export async function createTestAgentDefinition(
+  opts: {
+    id?: string;
+    name?: string;
+    modelId?: string;
+    systemPrompt?: string;
+    outputSchemaJson?: string;
+    maxRunsPerHour?: number;
+    isActive?: number;
+  } = {},
+) {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const def = {
+    id: opts.id ?? "agent-def-1",
+    name: opts.name ?? "Test Agent",
+    description: null,
+    modelId: opts.modelId ?? "@cf/meta/llama-3.3-70b-instruct",
+    systemPrompt: opts.systemPrompt ?? "You are a helpful assistant.",
+    outputSchemaJson:
+      opts.outputSchemaJson ??
+      JSON.stringify({
+        type: "object",
+        properties: {
+          greeting: { type: "string", description: "A greeting message" },
+        },
+        required: ["greeting"],
+      }),
+    maxRunsPerHour: opts.maxRunsPerHour ?? 10,
+    isActive: opts.isActive ?? 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(agentDefinitions).values(def);
+  return def;
+}
+
+/** Create a test agent assignment. */
+export async function createTestAgentAssignment(
+  opts: {
+    id?: string;
+    agentId?: string;
+    mailbox?: string | null;
+    personId?: string | null;
+    templateSlug?: string;
+    mode?: string;
+    isActive?: number;
+  } = {},
+) {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const assignment = {
+    id: opts.id ?? "assignment-1",
+    agentId: opts.agentId ?? "agent-def-1",
+    mailbox: opts.mailbox !== undefined ? opts.mailbox : "inbox@saasmail.test",
+    personId: opts.personId !== undefined ? opts.personId : null,
+    templateSlug: opts.templateSlug ?? "welcome",
+    mode: opts.mode ?? "every_mail_reply",
+    isActive: opts.isActive ?? 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(agentAssignments).values(assignment);
+  return assignment;
+}
+
+/** Create a test agent run. */
+export async function createTestAgentRun(
+  opts: {
+    id?: string;
+    assignmentId?: string;
+    emailId?: string;
+    personId?: string;
+    status?: string;
+    action?: string | null;
+  } = {},
+) {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const run = {
+    id: opts.id ?? "run-1",
+    assignmentId: opts.assignmentId ?? "assignment-1",
+    emailId: opts.emailId ?? "email-1",
+    personId: opts.personId ?? "sender-1",
+    status: opts.status ?? "succeeded",
+    action: opts.action !== undefined ? opts.action : "sent",
+    sentEmailId: null,
+    draftId: null,
+    modelId: "@cf/meta/llama-3.3-70b-instruct",
+    inputTokens: 100,
+    outputTokens: 50,
+    errorMessage: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(agentRuns).values(run);
+  return run;
 }

--- a/worker/src/db/agent-assignments.schema.ts
+++ b/worker/src/db/agent-assignments.schema.ts
@@ -1,0 +1,26 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+// mode values:
+//   "first_thread_reply" — send only when this is the first email in the thread
+//   "every_mail_reply"   — send on every inbound email from this person
+//   "draft_only"         — create a draft instead of sending
+
+export const agentAssignments = sqliteTable(
+  "agent_assignments",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    // Scope — both nullable means "wildcard" (match any mailbox / any person).
+    mailbox: text("mailbox"),
+    personId: text("person_id"),
+    templateSlug: text("template_slug").notNull(),
+    mode: text("mode").notNull(),
+    isActive: integer("is_active").notNull().default(1),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("assignments_agent_idx").on(table.agentId),
+    index("assignments_mailbox_person_idx").on(table.mailbox, table.personId),
+  ],
+);

--- a/worker/src/db/agent-definitions.schema.ts
+++ b/worker/src/db/agent-definitions.schema.ts
@@ -1,0 +1,18 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const agentDefinitions = sqliteTable("agent_definitions", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  // Workers AI model ID, e.g. "@cf/meta/llama-3.3-70b-instruct"
+  modelId: text("model_id").notNull(),
+  systemPrompt: text("system_prompt").notNull(),
+  // Full JSON Schema object (serialised). Shape:
+  //   { type: "object", properties: { key: { type: "string", description: "…" } }, required: […] }
+  // Template vars must be a subset of properties keys — enforced at assignment time.
+  outputSchemaJson: text("output_schema_json").notNull(),
+  maxRunsPerHour: integer("max_runs_per_hour").notNull().default(10),
+  isActive: integer("is_active").notNull().default(1),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/worker/src/db/agent-runs.schema.ts
+++ b/worker/src/db/agent-runs.schema.ts
@@ -1,0 +1,34 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+// status: queued | running | succeeded | failed |
+//         skipped_inactive | skipped_mode | skipped_loop | skipped_rate_limit
+// action: "sent" | "draft" | null
+
+export const agentRuns = sqliteTable(
+  "agent_runs",
+  {
+    id: text("id").primaryKey(),
+    assignmentId: text("assignment_id").notNull(),
+    emailId: text("email_id").notNull(),
+    personId: text("person_id").notNull(),
+    status: text("status").notNull(),
+    action: text("action"),
+    sentEmailId: text("sent_email_id"),
+    draftId: text("draft_id"),
+    modelId: text("model_id"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
+    errorMessage: text("error_message"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("runs_assignment_person_created_idx").on(
+      table.assignmentId,
+      table.personId,
+      table.createdAt,
+    ),
+    index("runs_email_idx").on(table.emailId),
+    index("runs_status_created_idx").on(table.status, table.createdAt),
+  ],
+);

--- a/worker/src/db/drafts.schema.ts
+++ b/worker/src/db/drafts.schema.ts
@@ -1,0 +1,24 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+// Agent-generated draft replies (mode = "draft_only").
+// Shown in the UI for human review before sending.
+
+export const drafts = sqliteTable(
+  "drafts",
+  {
+    id: text("id").primaryKey(),
+    personId: text("person_id").notNull(),
+    agentRunId: text("agent_run_id").notNull(),
+    fromAddress: text("from_address").notNull(),
+    toAddress: text("to_address").notNull(),
+    subject: text("subject").notNull(),
+    bodyHtml: text("body_html"),
+    inReplyTo: text("in_reply_to"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("drafts_person_created_idx").on(table.personId, table.createdAt),
+    index("drafts_agent_run_idx").on(table.agentRunId),
+  ],
+);

--- a/worker/src/db/index.ts
+++ b/worker/src/db/index.ts
@@ -14,3 +14,7 @@ export * from "./sender-identities.schema";
 export * from "./inbox-permissions.schema";
 export * from "./push-subscriptions.schema";
 export * from "./schema";
+export * from "./agent-definitions.schema";
+export * from "./agent-assignments.schema";
+export * from "./agent-runs.schema";
+export * from "./drafts.schema";

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -12,6 +12,10 @@ import { sequenceEmails } from "./sequence-emails.schema";
 import { senderIdentities } from "./sender-identities.schema";
 import { inboxPermissions } from "./inbox-permissions.schema";
 import { pushSubscriptions } from "./push-subscriptions.schema";
+import { agentDefinitions } from "./agent-definitions.schema";
+import { agentAssignments } from "./agent-assignments.schema";
+import { agentRuns } from "./agent-runs.schema";
+import { drafts } from "./drafts.schema";
 
 export const schema = {
   ...authSchema,
@@ -28,4 +32,8 @@ export const schema = {
   senderIdentities,
   inboxPermissions,
   pushSubscriptions,
+  agentDefinitions,
+  agentAssignments,
+  agentRuns,
+  drafts,
 } as const;

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -228,6 +228,42 @@ export async function handleEmail(
     })(),
   );
 
+  // Dispatch AI agents for this email (non-blocking, best-effort)
+  ctx.waitUntil(
+    (async () => {
+      try {
+        const { dispatchAgentsForEmail } =
+          await import("./lib/dispatch-agents");
+        // Detect mail-loop headers
+        const rawHeadersParsed = parsed.headers as Record<
+          string,
+          string | string[]
+        >;
+        const autoSubmitted =
+          typeof rawHeadersParsed["auto-submitted"] === "string"
+            ? rawHeadersParsed["auto-submitted"]
+            : Array.isArray(rawHeadersParsed["auto-submitted"])
+              ? rawHeadersParsed["auto-submitted"][0]
+              : null;
+        const hasListHeader = Object.keys(rawHeadersParsed).some((k) =>
+          k.toLowerCase().startsWith("list-"),
+        );
+        await dispatchAgentsForEmail(
+          {
+            emailId,
+            personId: actualPersonId,
+            mailbox: parsed.to,
+            autoSubmitted,
+            hasListHeader,
+          },
+          env,
+        );
+      } catch (err) {
+        console.warn("Agent dispatch error:", err);
+      }
+    })(),
+  );
+
   // Cancel any active sequences for this person
   await cancelSequencesForPerson(db, actualPersonId);
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -25,6 +25,12 @@ import { sequencesRouter } from "./routers/sequences-router";
 import { handleScheduled, handleQueueBatch } from "./lib/sequence-processor";
 import type { SequenceEmailMessage } from "./lib/sequence-processor";
 import { notificationsRouter } from "./routers/notifications-router";
+import { agentDefinitionsRouter } from "./routers/agent-definitions-router";
+import { agentAssignmentsRouter } from "./routers/agent-assignments-router";
+import { agentRunsRouter } from "./routers/agent-runs-router";
+import { draftsRouter } from "./routers/drafts-router";
+import { handleAgentQueueBatch } from "./lib/agent-processor";
+import type { AgentRunMessage } from "./lib/agent-processor";
 export { NotificationsHub } from "./do/notifications";
 import type { Variables } from "./variables";
 import type { MiddlewareHandler } from "hono";
@@ -197,6 +203,10 @@ app.route("/api/api-keys", apiKeysRouter);
 app.route("/api/invites", invitesRouter);
 app.route("/api/sequences", sequencesRouter);
 app.route("/api/notifications", notificationsRouter);
+app.route("/api/agents/definitions", agentDefinitionsRouter);
+app.route("/api/agents/assignments", agentAssignmentsRouter);
+app.route("/api/agents/runs", agentRunsRouter);
+app.route("/api/drafts", draftsRouter);
 
 // Admin routes (require admin role)
 app.use("/api/admin/*", requireAdmin);
@@ -236,9 +246,13 @@ export default {
     ctx.waitUntil(handleScheduled(env));
   },
   async queue(
-    batch: MessageBatch<SequenceEmailMessage>,
+    batch: MessageBatch<SequenceEmailMessage | AgentRunMessage>,
     env: CloudflareBindings,
   ) {
-    await handleQueueBatch(batch, env);
+    if (batch.queue === "saasmail-agent-runs") {
+      await handleAgentQueueBatch(batch as MessageBatch<AgentRunMessage>, env);
+    } else {
+      await handleQueueBatch(batch as MessageBatch<SequenceEmailMessage>, env);
+    }
   },
 };

--- a/worker/src/lib/agent-processor.ts
+++ b/worker/src/lib/agent-processor.ts
@@ -1,0 +1,282 @@
+import { drizzle } from "drizzle-orm/d1";
+import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { createWorkersAI } from "workers-ai-provider";
+import { generateObject, jsonSchema } from "ai";
+import { schema } from "../db/schema";
+import { agentRuns } from "../db/agent-runs.schema";
+import { agentAssignments } from "../db/agent-assignments.schema";
+import { agentDefinitions } from "../db/agent-definitions.schema";
+import { emailTemplates } from "../db/email-templates.schema";
+import { emails } from "../db/emails.schema";
+import { people } from "../db/people.schema";
+import { drafts } from "../db/drafts.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { createEmailSender } from "./email-sender";
+import { interpolate } from "./interpolate";
+import { formatFromAddress } from "./format-from-address";
+import { generateMessageId } from "./message-id";
+
+export interface AgentRunMessage {
+  runId: string;
+  assignmentId: string;
+  emailId: string;
+}
+
+type Db = ReturnType<typeof drizzle>;
+
+export async function handleAgentQueueBatch(
+  batch: MessageBatch<AgentRunMessage>,
+  env: CloudflareBindings,
+): Promise<void> {
+  const db = drizzle(env.DB, { schema });
+  const sender = createEmailSender(env);
+
+  for (const msg of batch.messages) {
+    try {
+      await processAgentRun(db, sender, env, msg.body);
+      msg.ack();
+    } catch (err) {
+      console.error(`Failed to process agent run ${msg.body.runId}:`, err);
+      const now = Math.floor(Date.now() / 1000);
+      await db
+        .update(agentRuns)
+        .set({
+          status: "failed",
+          errorMessage: err instanceof Error ? err.message : String(err),
+          updatedAt: now,
+        })
+        .where(eq(agentRuns.id, msg.body.runId))
+        .catch(() => undefined);
+      msg.retry();
+    }
+  }
+}
+
+async function processAgentRun(
+  db: Db,
+  sender: ReturnType<typeof createEmailSender>,
+  env: CloudflareBindings,
+  { runId, assignmentId, emailId }: AgentRunMessage,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+
+  // Mark running
+  await db
+    .update(agentRuns)
+    .set({ status: "running", updatedAt: now })
+    .where(eq(agentRuns.id, runId));
+
+  // Load assignment
+  const [assignment] = await db
+    .select()
+    .from(agentAssignments)
+    .where(eq(agentAssignments.id, assignmentId))
+    .limit(1);
+  if (!assignment) throw new Error(`Assignment ${assignmentId} not found`);
+
+  // Load agent definition
+  const [def] = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, assignment.agentId))
+    .limit(1);
+  if (!def) throw new Error(`Agent definition ${assignment.agentId} not found`);
+
+  // Load trigger email
+  const [email] = await db
+    .select()
+    .from(emails)
+    .where(eq(emails.id, emailId))
+    .limit(1);
+  if (!email) throw new Error(`Email ${emailId} not found`);
+
+  // Load person
+  const [person] = await db
+    .select()
+    .from(people)
+    .where(eq(people.id, email.personId))
+    .limit(1);
+  if (!person) throw new Error(`Person ${email.personId} not found`);
+
+  // Thread context: last 10 emails from same person to same mailbox, excluding trigger
+  const allThread = await db
+    .select({
+      id: emails.id,
+      subject: emails.subject,
+      bodyText: emails.bodyText,
+      receivedAt: emails.receivedAt,
+    })
+    .from(emails)
+    .where(
+      and(
+        eq(emails.personId, person.id),
+        eq(emails.recipient, email.recipient),
+      ),
+    )
+    .orderBy(desc(emails.receivedAt))
+    .limit(11);
+  const thread = allThread.filter((r) => r.id !== emailId).slice(0, 10);
+
+  // Build LLM prompt messages
+  const messages = buildMessages(def.systemPrompt, email, person, thread);
+
+  // Reconstruct JSON Schema for generateObject
+  const outputSchema = jsonSchema<Record<string, string>>(
+    JSON.parse(def.outputSchemaJson),
+  );
+
+  // Call Workers AI via AI Gateway
+  const gatewayOpts = env.AI_GATEWAY_SLUG
+    ? {
+        gateway: {
+          id: env.AI_GATEWAY_SLUG,
+          skipCache: false,
+          cacheTtl: 3600,
+        },
+      }
+    : {};
+
+  const workersAI = createWorkersAI({ binding: env.AI });
+  const { object, usage } = await generateObject({
+    model: workersAI(def.modelId, gatewayOpts),
+    schema: outputSchema,
+    messages,
+  });
+
+  // Load template and interpolate
+  const [template] = await db
+    .select()
+    .from(emailTemplates)
+    .where(eq(emailTemplates.slug, assignment.templateSlug))
+    .limit(1);
+  if (!template)
+    throw new Error(`Template ${assignment.templateSlug} not found`);
+
+  const renderedSubject = interpolate(template.subject, object);
+  const renderedHtml = interpolate(template.bodyHtml, object);
+
+  const fromAddress = template.fromAddress ?? email.recipient;
+  const formattedFrom = await formatFromAddress(db, fromAddress);
+  const inputTokens =
+    (usage as { promptTokens?: number } | undefined)?.promptTokens ?? null;
+  const outputTokens =
+    (usage as { completionTokens?: number } | undefined)?.completionTokens ??
+    null;
+
+  if (assignment.mode === "draft_only") {
+    const draftId = nanoid();
+    await db.insert(drafts).values({
+      id: draftId,
+      personId: person.id,
+      agentRunId: runId,
+      fromAddress,
+      toAddress: person.email,
+      subject: renderedSubject,
+      bodyHtml: renderedHtml,
+      inReplyTo: email.messageId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db
+      .update(agentRuns)
+      .set({
+        status: "succeeded",
+        action: "draft",
+        draftId,
+        modelId: def.modelId,
+        inputTokens,
+        outputTokens,
+        updatedAt: now,
+      })
+      .where(eq(agentRuns.id, runId));
+  } else {
+    const messageId = generateMessageId(fromAddress);
+    const result = await sender.send({
+      from: formattedFrom,
+      to: person.email,
+      subject: renderedSubject,
+      html: renderedHtml,
+      headers: {
+        "Message-ID": messageId,
+        "Auto-Submitted": "auto-replied",
+        ...(email.messageId ? { "In-Reply-To": email.messageId } : {}),
+      },
+    });
+
+    const sentId = nanoid();
+    await db.insert(sentEmails).values({
+      id: sentId,
+      personId: person.id,
+      fromAddress,
+      toAddress: person.email,
+      subject: renderedSubject,
+      bodyHtml: renderedHtml,
+      bodyText: null,
+      inReplyTo: email.messageId,
+      messageId,
+      resendId: result.id,
+      status: result.error ? "failed" : "sent",
+      sentAt: now,
+      createdAt: now,
+    });
+
+    if (result.error) throw new Error(`Send failed: ${result.error}`);
+
+    await db
+      .update(agentRuns)
+      .set({
+        status: "succeeded",
+        action: "sent",
+        sentEmailId: sentId,
+        modelId: def.modelId,
+        inputTokens,
+        outputTokens,
+        updatedAt: now,
+      })
+      .where(eq(agentRuns.id, runId));
+  }
+}
+
+function buildMessages(
+  systemPrompt: string,
+  email: {
+    subject: string | null;
+    bodyText: string | null;
+    receivedAt: number;
+  },
+  person: { email: string; name: string | null },
+  thread: {
+    subject: string | null;
+    bodyText: string | null;
+    receivedAt: number;
+  }[],
+): { role: "system" | "user"; content: string }[] {
+  const threadSection =
+    thread.length > 0
+      ? `\n\n**Previous messages in thread (${thread.length} shown):**\n${thread
+          .map(
+            (t) =>
+              `[${new Date(t.receivedAt * 1000).toISOString()}] ${t.subject ?? "(no subject)"}: ${(t.bodyText ?? "").slice(0, 500)}`,
+          )
+          .join("\n---\n")}`
+      : "";
+
+  return [
+    { role: "system", content: systemPrompt },
+    {
+      role: "user",
+      content:
+        `You have received an email. Analyze it and provide the requested output.
+
+**Sender:** ${person.name ?? person.email} <${person.email}>
+**Subject:** ${email.subject ?? "(no subject)"}
+**Received:** ${new Date(email.receivedAt * 1000).toISOString()}
+
+**Email body:**
+${email.bodyText ?? "(no plain text body)"}${threadSection}
+
+Provide the output fields as specified.`.trim(),
+    },
+  ];
+}

--- a/worker/src/lib/dispatch-agents.ts
+++ b/worker/src/lib/dispatch-agents.ts
@@ -1,0 +1,263 @@
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, gt, isNull, or, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { schema } from "../db/schema";
+import { agentAssignments } from "../db/agent-assignments.schema";
+import { agentDefinitions } from "../db/agent-definitions.schema";
+import { agentRuns } from "../db/agent-runs.schema";
+import { emails } from "../db/emails.schema";
+import type { AgentRunMessage } from "./agent-processor";
+
+export interface EmailDispatchContext {
+  emailId: string;
+  personId: string;
+  mailbox: string;
+  autoSubmitted?: string | null;
+  hasListHeader: boolean;
+}
+
+type Db = ReturnType<typeof drizzle>;
+
+/**
+ * For a newly received email, find the best matching active assignment and
+ * either insert a skipped_* run or enqueue the run to AGENT_QUEUE.
+ * Designed to be called from ctx.waitUntil() in email-handler.ts.
+ */
+export async function dispatchAgentsForEmail(
+  ctx: EmailDispatchContext,
+  env: CloudflareBindings,
+): Promise<void> {
+  if (env.AGENTS_ENABLED === "false") return;
+
+  const db = drizzle(env.DB, { schema });
+  const now = Math.floor(Date.now() / 1000);
+
+  // Find the most-specific active assignment for this mailbox + person
+  const assignment = await findMatchingAssignment(
+    db,
+    ctx.mailbox,
+    ctx.personId,
+  );
+  if (!assignment) return;
+
+  // Check agent definition is active
+  if (!assignment.agentIsActive) {
+    await insertSkippedRun(
+      db,
+      assignment.id,
+      ctx.emailId,
+      ctx.personId,
+      "skipped_inactive",
+      now,
+    );
+    return;
+  }
+
+  // Mail-loop detection
+  const autoSubmitted = ctx.autoSubmitted;
+  if (autoSubmitted && autoSubmitted.toLowerCase() !== "no") {
+    await insertSkippedRun(
+      db,
+      assignment.id,
+      ctx.emailId,
+      ctx.personId,
+      "skipped_loop",
+      now,
+    );
+    return;
+  }
+  if (ctx.hasListHeader) {
+    await insertSkippedRun(
+      db,
+      assignment.id,
+      ctx.emailId,
+      ctx.personId,
+      "skipped_loop",
+      now,
+    );
+    return;
+  }
+
+  // Mode check: first_thread_reply — skip if person has sent email to this mailbox before
+  if (assignment.mode === "first_thread_reply") {
+    const priorEmails = await db
+      .select({ id: emails.id })
+      .from(emails)
+      .where(
+        and(
+          eq(emails.personId, ctx.personId),
+          eq(emails.recipient, ctx.mailbox),
+        ),
+      )
+      .limit(2);
+
+    // More than 1 means this is not the first email
+    if (priorEmails.length > 1) {
+      await insertSkippedRun(
+        db,
+        assignment.id,
+        ctx.emailId,
+        ctx.personId,
+        "skipped_mode",
+        now,
+      );
+      return;
+    }
+  }
+
+  // Rate limit: count non-skipped runs in the last hour for this (assignment, person)
+  const oneHourAgo = now - 3600;
+  const recentRuns = await db
+    .select({ id: agentRuns.id, status: agentRuns.status })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.assignmentId, assignment.id),
+        eq(agentRuns.personId, ctx.personId),
+        gt(agentRuns.createdAt, oneHourAgo),
+      ),
+    );
+
+  const nonSkippedCount = recentRuns.filter(
+    (r) => !r.status.startsWith("skipped_"),
+  ).length;
+  if (nonSkippedCount >= assignment.maxRunsPerHour) {
+    await insertSkippedRun(
+      db,
+      assignment.id,
+      ctx.emailId,
+      ctx.personId,
+      "skipped_rate_limit",
+      now,
+    );
+    return;
+  }
+
+  // All checks passed — insert queued run and push to AGENT_QUEUE
+  const runId = nanoid();
+  await db.insert(agentRuns).values({
+    id: runId,
+    assignmentId: assignment.id,
+    emailId: ctx.emailId,
+    personId: ctx.personId,
+    status: "queued",
+    action: null,
+    sentEmailId: null,
+    draftId: null,
+    modelId: null,
+    inputTokens: null,
+    outputTokens: null,
+    errorMessage: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const message: AgentRunMessage = {
+    runId,
+    assignmentId: assignment.id,
+    emailId: ctx.emailId,
+  };
+  await env.AGENT_QUEUE.send(message);
+}
+
+// ── Internals ──────────────────────────────────────────────────────────────
+
+interface MatchedAssignment {
+  id: string;
+  agentId: string;
+  mode: string;
+  templateSlug: string;
+  mailbox: string | null;
+  personId: string | null;
+  maxRunsPerHour: number;
+  agentIsActive: boolean;
+}
+
+/**
+ * Return the most specific active assignment matching the given mailbox+personId.
+ * Priority: (mailbox+person) > (mailbox+*) > (*+person) > (*+*)
+ */
+async function findMatchingAssignment(
+  db: Db,
+  mailbox: string,
+  personId: string,
+): Promise<MatchedAssignment | null> {
+  const rows = await db
+    .select({
+      id: agentAssignments.id,
+      agentId: agentAssignments.agentId,
+      mode: agentAssignments.mode,
+      templateSlug: agentAssignments.templateSlug,
+      mailbox: agentAssignments.mailbox,
+      personId: agentAssignments.personId,
+      maxRunsPerHour: agentDefinitions.maxRunsPerHour,
+      agentIsActive: agentDefinitions.isActive,
+    })
+    .from(agentAssignments)
+    .innerJoin(
+      agentDefinitions,
+      eq(agentAssignments.agentId, agentDefinitions.id),
+    )
+    .where(
+      and(
+        eq(agentAssignments.isActive, 1),
+        or(
+          and(
+            eq(agentAssignments.mailbox, mailbox),
+            eq(agentAssignments.personId, personId),
+          ),
+          and(
+            eq(agentAssignments.mailbox, mailbox),
+            isNull(agentAssignments.personId),
+          ),
+          and(
+            isNull(agentAssignments.mailbox),
+            eq(agentAssignments.personId, personId),
+          ),
+          and(
+            isNull(agentAssignments.mailbox),
+            isNull(agentAssignments.personId),
+          ),
+        ),
+      ),
+    );
+
+  if (rows.length === 0) return null;
+
+  // Sort by specificity (highest score = most specific)
+  const specificity = (r: (typeof rows)[0]) =>
+    (r.mailbox !== null ? 2 : 0) + (r.personId !== null ? 1 : 0);
+  rows.sort((a, b) => specificity(b) - specificity(a));
+
+  const r = rows[0];
+  return {
+    ...r,
+    agentIsActive: !!r.agentIsActive,
+  };
+}
+
+async function insertSkippedRun(
+  db: Db,
+  assignmentId: string,
+  emailId: string,
+  personId: string,
+  status: string,
+  now: number,
+): Promise<void> {
+  await db.insert(agentRuns).values({
+    id: nanoid(),
+    assignmentId,
+    emailId,
+    personId,
+    status,
+    action: null,
+    sentEmailId: null,
+    draftId: null,
+    modelId: null,
+    inputTokens: null,
+    outputTokens: null,
+    errorMessage: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}

--- a/worker/src/routers/agent-assignments-router.ts
+++ b/worker/src/routers/agent-assignments-router.ts
@@ -1,0 +1,400 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { and, desc, eq, isNull, or } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { agentAssignments } from "../db/agent-assignments.schema";
+import { agentDefinitions } from "../db/agent-definitions.schema";
+import { emailTemplates } from "../db/email-templates.schema";
+import { extractVariables } from "../lib/interpolate";
+import { json200Response, json201Response } from "../lib/helpers";
+import {
+  agentAssignmentResponse,
+  agentModeEnum,
+  jsonSchemaToFields,
+} from "./agents-schemas";
+import type { Variables } from "../variables";
+
+export const agentAssignmentsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+function rowToResponse(
+  row: typeof agentAssignments.$inferSelect & {
+    agentName: string | null;
+    templateName: string | null;
+  },
+) {
+  return {
+    ...row,
+    isActive: !!row.isActive,
+    agentName: row.agentName ?? "",
+    templateName: row.templateName ?? "",
+  };
+}
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Agent Assignments"],
+  description: "List agent assignments. Filter by agentId via query param.",
+  request: {
+    query: z.object({ agentId: z.string().optional() }),
+  },
+  responses: {
+    ...json200Response(z.array(agentAssignmentResponse), "Agent assignments"),
+  },
+});
+
+agentAssignmentsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const { agentId } = c.req.valid("query");
+
+  const rows = await db
+    .select({
+      id: agentAssignments.id,
+      agentId: agentAssignments.agentId,
+      mailbox: agentAssignments.mailbox,
+      personId: agentAssignments.personId,
+      templateSlug: agentAssignments.templateSlug,
+      mode: agentAssignments.mode,
+      isActive: agentAssignments.isActive,
+      createdAt: agentAssignments.createdAt,
+      updatedAt: agentAssignments.updatedAt,
+      agentName: agentDefinitions.name,
+      templateName: emailTemplates.name,
+    })
+    .from(agentAssignments)
+    .leftJoin(
+      agentDefinitions,
+      eq(agentAssignments.agentId, agentDefinitions.id),
+    )
+    .leftJoin(
+      emailTemplates,
+      eq(agentAssignments.templateSlug, emailTemplates.slug),
+    )
+    .where(agentId ? eq(agentAssignments.agentId, agentId) : undefined)
+    .orderBy(desc(agentAssignments.createdAt));
+
+  return c.json(rows.map(rowToResponse), 200);
+});
+
+const createRoute_ = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Agent Assignments"],
+  description: "Create an agent assignment.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            agentId: z.string(),
+            mailbox: z.string().email().nullable().optional(),
+            personId: z.string().nullable().optional(),
+            templateSlug: z.string().min(1),
+            mode: agentModeEnum,
+            isActive: z.boolean().default(true),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json201Response(agentAssignmentResponse, "Created assignment"),
+    422: {
+      description: "Template uses variables not in agent outputSchema",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.string(), missing: z.array(z.string()) }),
+        },
+      },
+    },
+    409: {
+      description: "Scope conflict",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.string(), existingId: z.string() }),
+        },
+      },
+    },
+  },
+});
+
+agentAssignmentsRouter.openapi(createRoute_, async (c) => {
+  const db = c.get("db");
+  const { agentId, mailbox, personId, templateSlug, mode, isActive } =
+    c.req.valid("json");
+
+  // Load agent definition
+  const [agentDef] = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, agentId))
+    .limit(1);
+  if (!agentDef) return c.json({ error: "Agent definition not found" }, 404);
+
+  // Load template
+  const [template] = await db
+    .select()
+    .from(emailTemplates)
+    .where(eq(emailTemplates.slug, templateSlug))
+    .limit(1);
+  if (!template) return c.json({ error: "Template not found" }, 404);
+
+  // Validate template vars are a subset of outputSchema keys
+  const schemaFields = jsonSchemaToFields(agentDef.outputSchemaJson);
+  const schemaKeys = new Set(schemaFields.map((f) => f.name));
+  const templateVars = [
+    ...extractVariables(template.subject),
+    ...extractVariables(template.bodyHtml),
+  ];
+  const missing = templateVars.filter((v) => !schemaKeys.has(v));
+  if (missing.length > 0) {
+    return c.json(
+      {
+        error: `Template uses variables not in agent outputSchema: ${missing.join(", ")}`,
+        missing,
+      },
+      422,
+    );
+  }
+
+  // Scope uniqueness check (application-level — SQLite NULLs can't use UNIQUE)
+  const resolvedMailbox = mailbox ?? null;
+  const resolvedPersonId = personId ?? null;
+
+  const existing = await db
+    .select({ id: agentAssignments.id })
+    .from(agentAssignments)
+    .where(
+      and(
+        eq(agentAssignments.isActive, 1),
+        resolvedMailbox !== null
+          ? eq(agentAssignments.mailbox, resolvedMailbox)
+          : isNull(agentAssignments.mailbox),
+        resolvedPersonId !== null
+          ? eq(agentAssignments.personId, resolvedPersonId)
+          : isNull(agentAssignments.personId),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return c.json(
+      {
+        error: "An active assignment already exists for this scope",
+        existingId: existing[0].id,
+      },
+      409,
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const row = {
+    id: nanoid(),
+    agentId,
+    mailbox: resolvedMailbox,
+    personId: resolvedPersonId,
+    templateSlug,
+    mode,
+    isActive: isActive ? 1 : 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(agentAssignments).values(row);
+
+  return c.json(
+    {
+      ...row,
+      isActive: !!row.isActive,
+      agentName: agentDef.name,
+      templateName: template.name,
+    },
+    201,
+  );
+});
+
+const getRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Agent Assignments"],
+  description: "Get an assignment by ID.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(agentAssignmentResponse, "Assignment"),
+  },
+});
+
+agentAssignmentsRouter.openapi(getRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+
+  const rows = await db
+    .select({
+      id: agentAssignments.id,
+      agentId: agentAssignments.agentId,
+      mailbox: agentAssignments.mailbox,
+      personId: agentAssignments.personId,
+      templateSlug: agentAssignments.templateSlug,
+      mode: agentAssignments.mode,
+      isActive: agentAssignments.isActive,
+      createdAt: agentAssignments.createdAt,
+      updatedAt: agentAssignments.updatedAt,
+      agentName: agentDefinitions.name,
+      templateName: emailTemplates.name,
+    })
+    .from(agentAssignments)
+    .leftJoin(
+      agentDefinitions,
+      eq(agentAssignments.agentId, agentDefinitions.id),
+    )
+    .leftJoin(
+      emailTemplates,
+      eq(agentAssignments.templateSlug, emailTemplates.slug),
+    )
+    .where(eq(agentAssignments.id, id))
+    .limit(1);
+
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  return c.json(rowToResponse(rows[0]), 200);
+});
+
+const updateRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  tags: ["Agent Assignments"],
+  description: "Update an assignment.",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            templateSlug: z.string().optional(),
+            mode: agentModeEnum.optional(),
+            isActive: z.boolean().optional(),
+            mailbox: z.string().email().nullable().optional(),
+            personId: z.string().nullable().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json200Response(agentAssignmentResponse, "Updated assignment"),
+  },
+});
+
+agentAssignmentsRouter.openapi(updateRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const updates = c.req.valid("json");
+  const now = Math.floor(Date.now() / 1000);
+
+  const [existing] = await db
+    .select()
+    .from(agentAssignments)
+    .where(eq(agentAssignments.id, id))
+    .limit(1);
+  if (!existing) return c.json({ error: "Not found" }, 404);
+
+  // If templateSlug is changing, re-validate template vars
+  if (updates.templateSlug) {
+    const [agentDef] = await db
+      .select()
+      .from(agentDefinitions)
+      .where(eq(agentDefinitions.id, existing.agentId))
+      .limit(1);
+    const [template] = await db
+      .select()
+      .from(emailTemplates)
+      .where(eq(emailTemplates.slug, updates.templateSlug))
+      .limit(1);
+    if (!template) return c.json({ error: "Template not found" }, 404);
+    if (agentDef) {
+      const schemaKeys = new Set(
+        jsonSchemaToFields(agentDef.outputSchemaJson).map((f) => f.name),
+      );
+      const templateVars = [
+        ...extractVariables(template.subject),
+        ...extractVariables(template.bodyHtml),
+      ];
+      const missing = templateVars.filter((v) => !schemaKeys.has(v));
+      if (missing.length > 0) {
+        return c.json(
+          {
+            error: `Template uses variables not in agent outputSchema: ${missing.join(", ")}`,
+            missing,
+          },
+          422,
+        );
+      }
+    }
+  }
+
+  const dbUpdates: Record<string, unknown> = { updatedAt: now };
+  if (updates.templateSlug !== undefined)
+    dbUpdates.templateSlug = updates.templateSlug;
+  if (updates.mode !== undefined) dbUpdates.mode = updates.mode;
+  if (updates.isActive !== undefined)
+    dbUpdates.isActive = updates.isActive ? 1 : 0;
+  if (updates.mailbox !== undefined) dbUpdates.mailbox = updates.mailbox;
+  if (updates.personId !== undefined) dbUpdates.personId = updates.personId;
+
+  await db
+    .update(agentAssignments)
+    .set(dbUpdates)
+    .where(eq(agentAssignments.id, id));
+
+  const rows = await db
+    .select({
+      id: agentAssignments.id,
+      agentId: agentAssignments.agentId,
+      mailbox: agentAssignments.mailbox,
+      personId: agentAssignments.personId,
+      templateSlug: agentAssignments.templateSlug,
+      mode: agentAssignments.mode,
+      isActive: agentAssignments.isActive,
+      createdAt: agentAssignments.createdAt,
+      updatedAt: agentAssignments.updatedAt,
+      agentName: agentDefinitions.name,
+      templateName: emailTemplates.name,
+    })
+    .from(agentAssignments)
+    .leftJoin(
+      agentDefinitions,
+      eq(agentAssignments.agentId, agentDefinitions.id),
+    )
+    .leftJoin(
+      emailTemplates,
+      eq(agentAssignments.templateSlug, emailTemplates.slug),
+    )
+    .where(eq(agentAssignments.id, id))
+    .limit(1);
+
+  return c.json(rowToResponse(rows[0]), 200);
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Agent Assignments"],
+  description: "Delete an assignment.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(z.object({ success: z.boolean() }), "Deleted"),
+  },
+});
+
+agentAssignmentsRouter.openapi(deleteRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const [existing] = await db
+    .select()
+    .from(agentAssignments)
+    .where(eq(agentAssignments.id, id))
+    .limit(1);
+  if (!existing) return c.json({ error: "Not found" }, 404);
+  await db.delete(agentAssignments).where(eq(agentAssignments.id, id));
+  return c.json({ success: true }, 200);
+});

--- a/worker/src/routers/agent-definitions-router.ts
+++ b/worker/src/routers/agent-definitions-router.ts
@@ -1,0 +1,245 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { agentDefinitions } from "../db/agent-definitions.schema";
+import { agentAssignments } from "../db/agent-assignments.schema";
+import { json200Response, json201Response } from "../lib/helpers";
+import {
+  agentDefinitionResponse,
+  outputFieldSchema,
+  fieldsToJsonSchema,
+  jsonSchemaToFields,
+} from "./agents-schemas";
+import type { Variables } from "../variables";
+
+export const agentDefinitionsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const createRoute_ = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Agents"],
+  description: "Create an agent definition.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            name: z.string().min(1).max(100),
+            description: z.string().optional(),
+            modelId: z
+              .string()
+              .min(1)
+              .default("@cf/meta/llama-3.3-70b-instruct"),
+            systemPrompt: z.string().min(1),
+            outputFields: z.array(outputFieldSchema).min(1),
+            maxRunsPerHour: z.number().int().min(1).max(100).default(10),
+            isActive: z.boolean().default(true),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json201Response(agentDefinitionResponse, "Created agent definition"),
+  },
+});
+
+agentDefinitionsRouter.openapi(createRoute_, async (c) => {
+  const db = c.get("db");
+  const {
+    name,
+    description,
+    modelId,
+    systemPrompt,
+    outputFields,
+    maxRunsPerHour,
+    isActive,
+  } = c.req.valid("json");
+  const now = Math.floor(Date.now() / 1000);
+  const row = {
+    id: nanoid(),
+    name,
+    description: description ?? null,
+    modelId,
+    systemPrompt,
+    outputSchemaJson: fieldsToJsonSchema(outputFields),
+    maxRunsPerHour,
+    isActive: isActive ? 1 : 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(agentDefinitions).values(row);
+  return c.json({ ...row, outputFields, isActive: !!row.isActive }, 201);
+});
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Agents"],
+  description: "List all agent definitions.",
+  responses: {
+    ...json200Response(z.array(agentDefinitionResponse), "Agent definitions"),
+  },
+});
+
+agentDefinitionsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const rows = await db.select().from(agentDefinitions);
+  return c.json(
+    rows.map((r) => ({
+      ...r,
+      outputFields: jsonSchemaToFields(r.outputSchemaJson),
+      isActive: !!r.isActive,
+    })),
+    200,
+  );
+});
+
+const getRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Agents"],
+  description: "Get an agent definition by ID.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(agentDefinitionResponse, "Agent definition"),
+  },
+});
+
+agentDefinitionsRouter.openapi(getRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const rows = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, id))
+    .limit(1);
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  const r = rows[0];
+  return c.json(
+    {
+      ...r,
+      outputFields: jsonSchemaToFields(r.outputSchemaJson),
+      isActive: !!r.isActive,
+    },
+    200,
+  );
+});
+
+const updateRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  tags: ["Agents"],
+  description: "Update an agent definition.",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            name: z.string().min(1).max(100).optional(),
+            description: z.string().nullable().optional(),
+            modelId: z.string().min(1).optional(),
+            systemPrompt: z.string().min(1).optional(),
+            outputFields: z.array(outputFieldSchema).min(1).optional(),
+            maxRunsPerHour: z.number().int().min(1).max(100).optional(),
+            isActive: z.boolean().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json200Response(agentDefinitionResponse, "Updated agent definition"),
+  },
+});
+
+agentDefinitionsRouter.openapi(updateRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const updates = c.req.valid("json");
+  const now = Math.floor(Date.now() / 1000);
+
+  const existing = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, id))
+    .limit(1);
+  if (existing.length === 0) return c.json({ error: "Not found" }, 404);
+
+  const dbUpdates: Record<string, unknown> = { updatedAt: now };
+  if (updates.name !== undefined) dbUpdates.name = updates.name;
+  if (updates.description !== undefined)
+    dbUpdates.description = updates.description;
+  if (updates.modelId !== undefined) dbUpdates.modelId = updates.modelId;
+  if (updates.systemPrompt !== undefined)
+    dbUpdates.systemPrompt = updates.systemPrompt;
+  if (updates.outputFields !== undefined)
+    dbUpdates.outputSchemaJson = fieldsToJsonSchema(updates.outputFields);
+  if (updates.maxRunsPerHour !== undefined)
+    dbUpdates.maxRunsPerHour = updates.maxRunsPerHour;
+  if (updates.isActive !== undefined)
+    dbUpdates.isActive = updates.isActive ? 1 : 0;
+
+  await db
+    .update(agentDefinitions)
+    .set(dbUpdates)
+    .where(eq(agentDefinitions.id, id));
+
+  const updated = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, id))
+    .limit(1);
+  const r = updated[0];
+  return c.json(
+    {
+      ...r,
+      outputFields: jsonSchemaToFields(r.outputSchemaJson),
+      isActive: !!r.isActive,
+    },
+    200,
+  );
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Agents"],
+  description: "Delete an agent definition. Fails if active assignments exist.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(z.object({ success: z.boolean() }), "Deleted"),
+  },
+});
+
+agentDefinitionsRouter.openapi(deleteRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+
+  const existing = await db
+    .select()
+    .from(agentDefinitions)
+    .where(eq(agentDefinitions.id, id))
+    .limit(1);
+  if (existing.length === 0) return c.json({ error: "Not found" }, 404);
+
+  const activeAssignments = await db
+    .select({ id: agentAssignments.id })
+    .from(agentAssignments)
+    .where(eq(agentAssignments.agentId, id))
+    .limit(1);
+
+  if (activeAssignments.length > 0) {
+    return c.json(
+      { error: "Delete or deactivate all assignments for this agent first" },
+      409,
+    );
+  }
+
+  await db.delete(agentDefinitions).where(eq(agentDefinitions.id, id));
+  return c.json({ success: true }, 200);
+});

--- a/worker/src/routers/agent-runs-router.ts
+++ b/worker/src/routers/agent-runs-router.ts
@@ -1,0 +1,114 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { agentRuns } from "../db/agent-runs.schema";
+import { json200Response } from "../lib/helpers";
+import { agentRunResponse } from "./agents-schemas";
+import type { Variables } from "../variables";
+
+export const agentRunsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Agent Runs"],
+  description: "List agent runs with optional filters.",
+  request: {
+    query: z.object({
+      assignmentId: z.string().optional(),
+      personId: z.string().optional(),
+      status: z.string().optional(),
+      limit: z.coerce.number().int().min(1).max(100).default(50),
+      offset: z.coerce.number().int().min(0).default(0),
+    }),
+  },
+  responses: {
+    ...json200Response(
+      z.object({ runs: z.array(agentRunResponse), total: z.number() }),
+      "Paginated agent runs",
+    ),
+  },
+});
+
+agentRunsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const { assignmentId, personId, status, limit, offset } =
+    c.req.valid("query");
+
+  const conditions = [
+    assignmentId ? eq(agentRuns.assignmentId, assignmentId) : undefined,
+    personId ? eq(agentRuns.personId, personId) : undefined,
+    status ? eq(agentRuns.status, status) : undefined,
+  ].filter(Boolean) as ReturnType<typeof eq>[];
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [rows, countRows] = await Promise.all([
+    db
+      .select()
+      .from(agentRuns)
+      .where(whereClause)
+      .orderBy(desc(agentRuns.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(agentRuns)
+      .where(whereClause),
+  ]);
+
+  return c.json(
+    {
+      runs: rows.map((r) => ({
+        ...r,
+        action: r.action ?? null,
+        sentEmailId: r.sentEmailId ?? null,
+        draftId: r.draftId ?? null,
+        modelId: r.modelId ?? null,
+        inputTokens: r.inputTokens ?? null,
+        outputTokens: r.outputTokens ?? null,
+        errorMessage: r.errorMessage ?? null,
+      })),
+      total: countRows[0]?.count ?? 0,
+    },
+    200,
+  );
+});
+
+const getRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Agent Runs"],
+  description: "Get a single agent run.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(agentRunResponse, "Agent run"),
+  },
+});
+
+agentRunsRouter.openapi(getRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const rows = await db
+    .select()
+    .from(agentRuns)
+    .where(eq(agentRuns.id, id))
+    .limit(1);
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  const r = rows[0];
+  return c.json(
+    {
+      ...r,
+      action: r.action ?? null,
+      sentEmailId: r.sentEmailId ?? null,
+      draftId: r.draftId ?? null,
+      modelId: r.modelId ?? null,
+      inputTokens: r.inputTokens ?? null,
+      outputTokens: r.outputTokens ?? null,
+      errorMessage: r.errorMessage ?? null,
+    },
+    200,
+  );
+});

--- a/worker/src/routers/agents-schemas.ts
+++ b/worker/src/routers/agents-schemas.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+
+// ── Enums ─────────────────────────────────────────────────────────────────
+
+export const agentModeEnum = z.enum([
+  "first_thread_reply",
+  "every_mail_reply",
+  "draft_only",
+]);
+
+// ── Output field shape ─────────────────────────────────────────────────────
+
+export const outputFieldSchema = z.object({
+  name: z
+    .string()
+    .regex(/^\w+$/, "Field names must be alphanumeric/underscore"),
+  description: z.string().min(1),
+});
+
+export type OutputField = z.infer<typeof outputFieldSchema>;
+
+// ── Response shapes ────────────────────────────────────────────────────────
+
+export const agentDefinitionResponse = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  modelId: z.string(),
+  systemPrompt: z.string(),
+  outputFields: z.array(outputFieldSchema),
+  maxRunsPerHour: z.number(),
+  isActive: z.boolean(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const agentAssignmentResponse = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  mailbox: z.string().nullable(),
+  personId: z.string().nullable(),
+  templateSlug: z.string(),
+  mode: agentModeEnum,
+  isActive: z.boolean(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  agentName: z.string(),
+  templateName: z.string(),
+});
+
+export const agentRunResponse = z.object({
+  id: z.string(),
+  assignmentId: z.string(),
+  emailId: z.string(),
+  personId: z.string(),
+  status: z.string(),
+  action: z.string().nullable(),
+  sentEmailId: z.string().nullable(),
+  draftId: z.string().nullable(),
+  modelId: z.string().nullable(),
+  inputTokens: z.number().nullable(),
+  outputTokens: z.number().nullable(),
+  errorMessage: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const draftResponse = z.object({
+  id: z.string(),
+  personId: z.string(),
+  agentRunId: z.string(),
+  fromAddress: z.string(),
+  toAddress: z.string(),
+  subject: z.string(),
+  bodyHtml: z.string().nullable(),
+  inReplyTo: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+// ── Utility: JSON Schema ↔ outputFields conversion ─────────────────────────
+
+export type OutputSchemaJson = {
+  type: "object";
+  properties: Record<string, { type: string; description?: string }>;
+  required: string[];
+};
+
+/**
+ * Convert an array of output fields into a stored JSON Schema string.
+ * All fields are typed as "string" (v1 constraint).
+ */
+export function fieldsToJsonSchema(fields: OutputField[]): string {
+  const properties: Record<string, { type: string; description: string }> = {};
+  for (const f of fields) {
+    properties[f.name] = { type: "string", description: f.description };
+  }
+  return JSON.stringify({
+    type: "object",
+    properties,
+    required: fields.map((f) => f.name),
+  });
+}
+
+/**
+ * Parse a stored JSON Schema string back into an array of output fields.
+ */
+export function jsonSchemaToFields(raw: string): OutputField[] {
+  try {
+    const schema = JSON.parse(raw) as OutputSchemaJson;
+    return Object.entries(schema.properties ?? {}).map(([name, def]) => ({
+      name,
+      description: def.description ?? "",
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/worker/src/routers/drafts-router.ts
+++ b/worker/src/routers/drafts-router.ts
@@ -1,0 +1,158 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { desc, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { drafts } from "../db/drafts.schema";
+import { agentRuns } from "../db/agent-runs.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { createEmailSender } from "../lib/email-sender";
+import { generateMessageId } from "../lib/message-id";
+import { formatFromAddress } from "../lib/format-from-address";
+import { json200Response } from "../lib/helpers";
+import { draftResponse } from "./agents-schemas";
+import type { Variables } from "../variables";
+
+export const draftsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Drafts"],
+  description: "List pending agent drafts.",
+  request: {
+    query: z.object({ personId: z.string().optional() }),
+  },
+  responses: {
+    ...json200Response(z.array(draftResponse), "Draft list"),
+  },
+});
+
+draftsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const { personId } = c.req.valid("query");
+  const rows = await db
+    .select()
+    .from(drafts)
+    .where(personId ? eq(drafts.personId, personId) : undefined)
+    .orderBy(desc(drafts.createdAt));
+  return c.json(
+    rows.map((r) => ({
+      ...r,
+      bodyHtml: r.bodyHtml ?? null,
+      inReplyTo: r.inReplyTo ?? null,
+    })),
+    200,
+  );
+});
+
+const getRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Drafts"],
+  description: "Get a draft by ID.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(draftResponse, "Draft"),
+  },
+});
+
+draftsRouter.openapi(getRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const rows = await db.select().from(drafts).where(eq(drafts.id, id)).limit(1);
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  const r = rows[0];
+  return c.json(
+    { ...r, bodyHtml: r.bodyHtml ?? null, inReplyTo: r.inReplyTo ?? null },
+    200,
+  );
+});
+
+const sendRoute = createRoute({
+  method: "post",
+  path: "/{id}/send",
+  tags: ["Drafts"],
+  description: "Promote a draft to a sent email.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(z.object({ sentEmailId: z.string() }), "Sent"),
+  },
+});
+
+draftsRouter.openapi(sendRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+
+  const rows = await db.select().from(drafts).where(eq(drafts.id, id)).limit(1);
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  const draft = rows[0];
+
+  const sender = createEmailSender(c.env);
+  const messageId = generateMessageId(draft.fromAddress);
+  const formattedFrom = await formatFromAddress(db, draft.fromAddress);
+
+  const result = await sender.send({
+    from: formattedFrom,
+    to: draft.toAddress,
+    subject: draft.subject,
+    html: draft.bodyHtml ?? "",
+    headers: {
+      "Message-ID": messageId,
+      "Auto-Submitted": "auto-replied",
+      ...(draft.inReplyTo ? { "In-Reply-To": draft.inReplyTo } : {}),
+    },
+  });
+
+  if (result.error) {
+    return c.json({ error: `Send failed: ${result.error}` }, 500);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const sentId = nanoid();
+  await db.insert(sentEmails).values({
+    id: sentId,
+    personId: draft.personId,
+    fromAddress: draft.fromAddress,
+    toAddress: draft.toAddress,
+    subject: draft.subject,
+    bodyHtml: draft.bodyHtml,
+    bodyText: null,
+    inReplyTo: draft.inReplyTo,
+    messageId,
+    resendId: result.id,
+    status: "sent",
+    sentAt: now,
+    createdAt: now,
+  });
+
+  await db
+    .update(agentRuns)
+    .set({ action: "sent", sentEmailId: sentId, draftId: null, updatedAt: now })
+    .where(eq(agentRuns.id, draft.agentRunId));
+
+  await db.delete(drafts).where(eq(drafts.id, id));
+
+  return c.json({ sentEmailId: sentId }, 200);
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Drafts"],
+  description: "Discard a draft.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(z.object({ success: z.boolean() }), "Deleted"),
+  },
+});
+
+draftsRouter.openapi(deleteRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const rows = await db.select().from(drafts).where(eq(drafts.id, id)).limit(1);
+  if (rows.length === 0) return c.json({ error: "Not found" }, 404);
+  await db.delete(drafts).where(eq(drafts.id, id));
+  return c.json({ success: true }, 200);
+});

--- a/wrangler.jsonc.ci
+++ b/wrangler.jsonc.ci
@@ -36,6 +36,10 @@
       {
         "binding": "EMAIL_QUEUE",
         "queue": "saasmail-sequence-emails"
+      },
+      {
+        "binding": "AGENT_QUEUE",
+        "queue": "saasmail-agent-runs"
       }
     ],
     "consumers": [
@@ -43,6 +47,11 @@
         "queue": "saasmail-sequence-emails",
         "max_batch_size": 10,
         "max_retries": 3
+      },
+      {
+        "queue": "saasmail-agent-runs",
+        "max_batch_size": 5,
+        "max_retries": 2
       }
     ]
   },

--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -32,6 +32,11 @@
   // "send_email": [
   //   { "name": "EMAIL" }
   // ],
+  // Workers AI binding — gives access to Cloudflare-hosted models.
+  // No API keys needed; usage is billed to your CF account.
+  "ai": {
+    "binding": "AI"
+  },
   "assets": {
     "directory": "./dist/client",
     "binding": "ASSETS",
@@ -49,6 +54,10 @@
       {
         "binding": "EMAIL_QUEUE",
         "queue": "saasmail-sequence-emails"
+      },
+      {
+        "binding": "AGENT_QUEUE",
+        "queue": "saasmail-agent-runs"
       }
     ],
     "consumers": [
@@ -56,6 +65,11 @@
         "queue": "saasmail-sequence-emails",
         "max_batch_size": 10,
         "max_retries": 3
+      },
+      {
+        "queue": "saasmail-agent-runs",
+        "max_batch_size": 5,
+        "max_retries": 2
       }
     ]
   },
@@ -93,7 +107,13 @@
     // VAPID_PUBLIC_KEY and VAPID_SUBJECT are public config (safe to commit here).
     // Generate all three with `yarn vapid:generate`. Leave blank to disable push.
     "VAPID_PUBLIC_KEY": "",
-    "VAPID_SUBJECT": "mailto:admin@<your-domain>"
+    "VAPID_SUBJECT": "mailto:admin@<your-domain>",
+    // AI Gateway slug — create at dash.cloudflare.com → AI → AI Gateway.
+    // All agent LLM calls route through here for logging and caching.
+    // Leave blank to bypass the gateway.
+    "AI_GATEWAY_SLUG": "",
+    // Set to "false" to disable all agent processing globally.
+    // "AGENTS_ENABLED": "true"
     // DO NOT set DISABLE_PASSKEY_GATE in production. It's intended for local
     // dev only (see .dev.vars.example) and turns off the server-side passkey
     // requirement for /api/* when set to "true".

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,31 @@
 # yarn lockfile v1
 
 
+"@ai-sdk/gateway@3.0.104":
+  version "3.0.104"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.104.tgz#3ad45f88907f385544d416397a33e82f1efd0758"
+  integrity sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==
+  dependencies:
+    "@ai-sdk/provider" "3.0.8"
+    "@ai-sdk/provider-utils" "4.0.23"
+    "@vercel/oidc" "3.2.0"
+
+"@ai-sdk/provider-utils@4.0.23":
+  version "4.0.23"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz#fa0e89d6756816d8a0015f556e0b20df6df14dfa"
+  integrity sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.8"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.6"
+
+"@ai-sdk/provider@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.8.tgz#fd7fac7533c03534ac1d3fb710a6b96e2aa00263"
+  integrity sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==
+  dependencies:
+    json-schema "^0.4.0"
+
 "@asteasolutions/zod-to-openapi@7.3.0":
   version "7.3.0"
   resolved "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.0.tgz"
@@ -1129,6 +1154,11 @@
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz"
   integrity sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==
 
+"@opentelemetry/api@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
 "@opentelemetry/api@^1.9.1":
   version "1.9.1"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz"
@@ -2248,6 +2278,11 @@
   resolved "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz"
   integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
+"@vercel/oidc@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.2.0.tgz#5782a4d4904443f015808705b5537cf9c3b68528"
+  integrity sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==
+
 "@vitejs/plugin-react-swc@^3.9.0":
   version "3.11.0"
   resolved "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz"
@@ -2315,6 +2350,16 @@
     "@vitest/pretty-format" "4.1.5"
     convert-source-map "^2.0.0"
     tinyrainbow "^3.1.0"
+
+ai@^6.0.168:
+  version "6.0.168"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.168.tgz#314a8622481c3dbceaef4d911a1c132df59dc1ef"
+  integrity sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==
+  dependencies:
+    "@ai-sdk/gateway" "3.0.104"
+    "@ai-sdk/provider" "3.0.8"
+    "@ai-sdk/provider-utils" "4.0.23"
+    "@opentelemetry/api" "1.9.0"
 
 ansi-escapes@^7.0.0:
   version "7.3.0"
@@ -2725,6 +2770,11 @@ eventemitter3@^5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
   integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
+eventsource-parser@^3.0.6:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
+
 expect-type@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz"
@@ -2818,6 +2868,11 @@ js-base64@^3.7.7:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 kleur@^4.1.5:
   version "4.1.5"
@@ -3690,6 +3745,11 @@ workerd@1.20260421.1:
     "@cloudflare/workerd-linux-64" "1.20260421.1"
     "@cloudflare/workerd-linux-arm64" "1.20260421.1"
     "@cloudflare/workerd-windows-64" "1.20260421.1"
+
+workers-ai-provider@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/workers-ai-provider/-/workers-ai-provider-3.1.12.tgz#d78965724e5e4dce95c8689364641e54e41ecaf1"
+  integrity sha512-L11DDxFtMb1o1pB1FEh/zEahp7imnh3zCA/0YJLnbd1ezYfPydCCcZbsun8MyeKmFXZP54syUfD9FiBt0ijRSQ==
 
 wrangler@4.84.1, wrangler@^4.84.1:
   version "4.84.1"


### PR DESCRIPTION
Adds an end-to-end AI agents pipeline powered by Cloudflare Workers AI and AI Gateway. Inbound emails trigger a queue-based agent run that classifies intent, generates structured output, and creates a draft reply for human review before sending.

Backend
- 4 new DB tables: agent_definitions, agent_assignments, agent_runs, drafts
- Migration 0020 with FK indexes
- Full CRUD routers for definitions/assignments; read-only runs; draft send/discard
- agent-processor.ts: queue consumer using workers-ai-provider + generateObject
- dispatch-agents.ts: scope-matched assignment lookup, mail-loop guard, rate limit
- index.ts wired for saasmail-agent-runs queue

Frontend
- AgentsPage, AgentEditorPage, AgentDetailPage, AgentRunsPage, DraftsPage
- Sidebar nav entries for Agents and Drafts

Infrastructure
- wrangler.jsonc.example: AI binding, AGENT_QUEUE, AI_GATEWAY_SLUG var
- wrangler.jsonc.ci: AGENT_QUEUE added for CI/local test runs
- worker-configuration.d.ts: AI, AGENT_QUEUE, AI_GATEWAY_SLUG, AGENTS_ENABLED

Demo seed
- Support Intent Classifier agent seeded in demo.sql
- Classifies 3 intents (missing email / network issue / discount inquiry) and outputs one of 3 verbatim reply phrases via draft mode

## Summary

<!-- One or two sentences on what this PR changes and why. Link any related issue. -->

## Changes

<!-- Bulleted list of user-visible or reviewer-visible changes. -->

-

## Test plan

<!-- How did you verify this works? Include commands run and/or scenarios exercised. -->

- [ ] `yarn tsc --noEmit`
- [ ] `yarn test`
- [ ] `yarn test:e2e` (if the change touches UI or API surface)
- [ ] Manual verification:

## Notes for reviewers

<!-- Anything non-obvious: migrations, config changes, follow-ups, known gaps. -->

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed
- [ ] Updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [ ] Updated docs (`README.md`, `docs/`) if behavior or setup changed
