### PR TITLE
feat: admin can revoke invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Admins can revoke invitations from the admin users page.
+
 ## [0.5.1] - 2026-05-23
 
 ### Added

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -462,6 +462,12 @@ export async function deleteUser(id: string): Promise<{ success: boolean }> {
   });
 }
 
+export async function revokeInvite(id: string): Promise<{ success: true }> {
+  return apiFetch<{ success: true }>(`/api/admin/invites/${id}`, {
+    method: "DELETE",
+  });
+}
+
 // --- Public Invite API ---
 
 export async function validateInvite(token: string): Promise<InviteInfo> {

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -18,6 +18,7 @@ import {
   createInvite,
   updateUserRole,
   deleteUser,
+  revokeInvite,
 } from "@/lib/api";
 import type { User, Invite } from "@/lib/api";
 import {
@@ -175,6 +176,12 @@ export default function AdminUsersPage() {
   async function handleDelete(userId: string) {
     if (!confirm("Delete this user? This can't be undone.")) return;
     await deleteUser(userId);
+    await loadData();
+  }
+
+  async function handleRevoke(inviteId: string) {
+    if (!confirm("Revoke this invitation? This cannot be undone.")) return;
+    await revokeInvite(inviteId);
     await loadData();
   }
 
@@ -472,6 +479,29 @@ export default function AdminUsersPage() {
                             : `expires ${relativeTime(invite.expiresAt)}`}
                       </p>
                     </div>
+                    {status === "pending" && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            aria-label="More actions"
+                            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                          >
+                            <MoreHorizontal size={14} />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          className="border-border bg-card text-text-primary ring-1 ring-border"
+                        >
+                          <DropdownMenuItem
+                            onClick={() => handleRevoke(invite.id)}
+                            className="text-xs text-destructive focus:bg-bg-muted"
+                          >
+                            Revoke invitation
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </li>
                 );
               })}

--- a/worker/src/__tests__/admin-router.test.ts
+++ b/worker/src/__tests__/admin-router.test.ts
@@ -179,6 +179,92 @@ describe("admin router", () => {
     });
   });
 
+  describe("DELETE /api/admin/invites/:id", () => {
+    it("revokes a pending invite", async () => {
+      const db = getDb();
+      const now = new Date();
+      await db.insert(invitations).values({
+        id: "invite-1",
+        token: crypto.randomUUID(),
+        role: "member",
+        email: null,
+        expiresAt: new Date(now.getTime() + 86400000),
+        usedBy: null,
+        usedAt: null,
+        createdBy: userId,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/admin/invites/invite-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+
+      const remaining = await db
+        .select()
+        .from(invitations)
+        .where(eq(invitations.id, "invite-1"))
+        .get();
+      expect(remaining).toBeUndefined();
+    });
+
+    it("revokes a used invite", async () => {
+      const db = getDb();
+      const now = new Date();
+      const now2 = Date.now();
+      await db.insert(users).values({
+        id: "user-2",
+        name: "Accepted User",
+        email: "accepted@example.com",
+        emailVerified: false,
+        createdAt: new Date(now2),
+        updatedAt: new Date(now2),
+        role: "member",
+      });
+      await db.insert(invitations).values({
+        id: "invite-2",
+        token: crypto.randomUUID(),
+        role: "member",
+        email: "accepted@example.com",
+        expiresAt: new Date(now.getTime() + 86400000),
+        usedBy: "user-2",
+        usedAt: now,
+        createdBy: userId,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/admin/invites/invite-2", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("returns 404 for nonexistent invite id", async () => {
+      const res = await authFetch("/api/admin/invites/nonexistent", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects non-admin for revoke endpoint", async () => {
+      await cleanDb();
+      const { apiKey: memberApiKey } = await createTestUser({ role: "member" });
+
+      const res = await authFetch("/api/admin/invites/any-id", {
+        apiKey: memberApiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe("admin guard", () => {
     it("rejects non-admin users", async () => {
       await cleanDb();

--- a/worker/src/routers/admin-router.ts
+++ b/worker/src/routers/admin-router.ts
@@ -139,6 +139,43 @@ adminRouter.openapi(listInvitesRoute, async (c) => {
   return c.json(result, 200);
 });
 
+const revokeInviteRoute = createRoute({
+  method: "delete",
+  path: "/invites/{id}",
+  tags: ["Admin"],
+  description: "Revoke an invitation by id.",
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    ...json200Response(
+      z.object({ success: z.literal(true) }),
+      "Invite revoked",
+    ),
+    404: {
+      description: "Invite not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+adminRouter.openapi(revokeInviteRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+
+  const target = await db
+    .select()
+    .from(invitations)
+    .where(eq(invitations.id, id))
+    .get();
+  if (!target) {
+    return c.json({ error: "Invite not found" }, 404);
+  }
+
+  await db.delete(invitations).where(eq(invitations.id, id));
+  return c.json({ success: true as const }, 200);
+});
+
 // --- User Management Endpoints ---
 
 const listUsersRoute = createRoute({


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/admin/invites/{id}` (admin-gated via existing `requireAdmin` middleware). 404 if the invite doesn't exist; otherwise hard-deletes the row.
- Adds a "Revoke" action to every invite row on the admin users page, with a confirm dialog that refetches the list after revoking.
- Adds `revokeInvite(id)` to the API client.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn test` — 251 passed (4 new tests in `worker/src/__tests__/admin-router.test.ts`: pending revoke, used revoke, 404 on unknown id, 403 for non-admin)
- [x] CHANGELOG entry added under `## [Unreleased]`