### PR TITLE
chore: release v0.3.3 — admin invite revocation & mobile search fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-04
+
+### Added
+
+- Admins can now revoke pending invitations from the admin users page: each invite row has a "Revoke" action that opens a confirm dialog and calls the new `DELETE /api/admin/invites/{id}` endpoint (admin-gated, hard-deletes the row, 404 if unknown).
+
+### Fixed
+
+- Person-list search bar no longer triggers iOS Safari's auto-zoom: font size raised to 16 px on mobile (compact desktop sizing restored at the `sm` breakpoint).
+
 ## [0.3.2] - 2026-05-02
 
 ### Dependencies
@@ -162,7 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/choyiny/saasmail/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/choyiny/saasmail/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/choyiny/saasmail/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/choyiny/saasmail/compare/v0.2.2...v0.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -314,6 +314,12 @@ export async function deleteUser(id: string): Promise<{ success: boolean }> {
   });
 }
 
+export async function revokeInvite(id: string): Promise<{ success: true }> {
+  return apiFetch<{ success: true }>(`/api/admin/invites/${id}`, {
+    method: "DELETE",
+  });
+}
+
 // --- Public Invite API ---
 
 export async function validateInvite(token: string): Promise<InviteInfo> {

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -7,6 +7,7 @@ import {
   createInvite,
   updateUserRole,
   deleteUser,
+  revokeInvite,
 } from "@/lib/api";
 import type { User, Invite } from "@/lib/api";
 import {
@@ -88,6 +89,12 @@ export default function AdminUsersPage() {
   async function handleDelete(userId: string) {
     if (!confirm("Are you sure you want to delete this user?")) return;
     await deleteUser(userId);
+    await loadData();
+  }
+
+  async function handleRevoke(inviteId: string) {
+    if (!confirm("Revoke this invitation? This cannot be undone.")) return;
+    await revokeInvite(inviteId);
     await loadData();
   }
 
@@ -320,17 +327,37 @@ export default function AdminUsersPage() {
                         {formatDate(invite.expiresAt)}
                       </p>
                     </div>
-                    <span
-                      className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                        st === "used"
-                          ? "bg-accent/20 text-accent"
-                          : st === "expired"
-                            ? "bg-bg-muted text-text-tertiary"
-                            : "border border-border text-text-secondary"
-                      }`}
-                    >
-                      {st}
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                          st === "used"
+                            ? "bg-accent/20 text-accent"
+                            : st === "expired"
+                              ? "bg-bg-muted text-text-tertiary"
+                              : "border border-border text-text-secondary"
+                        }`}
+                      >
+                        {st}
+                      </span>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button className="rounded px-1.5 py-0.5 text-xs text-text-tertiary hover:bg-bg-muted hover:text-text-secondary">
+                            ...
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          className="bg-white ring-1 ring-gray-200 border-border text-text-primary"
+                        >
+                          <DropdownMenuItem
+                            onClick={() => handleRevoke(invite.id)}
+                            className="text-xs text-destructive focus:bg-bg-muted"
+                          >
+                            Revoke
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
                   </div>
                 );
               })

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -123,7 +123,7 @@ export default function PersonList({
             placeholder="Search..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="h-8 w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 pr-7 text-xs text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+            className="h-10 w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 pr-9 text-base text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent sm:h-8 sm:pr-7 sm:text-xs"
           />
           {search && (
             <button
@@ -131,7 +131,7 @@ export default function PersonList({
               onClick={() => setSearch("")}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-secondary"
             >
-              <X size={12} />
+              <X className="h-4 w-4 sm:h-3 sm:w-3" />
             </button>
           )}
         </div>

--- a/worker/src/__tests__/admin-router.test.ts
+++ b/worker/src/__tests__/admin-router.test.ts
@@ -178,6 +178,92 @@ describe("admin router", () => {
     });
   });
 
+  describe("DELETE /api/admin/invites/:id", () => {
+    it("revokes a pending invite", async () => {
+      const db = getDb();
+      const now = new Date();
+      await db.insert(invitations).values({
+        id: "invite-1",
+        token: crypto.randomUUID(),
+        role: "member",
+        email: null,
+        expiresAt: new Date(now.getTime() + 86400000),
+        usedBy: null,
+        usedAt: null,
+        createdBy: userId,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/admin/invites/invite-1", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+
+      const remaining = await db
+        .select()
+        .from(invitations)
+        .where(eq(invitations.id, "invite-1"))
+        .get();
+      expect(remaining).toBeUndefined();
+    });
+
+    it("revokes a used invite", async () => {
+      const db = getDb();
+      const now = new Date();
+      const now2 = Date.now();
+      await db.insert(users).values({
+        id: "user-2",
+        name: "Accepted User",
+        email: "accepted@example.com",
+        emailVerified: false,
+        createdAt: new Date(now2),
+        updatedAt: new Date(now2),
+        role: "member",
+      });
+      await db.insert(invitations).values({
+        id: "invite-2",
+        token: crypto.randomUUID(),
+        role: "member",
+        email: "accepted@example.com",
+        expiresAt: new Date(now.getTime() + 86400000),
+        usedBy: "user-2",
+        usedAt: now,
+        createdBy: userId,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/admin/invites/invite-2", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("returns 404 for nonexistent invite id", async () => {
+      const res = await authFetch("/api/admin/invites/nonexistent", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects non-admin for revoke endpoint", async () => {
+      await cleanDb();
+      const { apiKey: memberApiKey } = await createTestUser({ role: "member" });
+
+      const res = await authFetch("/api/admin/invites/any-id", {
+        apiKey: memberApiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe("admin guard", () => {
     it("rejects non-admin users", async () => {
       await cleanDb();

--- a/worker/src/routers/admin-router.ts
+++ b/worker/src/routers/admin-router.ts
@@ -135,6 +135,40 @@ adminRouter.openapi(listInvitesRoute, async (c) => {
   return c.json(result, 200);
 });
 
+const revokeInviteRoute = createRoute({
+  method: "delete",
+  path: "/invites/{id}",
+  tags: ["Admin"],
+  description: "Revoke an invitation by id.",
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    ...json200Response(z.object({ success: z.literal(true) }), "Invite revoked"),
+    404: {
+      description: "Invite not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+adminRouter.openapi(revokeInviteRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+
+  const target = await db
+    .select()
+    .from(invitations)
+    .where(eq(invitations.id, id))
+    .get();
+  if (!target) {
+    return c.json({ error: "Invite not found" }, 404);
+  }
+
+  await db.delete(invitations).where(eq(invitations.id, id));
+  return c.json({ success: true as const }, 200);
+});
+
 // --- User Management Endpoints ---
 
 const listUsersRoute = createRoute({

--- a/worker/src/routers/admin-router.ts
+++ b/worker/src/routers/admin-router.ts
@@ -144,7 +144,10 @@ const revokeInviteRoute = createRoute({
     params: z.object({ id: z.string() }),
   },
   responses: {
-    ...json200Response(z.object({ success: z.literal(true) }), "Invite revoked"),
+    ...json200Response(
+      z.object({ success: z.literal(true) }),
+      "Invite revoked",
+    ),
     404: {
       description: "Invite not found",
       content: { "application/json": { schema: ErrorSchema } },


### PR DESCRIPTION
## Summary

- Incorporates PR #42 (feat: admin can revoke invitations) — adds `DELETE /api/admin/invites/{id}` (admin-gated); returns `{ success: true }` or 404. Adds a "Revoke" action to each invite row on the admin users page with a confirm dialog. Adds `revokeInvite(id)` to the API client.
- Incorporates PR #50 (fix: mobile-first search bar) — raises search input font size to 16 px on mobile to prevent iOS Safari auto-zoom on focus; compact desktop sizing restored at the `sm` breakpoint.
- Bumps version `0.3.2` → `0.3.3` in `package.json`.
- Adds `[0.3.3] - 2026-05-04` entry to `CHANGELOG.md`.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn test` — 4 new tests in `worker/src/__tests__/admin-router.test.ts` (pending revoke, used revoke, 404 on unknown id, 403 for non-admin)

https://claude.ai/code/session_01HLSFTVnpgUv45DZEYBEBPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLSFTVnpgUv45DZEYBEBPL)_