### PR TITLE
chore: release v0.2.2 — notification click deep-link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-26
+
+### Fixed
+
+- Clicking a Web Push notification now deep-links directly to the person's conversation instead of landing on the generic inbox view. Two bugs were fixed: `InboxPage` now reads `personId` from URL params and falls back to `fetchPerson(id)` when the contact isn't already in the loaded list; the service worker now `postMessage`s the target URL to any open same-origin tab (falling back to `openWindow`), and `App.tsx` adds a `/inbox/:inbox/:personId` route with a `NotificationClickListener` that calls `navigate(url)` on receipt.
+
 ## [0.2.1] - 2026-04-25
 
 ### Fixed
@@ -128,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/choyiny/saasmail/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/choyiny/saasmail/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/choyiny/saasmail/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/choyiny/saasmail/compare/v0.1.1...v0.1.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `0.2.1` → `0.2.2`
- Adds `[0.2.2]` entry to `CHANGELOG.md` documenting the web-push notification click deep-link fix landed on 2026-04-25 (commit e51c52c / PR #31)

## Changes captured

**Fixed** — Clicking a Web Push notification now deep-links directly to the person's conversation. Two compounding bugs were resolved: `InboxPage` now reads `personId` from URL params (with a `fetchPerson` fallback), the service worker `postMessage`s the target URL to open tabs, and `App.tsx` registers a `/inbox/:inbox/:personId` route with a `NotificationClickListener`.

## Test plan

- [ ] CI passes (type-check + tests)
- [ ] `package.json` version is `0.2.2`
- [ ] `CHANGELOG.md` contains a `[0.2.2] - 2026-04-26` section with the correct fix description

https://claude.ai/code/session_01K8sBs2qiDJvxPLcbWQpczy

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8sBs2qiDJvxPLcbWQpczy)_