### PR TITLE
Guide operators when setup DB is unmigrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ yarn db:migrate:dev
 yarn db:migrate:prod
 ```
 
+Run the production migration before opening the deployed app for the first setup. If the production D1 database has not been initialized, the onboarding screen will show **Database migration required** with the same command.
+
 ### 7. Configure email routing
 
 In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to your domain's **Email Routing** settings and add a catch-all rule that routes to your saasmail worker.

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -4,7 +4,14 @@ import { signIn } from "@/lib/auth-client";
 import { WordmarkLarge } from "@/components/Wordmark";
 import { useBranding } from "@/lib/branding";
 
-type Status = "checking" | "available" | "unavailable";
+type Status = "checking" | "available" | "unavailable" | "migration-required";
+
+type SetupStatusResponse = {
+  setupRequired?: boolean;
+  error?: string;
+  code?: string;
+  command?: string;
+};
 
 export default function OnboardingPage() {
   const navigate = useNavigate();
@@ -14,6 +21,8 @@ export default function OnboardingPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [migrationRequired, setMigrationRequired] =
+    useState<SetupStatusResponse | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -21,8 +30,13 @@ export default function OnboardingPage() {
     (async () => {
       try {
         const res = await fetch("/api/setup/status");
-        const data = (await res.json()) as { setupRequired: boolean };
+        const data = (await res.json()) as SetupStatusResponse;
         if (cancelled) return;
+        if (!res.ok && data.code === "DATABASE_MIGRATION_REQUIRED") {
+          setMigrationRequired(data);
+          setStatus("migration-required");
+          return;
+        }
         setStatus(data.setupRequired ? "available" : "unavailable");
       } catch {
         if (!cancelled) setStatus("unavailable");
@@ -44,8 +58,14 @@ export default function OnboardingPage() {
         body: JSON.stringify({ name, email, password }),
       });
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        const data = (await res
+          .json()
+          .catch(() => ({}))) as SetupStatusResponse;
         setError(data.error || "Setup failed");
+        if (res.status === 503 && data.code === "DATABASE_MIGRATION_REQUIRED") {
+          setMigrationRequired(data);
+          setStatus("migration-required");
+        }
         if (res.status === 403) setStatus("unavailable");
         return;
       }
@@ -64,6 +84,33 @@ export default function OnboardingPage() {
 
   if (status === "checking") {
     return <p className="text-sm text-white/60">Loading…</p>;
+  }
+
+  if (status === "migration-required") {
+    return (
+      <div className="flex w-full max-w-sm flex-col items-center gap-8">
+        <WordmarkLarge />
+        <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Database migration required
+          </h2>
+          <p className="mt-3 text-sm font-light text-white/60">
+            {migrationRequired?.error ||
+              "The production database has not been initialized yet."}
+          </p>
+          <div className="mt-5 rounded-md bg-white/5 px-3 py-2 text-xs font-medium text-white ring-1 ring-white/15">
+            {migrationRequired?.command || "yarn db:migrate:prod"}
+          </div>
+          <p className="mt-4 text-xs font-light text-white/40">
+            For a guided first deploy, run{" "}
+            <code className="rounded bg-white/10 px-1 py-0.5 text-white/70">
+              /saasmail-onboarding
+            </code>{" "}
+            in Claude Code, then reload this page.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   if (status === "unavailable") {

--- a/worker/src/__tests__/setup-router.test.ts
+++ b/worker/src/__tests__/setup-router.test.ts
@@ -1,3 +1,4 @@
+import { env } from "cloudflare:workers";
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { applyMigrations, cleanDb, createTestUser, authFetch } from "./helpers";
 
@@ -25,6 +26,26 @@ describe("setup router", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.setupRequired).toBe(false);
+    });
+
+    it("tells operators to run production migrations when users table is missing", async () => {
+      await env.DB.exec("DROP TABLE users");
+
+      try {
+        const res = await authFetch("/api/setup/status");
+        expect(res.status).toBe(503);
+        const data = (await res.json()) as {
+          error?: string;
+          code?: string;
+          command?: string;
+        };
+        expect(data.code).toBe("DATABASE_MIGRATION_REQUIRED");
+        expect(data.command).toBe("yarn db:migrate:prod");
+        expect(data.error).toContain("yarn db:migrate:prod");
+        expect(data.error).toContain("/saasmail-onboarding");
+      } finally {
+        await applyMigrations();
+      }
     });
   });
 

--- a/worker/src/routers/setup-router.ts
+++ b/worker/src/routers/setup-router.ts
@@ -14,6 +14,28 @@ const StatusSchema = z.object({
   setupRequired: z.boolean(),
 });
 
+const MigrationRequiredSchema = z.object({
+  error: z.string(),
+  code: z.literal("DATABASE_MIGRATION_REQUIRED"),
+  command: z.literal("yarn db:migrate:prod"),
+});
+
+const MIGRATION_REQUIRED_RESPONSE = {
+  error:
+    "Database migrations have not been applied yet. Run `yarn db:migrate:prod` to create the production D1 tables, or run `/saasmail-onboarding` to walk through setup, then reload saasmail.",
+  code: "DATABASE_MIGRATION_REQUIRED",
+  command: "yarn db:migrate:prod",
+} as const;
+
+function isMissingUsersTableError(err: unknown): boolean {
+  let current: unknown = err;
+  while (current instanceof Error) {
+    if (current.message.includes("no such table: users")) return true;
+    current = current.cause;
+  }
+  return String(current).includes("no such table: users");
+}
+
 const SetupRequestSchema = z.object({
   name: z.string().min(1).max(100),
   email: z.string().email(),
@@ -40,13 +62,24 @@ const statusRoute = createRoute({
   description: "Check whether initial setup is required (no users exist).",
   responses: {
     ...json200Response(StatusSchema, "Setup status"),
+    503: {
+      description: "Database migrations have not been applied",
+      content: { "application/json": { schema: MigrationRequiredSchema } },
+    },
   },
 });
 
 setupRouter.openapi(statusRoute, async (c) => {
   const db = c.get("db");
-  const count = await countUsers(db);
-  return c.json({ setupRequired: count === 0 }, 200);
+  try {
+    const count = await countUsers(db);
+    return c.json({ setupRequired: count === 0 }, 200);
+  } catch (err) {
+    if (isMissingUsersTableError(err)) {
+      return c.json(MIGRATION_REQUIRED_RESPONSE, 503);
+    }
+    throw err;
+  }
 });
 
 const createRouteDef = createRoute({
@@ -74,6 +107,10 @@ const createRouteDef = createRoute({
       description: "Invalid request",
       content: { "application/json": { schema: ErrorSchema } },
     },
+    503: {
+      description: "Database migrations have not been applied",
+      content: { "application/json": { schema: MigrationRequiredSchema } },
+    },
   },
 });
 
@@ -81,7 +118,15 @@ setupRouter.openapi(createRouteDef, async (c) => {
   const db = c.get("db");
 
   // Guard: reject if any users already exist.
-  const count = await countUsers(db);
+  let count: number;
+  try {
+    count = await countUsers(db);
+  } catch (err) {
+    if (isMissingUsersTableError(err)) {
+      return c.json(MIGRATION_REQUIRED_RESPONSE, 503);
+    }
+    throw err;
+  }
   if (count > 0) {
     return c.json({ error: "Setup has already been completed" }, 403);
   }


### PR DESCRIPTION
## Summary
- return a structured setup status error when the `users` table is missing
- keep migration guidance scoped to the onboarding page so the login flow is not exposed to this setup-only state
- port the migration-required UI to the refreshed auth/onboarding styling and include a `/saasmail-onboarding` CTA
- document the production migration prerequisite near the existing migration commands

## Tests
- `corepack yarn tsc --noEmit`
- `corepack yarn test worker/src/__tests__/setup-router.test.ts`
- `corepack yarn build`

Note: local validation used Node v20 with `corepack yarn install --frozen-lockfile --ignore-engines`. The focused worker test needs a local `wrangler.jsonc`; I used the repo's `wrangler.jsonc.ci` template for that local check.