### PR TITLE
fix(web-push): notification click deep-links to person's conversation

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -24,19 +24,30 @@ self.addEventListener("notificationclick", (event) => {
   event.notification.close();
   const url = (event.notification.data && event.notification.data.url) || "/";
   event.waitUntil(
-    self.clients
-      .matchAll({ type: "window", includeUncontrolled: true })
-      .then((wins) => {
-        for (const w of wins) {
+    (async () => {
+      const wins = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      // Prefer focusing any same-origin tab and asking it to navigate to the
+      // target URL — focusing alone leaves the tab on whatever route it was
+      // already showing (commonly "/"), which made notifications appear to
+      // "do nothing" for users who already had the app open.
+      for (const w of wins) {
+        try {
+          const u = new URL(w.url);
+          if (u.origin !== self.location.origin) continue;
           try {
-            const u = new URL(w.url);
-            if (u.pathname === url || u.pathname.startsWith(url)) {
-              return w.focus();
-            }
+            await w.focus();
           } catch (_) {}
-        }
-        return self.clients.openWindow(url);
-      }),
+          try {
+            w.postMessage({ type: "saasmail.notificationclick", url });
+          } catch (_) {}
+          return;
+        } catch (_) {}
+      }
+      await self.clients.openWindow(url);
+    })(),
   );
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Route,
   Navigate,
   Outlet,
+  useNavigate,
 } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrandingProvider, useBranding } from "@/lib/branding";
@@ -74,11 +75,41 @@ function AuthGuard() {
   return <Outlet />;
 }
 
+/**
+ * Listens for `saasmail.notificationclick` messages posted by the service
+ * worker (public/sw.js) when a user clicks a Web Push notification while a
+ * tab is already open. The SW focuses the tab and posts the target URL; we
+ * complete the deep link by performing a client-side navigation here.
+ */
+function NotificationClickListener() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator))
+      return;
+    function onMessage(e: MessageEvent) {
+      const data = e.data;
+      if (
+        data &&
+        data.type === "saasmail.notificationclick" &&
+        typeof data.url === "string"
+      ) {
+        navigate(data.url);
+      }
+    }
+    navigator.serviceWorker.addEventListener("message", onMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener("message", onMessage);
+    };
+  }, [navigate]);
+  return null;
+}
+
 function App() {
   return (
     <BrandingProvider>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
+          <NotificationClickListener />
           <Routes>
             {/* Public routes */}
             <Route path="/login" element={<LoginPage />} />
@@ -109,6 +140,9 @@ function App() {
                   path="/settings"
                   element={<NotificationsSettingsPage />}
                 />
+                {/* Deep link from Web Push notifications — see
+                    worker/src/do/notifications.ts where data.url is set. */}
+                <Route path="/inbox/:inbox/:personId" element={<InboxPage />} />
                 <Route path="/*" element={<InboxPage />} />
               </Route>
             </Route>

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,9 +1,15 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import PersonList from "./PersonList";
 import PersonDetail from "./PersonDetail";
 import ComposeModal from "./ComposeModal";
-import { fetchStats, type GroupedPerson, type Stats } from "@/lib/api";
+import {
+  fetchPerson,
+  fetchStats,
+  type GroupedPerson,
+  type Stats,
+} from "@/lib/api";
 import { useSession } from "@/lib/auth-client";
 import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
 import { PushOptInBanner } from "@/components/PushOptInBanner";
@@ -19,6 +25,56 @@ export default function InboxPage() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [showBanner, setShowBanner] = useState(false);
   const { data: session } = useSession();
+  // When the user arrives via a Web Push notification (URL shape:
+  // /inbox/:inbox/:personId — see worker/src/do/notifications.ts and
+  // the route in App.tsx), pre-select that person so the tab shows the
+  // intended conversation rather than the empty default view.
+  const { personId: routePersonId } = useParams<{
+    inbox: string;
+    personId: string;
+  }>();
+  const lastProcessedPersonId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!routePersonId) return;
+    if (lastProcessedPersonId.current === routePersonId) return;
+    if (selectedPerson?.id === routePersonId) {
+      lastProcessedPersonId.current = routePersonId;
+      return;
+    }
+    lastProcessedPersonId.current = routePersonId;
+
+    // Prefer a hit in the already-loaded list (cheaper, has full grouped
+    // stats); fall back to fetching the person directly so we can still
+    // open the conversation when it isn't on the current page.
+    const found = people.find((p) => p.id === routePersonId);
+    if (found) {
+      setSelectedPerson(found);
+      return;
+    }
+    let cancelled = false;
+    fetchPerson(routePersonId)
+      .then((p) => {
+        if (cancelled) return;
+        setSelectedPerson({
+          id: p.id,
+          email: p.email,
+          name: p.name,
+          lastEmailAt: p.lastEmailAt,
+          unreadCount: p.unreadCount,
+          totalCount: p.totalCount,
+          // recipientCount/hasAttachment aren't returned by /api/people/:id;
+          // the grouped list will overwrite this object with full stats once
+          // it loads. PersonDetail only needs `id` to fetch emails.
+          recipientCount: 1,
+          hasAttachment: 0,
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [routePersonId, people, selectedPerson?.id]);
 
   function handleEmailRead(personId: string) {
     setPeople((prev) =>


### PR DESCRIPTION
## Summary
- Clicking a Web Push notification only ever showed the default inbox view. Two compounding bugs:
  1. `InboxPage` ignored the URL — `data.url = /inbox/<inbox>/<personId>` (set in `worker/src/do/notifications.ts:131`) had no matching route, fell through to `/*`, and the page never read `useParams`, so it always rendered "no person selected."
  2. The service worker only focused existing tabs without telling them to navigate. If the app was already open at `/`, `w.focus()` left it there.
- Fix in three small pieces:
  - `public/sw.js` — focus any same-origin tab and `postMessage` the target URL; fall back to `openWindow` only when no tab exists.
  - `src/App.tsx` — added `/inbox/:inbox/:personId` route (before the catch-all) and a `NotificationClickListener` that calls `navigate(url)` on the SW message.
  - `src/pages/InboxPage.tsx` — reads `personId` from `useParams`; tries the loaded list first, falls back to `fetchPerson(id)`. A ref dedupes processing so the mobile back button (`setSelectedPerson(null)`) isn't immediately undone.

## Test plan
- [ ] `yarn tsc --noEmit` passes
- [ ] With app **closed**, click a push notification → opens directly to the person's conversation
- [ ] With app **open at `/`**, click a push notification → focuses the tab and navigates it to the conversation
- [ ] On mobile, after notification opens a person, tap the in-app back button → returns to person list (and stays there)
- [ ] Clicking a person from the list still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)