### PR TITLE
chore: release v0.3.0 — full-text email search via FTS5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-28
+
+### Added
+
+- Full-text email search via FTS5: the search box now surfaces people whose emails match the query by subject or body text, not just by name or email address. An `emails_fts` FTS5 virtual table is created with INSERT/UPDATE/DELETE triggers to keep the index in sync; existing emails are backfilled on migration. For members, FTS results are scoped to their permitted inboxes to prevent cross-inbox content leakage. The search box placeholder is updated to "Search…" and a clear (×) button appears when text is entered.
+
+### Dependencies
+
+- Bumped `better-auth` and `@better-auth/passkey` from 1.6.7 to 1.6.9.
+- Bumped Cloudflare dev group: `@cloudflare/vite-plugin` 1.33.1 → 1.33.2, `@cloudflare/vitest-pool-workers` 0.14.9 → 0.15.0, `@cloudflare/workers-types` 4.20260423.1 → 4.20260426.1, `wrangler` 4.84.1 → 4.85.0.
+- Bumped `@asteasolutions/zod-to-openapi` from 7.3.0 to 8.5.0.
+- Bumped `@hono/swagger-ui` from 0.5.3 to 0.6.1.
+- Bumped `actions/cache` from 4 to 5.
+- Bumped `actions/checkout` from 4 to 6.
+
 ## [0.2.2] - 2026-04-26
 
 ### Fixed
@@ -134,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/choyiny/saasmail/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/choyiny/saasmail/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/choyiny/saasmail/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/choyiny/saasmail/compare/v0.1.2...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version from `0.2.2` → `0.3.0` in `package.json`
- Updates `CHANGELOG.md` with the v0.3.0 entry covering all commits since the last release

## Changes included in this release

**Added**
- Full-text email search via FTS5 (#23): search box now surfaces people whose emails match by subject or body text; `emails_fts` virtual table with sync triggers and migration backfill; FTS results scoped to permitted inboxes for members; "Search…" placeholder and clear (×) button added to the search input.

**Dependencies**
- `better-auth` + `@better-auth/passkey` 1.6.7 → 1.6.9 (#37)
- Cloudflare dev group (`@cloudflare/vite-plugin`, `@cloudflare/vitest-pool-workers`, `@cloudflare/workers-types`, `wrangler`) (#36)
- `@asteasolutions/zod-to-openapi` 7.3.0 → 8.5.0 (#39)
- `@hono/swagger-ui` 0.5.3 → 0.6.1 (#40)
- `actions/cache` 4 → 5 (#35)
- `actions/checkout` 4 → 6 (#34)

## Test plan

- [ ] CI passes (type-check + unit + Playwright)
- [ ] `package.json` version reads `0.3.0`
- [ ] CHANGELOG entry is present and links resolve correctly

https://claude.ai/code/session_01G8joXW3EXBG5UZMQMEvX6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8joXW3EXBG5UZMQMEvX6J)_