### PR TITLE
chore: release v0.2.1 — web-push aes128gcm decryption fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-25
+
+### Fixed
+
+- Web push notifications now successfully decrypt in Chrome and other browsers: `deriveAes128GcmKeys` was appending a redundant `0x01` counter byte to the HKDF info before calling `hkdfExpand`, but `hkdfExpand` (RFC 5869) already appends its own counter byte for the first output block. The double-`0x01` caused "AES-GCM decryption failed" in `chrome://gcm-internals` while FCM silently accepted the malformed ciphertext. A known-answer test against the RFC 8291 §5 vector has been added to catch future regressions.
+
+### Dependencies
+
+- Bumped `postcss` from 8.5.9 to 8.5.10 (dev dependency).
+
 ## [0.2.0] - 2026-04-24
 
 ### Added
@@ -118,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/choyiny/saasmail/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/choyiny/saasmail/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/choyiny/saasmail/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/choyiny/saasmail/compare/v0.1.0...v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- **Fixed** aes128gcm double-counter bug in web push key derivation: `deriveAes128GcmKeys` was appending a manual `0x01` counter byte to the HKDF info, but `hkdfExpand` (RFC 5869) already appends its own counter byte. This caused Chrome to silently drop push notifications with "AES-GCM decryption failed" in `chrome://gcm-internals`. A known-answer test against the RFC 8291 §5 vector has been added.
- **Bumped** `postcss` dev dependency from 8.5.9 to 8.5.10.
- Updated `CHANGELOG.md` with a `[0.2.1]` entry and bumped `package.json` version to `0.2.1`.

## Test plan

- [ ] `yarn test` passes (includes the new RFC 8291 §5 known-answer vector)
- [ ] `yarn tsc --noEmit` passes
- [ ] CI checks green

---
_Generated by [Claude Code](https://claude.ai/code/session_013kMLyjLTN2KLaKjHc6crve)_