### PR TITLE
chore: release v0.3.2 — dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-02
+
+### Dependencies
+
+- Bumped `better-auth` and `@better-auth/passkey` from 1.6.7 to 1.6.9.
+- Bumped Cloudflare dev group: `@cloudflare/vite-plugin` 1.33.1 → 1.33.2, `@cloudflare/vitest-pool-workers` 0.14.9 → 0.15.0, `@cloudflare/workers-types` 4.20260423.1 → 4.20260426.1, `wrangler` 4.84.1 → 4.85.0.
+- Bumped `@asteasolutions/zod-to-openapi` from 7.3.0 to 8.5.0.
+- Bumped `@hono/swagger-ui` from 0.5.3 to 0.6.1.
+- Bumped `actions/cache` from 4 to 5.
+- Bumped `actions/checkout` from 4 to 6.
+
 ## [0.3.1] - 2026-04-30
 
 ### Dependencies
@@ -151,7 +162,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/choyiny/saasmail/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/choyiny/saasmail/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/choyiny/saasmail/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/choyiny/saasmail/compare/v0.2.1...v0.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `0.3.1` → `0.3.2`
- Adds `[0.3.2]` CHANGELOG entry (2026-05-02) documenting the dependency updates shipped in yesterday's release commit (#43)

## Changes

### Dependencies

- `better-auth` + `@better-auth/passkey` 1.6.7 → 1.6.9
- Cloudflare dev group: `@cloudflare/vite-plugin`, `@cloudflare/vitest-pool-workers`, `@cloudflare/workers-types`, `wrangler`
- `@asteasolutions/zod-to-openapi` 7.3.0 → 8.5.0
- `@hono/swagger-ui` 0.5.3 → 0.6.1
- `actions/cache` 4 → 5
- `actions/checkout` 4 → 6

## Test plan

- [ ] CI passes (type-check + tests)
- [ ] `package.json` version reads `0.3.2`
- [ ] CHANGELOG `[0.3.2]` entry and comparison links are correct

https://claude.ai/code/session_01Y4Y27zJqRmR5uXNo6PqhXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4Y27zJqRmR5uXNo6PqhXE)_