### PR TITLE
feat: v0.4.0 — UX/visual overhaul, bulk actions, table view, drawers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ playwright-report/
 
 # Local superpowers docs (specs, plans)
 docs/superpowers/
+
+# Per-developer Claude Code preview launch config
+.claude/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-07
+
+A large UX/visual overhaul plus a new bulk-actions API. Frontend, brand,
+and admin tooling all changed; the data model is unchanged.
+
+### Added
+
+- **Brand refresh**: lime + violet palette via Tailwind v4 `@theme` tokens, Inter + Caveat fonts, animated GrainGradient backdrop on auth screens, soft pastel backdrop on the dashboard, mail-glyph favicon, OpenGraph image, comprehensive SEO meta + JSON-LD `SoftwareApplication`.
+- **Top-nav layout**: floating dark pill nav with brand wordmark, route tabs, breadcrumbs strip, and a unified `Footer` (light variant for dashboard, dark variant for auth) — replaces the persistent left sidebar.
+- **Inbox table view + filter toolbar**: new default view shows people as a sortable table with stats strip (people / unread / multi-inbox / with attachments). Single unified toolbar combines search, inbox dropdown, unread/attachments chips, and a List ↔ Table view toggle.
+- **Bulk actions**: select multiple people via per-row checkboxes; floating `SelectionBar` exposes "Mark as read" with optimistic UI. Click an unread badge to mark just that person's emails as read. Per-inbox "Mark all in `<inbox>` as read" button on the active tab in `PersonDetail`.
+- **Per-person tabbed inbox view**: when a contact has emailed multiple inboxes, each inbox is its own tab (short label, count, unread badge, mode dot) instead of stacked sections.
+- **Drawer pattern for "View original" and "Reply"**: right-side animated slide-in (320 ms eased) with rich detail, From/To/ID/Time metadata, attachments with sizes, Rendered/Plain text toggle, copy-text. Reply drawer renders the email being replied to plus the surrounding thread alongside the editor (collapsible history).
+- **Chat redesign**: sticky reply input always visible, day separators (Today / Yesterday / weekday), top + bottom fade affordances, "Jump to latest" / "New messages" pill when scrolled away from bottom, larger bubbles with shadow + ring.
+- **Mobile-first overhaul**: floating compose FAB, full-screen drawers under `sm`, edge-to-edge inbox card on mobile, person tap opens full-screen, scroll-snap on inbox tabs, bottom-anchored selection bar with safe-area padding, larger touch targets (min 44 px), `text-base` on toolbar inputs to prevent iOS zoom.
+- **Capability-aware animation gating**: new `useReducedAnimations()` hook detects `prefers-reduced-motion`, `navigator.connection.saveData`, slow connections, low device memory (< 4 GB), low core count (< 4) and renders a static CSS gradient fallback instead of the WebGL shader. Global CSS `@media (prefers-reduced-motion: reduce)` zero-duration overrides for animations and transitions.
+- **Reusable page chrome**: `PageHeader` and `PageContainer` components applied to ApiKeys, Templates, Sequences, AdminUsers, Settings, and Inboxes — consistent title / subtitle / action layout, capped at `max-w-[1600px]` to better use desktop real estate.
+- **Inboxes admin redesign**: real `<table>` with bulk select header checkbox, bulk Thread/Chat/Delete actions in a contextual bar, inline display-name editing, per-row mode toggle, and a popover-based member assignment cell.
+- **Public legal pages**: `/terms` and `/privacy` rendered through a new `LegalLayout` (light readable doc style) with content appropriate for self-hosted Apache 2.0 software (operator-as-data-controller framing).
+- **API**: `POST /api/people/mark-read` bulk endpoint (with optional `recipient` scope); `GET /api/people/grouped` accepts `recipient` / `unread` / `hasAttachment` filters and returns a new `recipients: string[]` field.
+- **Demo seed generator**: `seeds/generate-demo.ts` (run via `npx tsx`) produces a 100-person / ~700-email dataset across 6 inboxes for stress-testing UI behaviour. The committed `seeds/demo.sql` is unchanged — use the generator to overwrite locally.
+
+### Changed
+
+- **Default inbox view** is now `Table` (was `List`).
+- **Default `displayMode`** for inboxes is now `chat` (was `thread`). Existing rows keep their explicit setting; only the fallback for rows without a `sender_identities` entry flipped. Tests updated accordingly.
+- **`PersonList` is now controlled** — data fetching for the people list lives in `InboxPage` so both Table and List views see the same paginated data. Previously the fetch was inside `PersonList`, which made the Table view show empty state.
+- **`InboxToolbar`** consolidates what used to be three separate components (search input in the sidebar header, filter bar above the inbox card, view toggle on its own row) into a single bordered bar.
+- **Auth pages** (`Login`, `Onboarding`, `InviteAccept`, `SetupPasskey`) restyled with the glass-card pattern on the animated dark backdrop. Login flow simplified to `Continue with passkey` (primary) and `Continue with email` (secondary fallback).
+- **Footer** is a single-row layout (Privacy/Terms pills · copyright · sponsor pill), with a `variant="dark"` mode for auth pages so it stays legible against the dark backdrop.
+- **`PeopleTable` "Inboxes" column** shows the actual inbox names as chips (first 3 + overflow `+N`), not just a count.
+
+### Fixed
+
+- Table view scroll: nested flex containers need `min-h-0 + overflow-hidden` on the immediate parent to constrain inner scroll regions; wrapper around `PeopleTable` updated.
+- Footer was painted over by the fixed `dashboard-backdrop-mask` overlay; mask gradient now fades earlier and `Footer` is wrapped in `relative z-10`.
+- Right-side drawers now slide in via pure-CSS keyframes (`drawer-slide-in / drawer-slide-out`) rather than relying on tailwindcss-animate's specific class names.
+
+### Dependencies
+
+- Added `@paper-design/shaders-react` for the auth-screen GrainGradient. `vite.config.ts` adds `resolve.dedupe: ["react","react-dom"]` and `optimizeDeps.include` so the lazy-loaded shader doesn't end up with a duplicate React copy.
+
 ## [0.3.3] - 2026-05-05
 
 ### Fixed

--- a/e2e/specs/chat-display.spec.ts
+++ b/e2e/specs/chat-display.spec.ts
@@ -19,6 +19,12 @@ test.describe.serial("chat-mode display (support@)", () => {
     await expect(page.getByText("Alice Anderson")).toBeVisible();
     await page.getByText("Alice Anderson").click();
 
+    // The redesign tabs each inbox per person. Switch to the support@ tab
+    // (chat mode) so chat bubbles are rendered.
+    await page
+      .locator(`[data-testid="inbox-tab"]`, { hasText: "support" })
+      .click();
+
     // Chat bubbles should be rendered (2 support@ emails)
     const bubbles = page.getByTestId(TEST_IDS.chatBubble);
     await expect(bubbles).toHaveCount(2);

--- a/e2e/specs/compose.spec.ts
+++ b/e2e/specs/compose.spec.ts
@@ -96,6 +96,12 @@ test.describe.serial("compose & send", () => {
     await expect(page.getByText("Alice Anderson")).toBeVisible();
     await page.getByText("Alice Anderson").click();
 
+    // Switch to the marketing@ tab (thread mode) so thread-message bubbles
+    // are rendered (the redesign tabs each inbox per person).
+    await page
+      .locator(`[data-testid="inbox-tab"]`, { hasText: "marketing" })
+      .click();
+
     // Wait for her emails to load in the right panel
     // The latest marketing@ email is e_m_a2 "Re: Welcome to our product"
     // MessageBubble renders with a Reply button hidden behind group-hover

--- a/e2e/specs/thread-display.spec.ts
+++ b/e2e/specs/thread-display.spec.ts
@@ -19,6 +19,12 @@ test.describe.serial("thread-mode display (marketing@)", () => {
     await expect(page.getByText("Alice Anderson")).toBeVisible();
     await page.getByText("Alice Anderson").click();
 
+    // The redesign tabs each inbox per person. Switch to the marketing@ tab
+    // (thread mode) so thread messages are rendered.
+    await page
+      .locator(`[data-testid="inbox-tab"]`, { hasText: "marketing" })
+      .click();
+
     // The latest email (e_m_a2) subject should be visible in the thread
     await expect(page.getByText("Re: Welcome to our product")).toBeVisible();
 

--- a/e2e/specs/unread-count-sync.spec.ts
+++ b/e2e/specs/unread-count-sync.spec.ts
@@ -28,8 +28,13 @@ test.describe.serial("sidebar unread count stays in sync", () => {
     const aliceBadge = aliceRow.getByTestId(TEST_IDS.personUnreadBadge);
     await expect(aliceBadge).toHaveText("4");
 
-    // Select Alice — opens PersonDetail with chat + thread sections.
+    // Select Alice — opens PersonDetail with tabbed inbox sections.
     await aliceRow.click();
+
+    // Switch to the support@ tab (chat mode) so chat bubbles are rendered.
+    await page
+      .locator(`[data-testid="inbox-tab"]`, { hasText: "support" })
+      .click();
 
     // Click the first chat bubble (support@e2e.test, chat-mode) to mark it read.
     const firstBubble = page.getByTestId(TEST_IDS.chatBubble).first();

--- a/index.html
+++ b/index.html
@@ -2,27 +2,97 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="color-scheme" content="light" />
+
+    <!-- Primary SEO -->
+    <title>saasmail · The centralized inbox for SaaS teams</title>
+    <meta
+      name="description"
+      content="One unified timeline per customer — marketing, notifications, and support emails collapsed into a single view. Self-hosted on Cloudflare Workers, open source under Apache 2.0."
+    />
+    <meta
+      name="keywords"
+      content="saasmail, shared inbox, customer email, support inbox, sales inbox, cloudflare workers, self-hosted email, email infrastructure, multi-inbox, customer timeline, open source email"
+    />
+    <meta name="author" content="saasmail" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <link rel="canonical" href="https://saasmail.dev/" />
+
+    <!-- Favicons -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon/favicon.ico" />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon/favicon-32x32.png"
+    <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="saasmail" />
+    <meta
+      property="og:title"
+      content="saasmail · The centralized inbox for SaaS teams"
     />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="/favicon/favicon-16x16.png"
+    <meta
+      property="og:description"
+      content="One unified timeline per customer. Self-hosted on Cloudflare Workers, open source under Apache 2.0."
     />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/favicon/apple-touch-icon.png"
+    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="saasmail — the centralized inbox for SaaS teams"
     />
-    <link rel="manifest" href="/favicon/site.webmanifest" />
-    <title>saasmail</title>
+    <meta property="og:url" content="https://saasmail.dev/" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter / X -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="saasmail · The centralized inbox for SaaS teams"
+    />
+    <meta
+      name="twitter:description"
+      content="One unified timeline per customer. Self-hosted on Cloudflare Workers, open source under Apache 2.0."
+    />
+    <meta name="twitter:image" content="/og-image.svg" />
+    <meta
+      name="twitter:image:alt"
+      content="saasmail — the centralized inbox for SaaS teams"
+    />
+
+    <!-- Structured data — SoftwareApplication -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "saasmail",
+        "description": "Self-managed email server for SaaS teams on Cloudflare Workers. One unified timeline per customer.",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Cloudflare Workers",
+        "license": "https://www.apache.org/licenses/LICENSE-2.0",
+        "url": "https://saasmail.dev/",
+        "codeRepository": "https://github.com/choyiny/saasmail",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Caveat:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -42,6 +42,7 @@
     "@hono/swagger-ui": "^0.6.1",
     "@hono/zod-openapi": "^1.3.0",
     "@opentelemetry/api": "^1.9.1",
+    "@paper-design/shaders-react": "^0.0.76",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/public/apple-touch-icon.svg
+++ b/public/apple-touch-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#0a0a0a"/>
+  <g fill="none" stroke="#BFFF00" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" transform="translate(45, 45) scale(3.75)">
+    <rect width="20" height="16" x="2" y="4" rx="2"/>
+    <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+  </g>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="0" y="0" width="24" height="24" rx="4" fill="#0a0a0a"/>
+  <g fill="none" stroke="#BFFF00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect width="20" height="16" x="2" y="4" rx="2"/>
+    <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+  </g>
+</svg>

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <radialGradient id="violet" cx="20%" cy="20%" r="60%">
+      <stop offset="0%" stop-color="#7C5CFC" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#7C5CFC" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="lime" cx="80%" cy="80%" r="55%">
+      <stop offset="0%" stop-color="#BFFF00" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#BFFF00" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="indigo" cx="100%" cy="20%" r="55%">
+      <stop offset="0%" stop-color="#6366F1" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#6366F1" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect width="1200" height="630" fill="url(#violet)"/>
+  <rect width="1200" height="630" fill="url(#indigo)"/>
+  <rect width="1200" height="630" fill="url(#lime)"/>
+
+  <g transform="translate(540, 195)">
+    <g fill="none" stroke="#BFFF00" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" transform="scale(5)">
+      <rect width="20" height="16" x="2" y="4" rx="2"/>
+      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+    </g>
+  </g>
+
+  <text
+    x="600"
+    y="430"
+    fill="#ffffff"
+    font-family="Inter, system-ui, sans-serif"
+    font-size="84"
+    font-weight="900"
+    text-anchor="middle"
+    letter-spacing="-2"
+  >SAASMAIL</text>
+
+  <text
+    x="600"
+    y="490"
+    fill="rgba(255,255,255,0.6)"
+    font-family="Inter, system-ui, sans-serif"
+    font-size="28"
+    font-weight="300"
+    text-anchor="middle"
+  >The centralized inbox for SaaS teams</text>
+
+  <text
+    x="600"
+    y="560"
+    fill="rgba(255,255,255,0.35)"
+    font-family="Inter, system-ui, sans-serif"
+    font-size="18"
+    font-weight="400"
+    text-anchor="middle"
+    letter-spacing="2"
+  >SELF-HOSTED · CLOUDFLARE WORKERS · APACHE 2.0</text>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "saasmail · centralized inbox for SaaS teams",
+  "short_name": "saasmail",
+  "description": "One unified timeline per customer. Self-hosted on Cloudflare Workers.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/apple-touch-icon.svg",
+      "sizes": "180x180",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/seeds/generate-demo.ts
+++ b/seeds/generate-demo.ts
@@ -1,0 +1,706 @@
+/**
+ * Generate seeds/demo.sql with realistic demo data:
+ *   - 6 inboxes (kept stable so admin display-name UI works)
+ *   - 100 people
+ *   - 600-900 inbound emails (varied length, varied subject, ~25% unread)
+ *   - 80-150 sent replies
+ *
+ * Run:  npx tsx seeds/generate-demo.ts
+ * Then: yarn db:seed:dev
+ */
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Reproducible RNG so re-runs give the same dataset.
+// ---------------------------------------------------------------------------
+function makeRng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+const rand = makeRng(1759);
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(rand() * arr.length)];
+}
+function pickN<T>(arr: T[], n: number): T[] {
+  const copy = [...arr];
+  const result: T[] = [];
+  while (n > 0 && copy.length) {
+    result.push(copy.splice(Math.floor(rand() * copy.length), 1)[0]);
+    n--;
+  }
+  return result;
+}
+function randInt(min: number, max: number): number {
+  return Math.floor(rand() * (max - min + 1)) + min;
+}
+function chance(p: number): boolean {
+  return rand() < p;
+}
+function sqlEscape(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+// ---------------------------------------------------------------------------
+// Inboxes
+// ---------------------------------------------------------------------------
+const INBOXES = [
+  { email: "support@example.com", display: "Support" },
+  { email: "sales@example.com", display: "Sales" },
+  { email: "hello@example.com", display: "General" },
+  { email: "billing@example.com", display: "Billing" },
+  { email: "newsletter@example.com", display: "Newsletter" },
+  { email: "notifications@example.com", display: "Notifications" },
+];
+
+// ---------------------------------------------------------------------------
+// Name + domain pools (stay short — total combos are still huge)
+// ---------------------------------------------------------------------------
+const FIRST_NAMES = [
+  "Alice",
+  "Bob",
+  "Carla",
+  "Dan",
+  "Eve",
+  "Frank",
+  "Grace",
+  "Henry",
+  "Iris",
+  "Jack",
+  "Kim",
+  "Leo",
+  "Maya",
+  "Noah",
+  "Olivia",
+  "Pavel",
+  "Quinn",
+  "Rosa",
+  "Sam",
+  "Tara",
+  "Uma",
+  "Victor",
+  "Wendy",
+  "Xavier",
+  "Yuki",
+  "Zane",
+  "Amir",
+  "Bella",
+  "Caleb",
+  "Diana",
+  "Emil",
+  "Faye",
+  "Gabriel",
+  "Hana",
+  "Idris",
+  "Jana",
+  "Karim",
+  "Lena",
+  "Marcus",
+  "Nadia",
+  "Owen",
+  "Priya",
+  "Rafael",
+  "Sofia",
+  "Tariq",
+  "Vera",
+  "Will",
+  "Yara",
+  "Zaid",
+  "Anya",
+  "Bruno",
+  "Chloe",
+  "Diego",
+  "Elsa",
+  "Felix",
+  "Gemma",
+  "Hugo",
+  "Indra",
+  "Julian",
+  "Kira",
+  "Lucas",
+  "Mira",
+  "Nico",
+  "Omar",
+  "Petra",
+  "Reina",
+  "Said",
+  "Tina",
+  "Ulrich",
+  "Vivi",
+  "Wei",
+  "Xiu",
+  "Yannis",
+  "Zara",
+];
+const LAST_NAMES = [
+  "Nguyen",
+  "Martinez",
+  "Schmidt",
+  "Park",
+  "Johansson",
+  "Liu",
+  "Okafor",
+  "Wayne",
+  "Chen",
+  "Prince",
+  "Novak",
+  "Halat",
+  "Patel",
+  "Tanaka",
+  "Kowalski",
+  "Singh",
+  "Rossi",
+  "Garcia",
+  "Khan",
+  "Müller",
+  "Andersson",
+  "Iyer",
+  "Reyes",
+  "Diaz",
+  "Cohen",
+  "Abadi",
+  "Fischer",
+  "Yamamoto",
+  "O'Brien",
+  "Walsh",
+  "Cruz",
+  "Brennan",
+  "Yusupov",
+  "Santos",
+  "Petrov",
+  "Nakamura",
+  "Kim",
+  "Bauer",
+  "Volkov",
+  "Hassan",
+  "Ferreira",
+  "Lindgren",
+  "Mendez",
+  "Sato",
+];
+const DOMAINS = [
+  "acme.co",
+  "globex.io",
+  "initech.dev",
+  "hooli.com",
+  "piedpiper.ai",
+  "soylent.corp",
+  "dundermifflin.com",
+  "wayne.enterprises",
+  "northwind.co",
+  "stark.industries",
+  "umbrella.med",
+  "tyrell.tech",
+  "weyland.space",
+  "aperture.science",
+  "vandelay.imp",
+  "orbis.health",
+];
+
+// ---------------------------------------------------------------------------
+// Email content libraries — keyed by inbox so subjects/bodies match the
+// channel's character.
+// ---------------------------------------------------------------------------
+type Snippet = { subject: string; body: string };
+
+const SUPPORT_SNIPPETS: Snippet[] = [
+  {
+    subject: "Trouble logging in on mobile",
+    body: "I can't log into the iOS app after the latest update — it just hangs on the spinner. Desktop works fine. Tried reinstalling, no change.",
+  },
+  {
+    subject: "Webhook deliveries failing intermittently",
+    body: "We're seeing 504s on about 3% of webhook deliveries to our /events endpoint. It's been happening for the past 48 hours. Sample request IDs attached.",
+  },
+  {
+    subject: "API rate limits unclear",
+    body: "What's the per-minute rate limit for the /messages endpoint on the Pro plan? The docs mention 60/s but our 429s suggest something lower.",
+  },
+  {
+    subject: "How do I rotate an API key without downtime?",
+    body: "Looking for the recommended way to rotate keys in production. Is there a grace-period overlap, or do I need to coordinate the swap myself?",
+  },
+  {
+    subject: "Re: Trouble logging in on mobile",
+    body: "That worked — thank you! Force-quitting and reinstalling fixed it.",
+  },
+  {
+    subject: "Re: Webhook deliveries failing intermittently",
+    body: "Tried the retry flag — still seeing failures on the same three endpoints. Latest IDs in the next message.",
+  },
+  {
+    subject: "Bug: timestamps off by one hour after DST",
+    body: "Since Sunday all our scheduled sends are firing an hour late. Looks like a TZ issue on your side. Account ID acme-7821.",
+  },
+  {
+    subject: "Export taking 30+ minutes",
+    body: "The CSV export for our last 90 days is timing out. Anything we can do about this? It used to take ~3 minutes.",
+  },
+  {
+    subject: "Two-factor backup codes not working",
+    body: "I lost my phone and the backup codes I saved aren't being accepted. What's the recovery path?",
+  },
+  {
+    subject: "Outbound mail going to spam in Gmail",
+    body: "We set up DKIM and SPF as the docs suggested but our sends still land in spam at most Gmail addresses. DMARC is also passing.",
+  },
+  {
+    subject: "Edge case in the threading logic",
+    body: "Replies from the same person to different inboxes are getting threaded together. Our customers think we're cross-routing emails internally.",
+  },
+  {
+    subject: "Quick question on retention",
+    body: "How long are messages retained on the Free plan? Want to make sure we don't lose anything before upgrading.",
+  },
+];
+
+const SALES_SNIPPETS: Snippet[] = [
+  {
+    subject: "Enterprise pricing question",
+    body: "We're evaluating a few tools for our team of 50. Could you share enterprise pricing and whether SSO + audit logs are included?",
+  },
+  {
+    subject: "Demo request — multi-region rollout",
+    body: "Could we get a 30-min walkthrough? We're rolling out to teams in the EU and US and need to understand data residency options.",
+  },
+  {
+    subject: "RFP for procurement",
+    body: "Attached is our RFP. Looking for responses by end of month. Happy to clarify any sections — let me know.",
+  },
+  {
+    subject: "Quote follow-up",
+    body: "Thanks for the quote last week. I shared it internally; we have a few clarifying questions on the implementation timeline.",
+  },
+  {
+    subject: "Annual contract — need invoice in EUR",
+    body: "We're ready to sign on an annual plan but our finance team needs the invoice in EUR rather than USD. Is that supported?",
+  },
+  {
+    subject: "Considering a switch from Front",
+    body: "Hey — we're looking at moving off Front for our support team. Curious how migration goes; we have ~18 months of history.",
+  },
+  {
+    subject: "Discount for nonprofits?",
+    body: "We're a registered 501(c)(3). Is there any nonprofit discount available?",
+  },
+  {
+    subject: "How does seat counting work for shared inboxes?",
+    body: "If five reps share a support@ inbox, do we pay for one seat or five? The pricing page wasn't clear.",
+  },
+  {
+    subject: "Need a longer trial",
+    body: "The default 14-day trial is too short for our procurement cycle. Could we get an extension to 45 days?",
+  },
+];
+
+const BILLING_SNIPPETS: Snippet[] = [
+  {
+    subject: "Invoice for September seems wrong",
+    body: "Our September invoice is $200 over the usual amount. Can you look into the line items?",
+  },
+  {
+    subject: "Switching from monthly to annual",
+    body: "Want to move our subscription to annual billing. Will the prorated credit just roll forward?",
+  },
+  {
+    subject: "Update payment method",
+    body: "Old card expired and the auto-update didn't kick in. New card is in the portal — please re-run the failed charge when convenient.",
+  },
+  {
+    subject: "VAT number for invoice",
+    body: "Could you add our VAT number (DE123456789) to upcoming invoices? Our finance team can't process them without it.",
+  },
+  {
+    subject: "Refund request",
+    body: "We accidentally subscribed twice last month. Could one of the charges be refunded?",
+  },
+  {
+    subject: "Receipts for 2025 tax filing",
+    body: "Need bulk-download of all our receipts from 2025 for tax filing. Is that exposed in the dashboard or do I have to email each time?",
+  },
+];
+
+const HELLO_SNIPPETS: Snippet[] = [
+  {
+    subject: "Quick intro",
+    body: "Hi! Just signed up — wanted to introduce ourselves. We're building a tools-for-creators app and are exploring email infrastructure.",
+  },
+  {
+    subject: "Partnership idea",
+    body: "We run a developer newsletter (~12k subs) and think there's a partnership opportunity. Open to chatting?",
+  },
+  {
+    subject: "Loving the product so far",
+    body: "Just wanted to say — the new threading view is a huge improvement. Saved us probably 40 minutes a day already.",
+  },
+  {
+    subject: "Feature request: keyboard shortcut for archive",
+    body: "Would love a keyboard shortcut to archive a thread. Right now I have to click the menu every time.",
+  },
+  {
+    subject: "Feedback after first week",
+    body: "We've been using it for a week. Two things slowing us down: the search is fuzzy in unhelpful ways, and there's no way to bulk-mark as read.",
+  },
+];
+
+const NEWSLETTER_SNIPPETS: Snippet[] = [
+  {
+    subject: "Weekly digest",
+    body: "Top three threads this week: Carla's webhook saga (resolved), Bob's enterprise quote (in progress), Alice's mobile bug (closed).",
+  },
+  {
+    subject: "Product update — chat mode",
+    body: "We're rolling out chat-style rendering for support inboxes. If you want it on by default, ping us.",
+  },
+  {
+    subject: "Office hours Friday",
+    body: "Holding open office hours this Friday at 11am PT. Come ask anything — we'll be in the Slack #saasmail channel.",
+  },
+  {
+    subject: "Outage post-mortem",
+    body: "Yesterday's 23-minute outage was caused by a bad config push. Post-mortem here. Sorry for the trouble.",
+  },
+];
+
+const NOTIFICATIONS_SNIPPETS: Snippet[] = [
+  {
+    subject: "[CI] Build failed on main",
+    body: "Build #4521 failed: \"Cannot find module '@/lib/foo'\". Triggered by commit 8a3f2b9.",
+  },
+  {
+    subject: "Domain verification successful",
+    body: "Your domain mail.acme.co is now verified. SPF, DKIM, and DMARC checks all passing.",
+  },
+  {
+    subject: "Daily summary — 14 unread",
+    body: "You have 14 unread messages across 4 inboxes. Oldest is 2 days old.",
+  },
+  {
+    subject: "Webhook delivery quota at 80%",
+    body: "You've used 80% of your monthly webhook quota. Upgrade or wait until the cycle resets on the 1st.",
+  },
+  {
+    subject: "Login from new device",
+    body: "A new sign-in was detected from Chrome on macOS, San Francisco. If this wasn't you, rotate your password.",
+  },
+  {
+    subject: "Password expires in 7 days",
+    body: "Your account password is set to expire on Nov 12. Update it from settings to avoid being locked out.",
+  },
+];
+
+const INBOX_SNIPPETS: Record<string, Snippet[]> = {
+  "support@example.com": SUPPORT_SNIPPETS,
+  "sales@example.com": SALES_SNIPPETS,
+  "billing@example.com": BILLING_SNIPPETS,
+  "hello@example.com": HELLO_SNIPPETS,
+  "newsletter@example.com": NEWSLETTER_SNIPPETS,
+  "notifications@example.com": NOTIFICATIONS_SNIPPETS,
+};
+
+// Padding text used to inflate "long" emails so we have a real range
+// of message lengths in the dataset (short / medium / long mix).
+const FILLER_LINES = [
+  "For context: we kicked off this initiative back in Q2 and have been iterating since.",
+  "Happy to jump on a call if it's easier than going back and forth in email.",
+  "I've also CC'd our team lead in case anyone else needs to weigh in.",
+  "Below is a more detailed breakdown of what we tried and the order we tried it in.",
+  "We can be flexible on timing — let us know what works on your end.",
+  "Just so you have the full picture, here's how this fits into our broader rollout plan.",
+  "I attached the relevant logs / screenshots / configs — let me know if you can't open them.",
+  "We're not blocked yet but it's becoming a recurring distraction during planning.",
+  "If it helps narrow things down, we can repro it deterministically on a fresh account too.",
+  "Open to suggestions on how to approach this differently if our framing is off.",
+];
+
+function inflateBody(body: string, targetWords: number): string {
+  const lines = [body];
+  while (lines.join(" ").split(/\s+/).length < targetWords) {
+    lines.push(pick(FILLER_LINES));
+  }
+  return lines.join("\n\n");
+}
+
+function bodyHtml(text: string): string {
+  return text
+    .split(/\n\n+/)
+    .map((p) => `<p>${sqlEscape(p)}</p>`)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Build people
+// ---------------------------------------------------------------------------
+interface Person {
+  id: string;
+  email: string;
+  name: string;
+  inboxes: string[]; // recipients they email
+  createdOffsetDays: number;
+}
+
+function buildPeople(count: number): Person[] {
+  const seen = new Set<string>();
+  const out: Person[] = [];
+  let i = 0;
+  while (out.length < count) {
+    const fn = pick(FIRST_NAMES);
+    const ln = pick(LAST_NAMES);
+    const dom = pick(DOMAINS);
+    const email = `${fn.toLowerCase()}.${ln.toLowerCase()}${i % 5 === 0 ? "" : ""}@${dom}`;
+    if (seen.has(email)) {
+      i++;
+      continue;
+    }
+    seen.add(email);
+    const inboxCount = chance(0.5) ? 1 : chance(0.6) ? 2 : chance(0.7) ? 3 : 4;
+    const inboxes = pickN(INBOXES, inboxCount).map((i) => i.email);
+    out.push({
+      id: `p_${out.length.toString().padStart(3, "0")}`,
+      email,
+      name: `${fn} ${ln}`,
+      inboxes,
+      createdOffsetDays: randInt(1, 60),
+    });
+    i++;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Build emails per person, per inbox
+// ---------------------------------------------------------------------------
+interface Email {
+  id: string;
+  personId: string;
+  recipient: string;
+  subject: string;
+  bodyHtml: string;
+  bodyText: string;
+  isRead: 0 | 1;
+  receivedOffsetSec: number;
+}
+
+interface SentReply {
+  id: string;
+  personId: string;
+  fromAddress: string;
+  to: string;
+  subject: string;
+  bodyHtml: string;
+  inReplyTo: string | null;
+  sentOffsetSec: number;
+}
+
+function buildEmails(people: Person[]): { emails: Email[]; sent: SentReply[] } {
+  const emails: Email[] = [];
+  const sent: SentReply[] = [];
+  let eId = 0;
+  let sId = 0;
+  for (const p of people) {
+    for (const inbox of p.inboxes) {
+      // Heavy-tailed thread length: most are 1-3, some 4-8, a few 9-15.
+      const r = rand();
+      const threadLen =
+        r < 0.55 ? randInt(1, 3) : r < 0.9 ? randInt(4, 8) : randInt(9, 15);
+      const snippets = INBOX_SNIPPETS[inbox] ?? HELLO_SNIPPETS;
+      // Pick a base subject; replies reuse "Re: <subject>".
+      const base = pick(snippets);
+      const isAutomated =
+        inbox === "newsletter@example.com" ||
+        inbox === "notifications@example.com";
+
+      for (let i = 0; i < threadLen; i++) {
+        // Spread emails across the time the person has existed (max 60 days back).
+        const maxOffsetDays = p.createdOffsetDays;
+        const offsetDays =
+          (maxOffsetDays * (threadLen - i)) / threadLen + rand() * 0.5;
+        const offsetSec = Math.floor(offsetDays * 86400) + randInt(0, 86399);
+
+        const isFirst = i === 0;
+        const subject = isFirst ? base.subject : `Re: ${base.subject}`;
+        // Body: pull a different snippet for follow-ups; vary length.
+        const snippet = isFirst ? base : pick(snippets);
+        // Length distribution: 30% short, 50% med, 20% long. Skew automated short.
+        const lengthRoll = rand();
+        const targetWords = isAutomated
+          ? randInt(15, 40)
+          : lengthRoll < 0.3
+            ? randInt(20, 45)
+            : lengthRoll < 0.8
+              ? randInt(60, 140)
+              : randInt(180, 320);
+        const text = inflateBody(snippet.body, targetWords);
+
+        // Read state: very recent emails skew unread.
+        const isRecent = offsetDays < 3;
+        const isRead: 0 | 1 = isRecent
+          ? chance(0.5)
+            ? 0
+            : 1
+          : chance(0.85)
+            ? 1
+            : 0;
+
+        emails.push({
+          id: `e_${eId.toString().padStart(4, "0")}`,
+          personId: p.id,
+          recipient: inbox,
+          subject,
+          bodyHtml: bodyHtml(text),
+          bodyText: text,
+          isRead,
+          receivedOffsetSec: offsetSec,
+        });
+        eId++;
+      }
+
+      // Sometimes seed a reply from us back to them (~30% of threads).
+      if (!isAutomated && chance(0.3)) {
+        const replyOffsetSec = randInt(1800, 86400 * 2);
+        const lastEmail = emails[emails.length - 1];
+        sent.push({
+          id: `s_${sId.toString().padStart(4, "0")}`,
+          personId: p.id,
+          fromAddress: inbox,
+          to: p.email,
+          subject: `Re: ${base.subject}`,
+          bodyHtml: bodyHtml(
+            inflateBody(
+              "Thanks for reaching out — I've looped in the right person on our side. Will follow up shortly with a more concrete answer.",
+              randInt(30, 80),
+            ),
+          ),
+          inReplyTo: lastEmail.id,
+          sentOffsetSec: Math.max(
+            lastEmail.receivedOffsetSec - replyOffsetSec,
+            60,
+          ),
+        });
+        sId++;
+      }
+    }
+  }
+  return { emails, sent };
+}
+
+// ---------------------------------------------------------------------------
+// Render SQL
+// ---------------------------------------------------------------------------
+function renderSql(): string {
+  const people = buildPeople(100);
+  const { emails, sent } = buildEmails(people);
+
+  const lines: string[] = [];
+
+  lines.push(
+    "-- AUTO-GENERATED by seeds/generate-demo.ts. Do not edit by hand.",
+  );
+  lines.push("-- Run: yarn db:seed:dev (after re-running the generator).");
+  lines.push(
+    `-- Stats: ${people.length} people, ${emails.length} emails, ${sent.length} sent replies.`,
+  );
+  lines.push("");
+  lines.push("DELETE FROM sequence_emails;");
+  lines.push("DELETE FROM sequence_enrollments;");
+  lines.push("DELETE FROM sequences;");
+  lines.push("DELETE FROM api_keys;");
+  lines.push("DELETE FROM email_templates;");
+  lines.push("DELETE FROM invitations;");
+  lines.push("DELETE FROM attachments;");
+  lines.push("DELETE FROM sent_emails;");
+  lines.push("DELETE FROM emails;");
+  lines.push("DELETE FROM people;");
+  lines.push("DELETE FROM inbox_permissions;");
+  lines.push("DELETE FROM sender_identities;");
+  lines.push("");
+
+  // Inboxes
+  lines.push(
+    "INSERT OR REPLACE INTO sender_identities (email, display_name, created_at, updated_at) VALUES",
+  );
+  lines.push(
+    INBOXES.map(
+      (i) =>
+        `  ('${i.email}', '${sqlEscape(i.display)}', CAST(strftime('%s','now') AS INTEGER), CAST(strftime('%s','now') AS INTEGER))`,
+    ).join(",\n") + ";",
+  );
+  lines.push("");
+
+  // People
+  lines.push(
+    "INSERT OR REPLACE INTO people (id, email, name, last_email_at, unread_count, total_count, created_at, updated_at) VALUES",
+  );
+  lines.push(
+    people
+      .map(
+        (p) =>
+          `  ('${p.id}', '${sqlEscape(p.email)}', '${sqlEscape(p.name)}', 0, 0, 0, (CAST(strftime('%s','now') AS INTEGER) - 86400 * ${p.createdOffsetDays}), CAST(strftime('%s','now') AS INTEGER))`,
+      )
+      .join(",\n") + ";",
+  );
+  lines.push("");
+
+  // Emails — chunk inserts so we don't blow past SQLite's statement limit.
+  const CHUNK = 50;
+  for (let off = 0; off < emails.length; off += CHUNK) {
+    const chunk = emails.slice(off, off + CHUNK);
+    lines.push(
+      "INSERT OR REPLACE INTO emails (id, person_id, recipient, subject, body_html, body_text, raw_headers, message_id, spf, dkim, dmarc, is_read, received_at, created_at) VALUES",
+    );
+    lines.push(
+      chunk
+        .map(
+          (e) =>
+            `  ('${e.id}', '${e.personId}', '${e.recipient}', '${sqlEscape(e.subject)}', '${e.bodyHtml}', '${sqlEscape(e.bodyText)}', '{}', '<${e.id}@example.test>', 'pass', 'pass', 'pass', ${e.isRead}, (CAST(strftime('%s','now') AS INTEGER) - ${e.receivedOffsetSec}), (CAST(strftime('%s','now') AS INTEGER) - ${e.receivedOffsetSec}))`,
+        )
+        .join(",\n") + ";",
+    );
+    lines.push("");
+  }
+
+  // Sent replies
+  if (sent.length > 0) {
+    for (let off = 0; off < sent.length; off += CHUNK) {
+      const chunk = sent.slice(off, off + CHUNK);
+      lines.push(
+        "INSERT OR REPLACE INTO sent_emails (id, person_id, to_address, from_address, subject, body_html, body_text, in_reply_to, status, sent_at, created_at) VALUES",
+      );
+      lines.push(
+        chunk
+          .map(
+            (s) =>
+              `  ('${s.id}', '${s.personId}', '${sqlEscape(s.to)}', '${s.fromAddress}', '${sqlEscape(s.subject)}', '${s.bodyHtml}', '${sqlEscape(s.bodyHtml.replace(/<[^>]+>/g, ""))}', ${s.inReplyTo ? `'${s.inReplyTo}'` : "NULL"}, 'sent', (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}), (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}))`,
+          )
+          .join(",\n") + ";",
+      );
+      lines.push("");
+    }
+  }
+
+  // Recompute aggregate columns on people from the emails we just inserted.
+  lines.push("UPDATE people SET");
+  lines.push(
+    "  last_email_at = COALESCE((SELECT MAX(received_at) FROM emails WHERE person_id = people.id), last_email_at),",
+  );
+  lines.push(
+    "  unread_count  = COALESCE((SELECT SUM(CASE WHEN is_read = 0 THEN 1 ELSE 0 END) FROM emails WHERE person_id = people.id), 0),",
+  );
+  lines.push(
+    "  total_count   = COALESCE((SELECT COUNT(*) FROM emails WHERE person_id = people.id), 0);",
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+const out = renderSql();
+const target = join(
+  import.meta.dirname ?? new URL(".", import.meta.url).pathname,
+  "demo.sql",
+);
+writeFileSync(target, out);
+console.log(`Wrote ${out.length.toLocaleString()} chars to ${target}`);

--- a/seeds/generate-demo.ts
+++ b/seeds/generate-demo.ts
@@ -491,6 +491,7 @@ interface SentReply {
   to: string;
   subject: string;
   bodyHtml: string;
+  bodyText: string;
   inReplyTo: string | null;
   sentOffsetSec: number;
 }
@@ -562,18 +563,18 @@ function buildEmails(people: Person[]): { emails: Email[]; sent: SentReply[] } {
       if (!isAutomated && chance(0.3)) {
         const replyOffsetSec = randInt(1800, 86400 * 2);
         const lastEmail = emails[emails.length - 1];
+        const replyText = inflateBody(
+          "Thanks for reaching out — I've looped in the right person on our side. Will follow up shortly with a more concrete answer.",
+          randInt(30, 80),
+        );
         sent.push({
           id: `s_${sId.toString().padStart(4, "0")}`,
           personId: p.id,
           fromAddress: inbox,
           to: p.email,
           subject: `Re: ${base.subject}`,
-          bodyHtml: bodyHtml(
-            inflateBody(
-              "Thanks for reaching out — I've looped in the right person on our side. Will follow up shortly with a more concrete answer.",
-              randInt(30, 80),
-            ),
-          ),
+          bodyHtml: bodyHtml(replyText),
+          bodyText: replyText,
           inReplyTo: lastEmail.id,
           sentOffsetSec: Math.max(
             lastEmail.receivedOffsetSec - replyOffsetSec,
@@ -673,7 +674,7 @@ function renderSql(): string {
         chunk
           .map(
             (s) =>
-              `  ('${s.id}', '${s.personId}', '${sqlEscape(s.to)}', '${s.fromAddress}', '${sqlEscape(s.subject)}', '${s.bodyHtml}', '${sqlEscape(s.bodyHtml.replace(/<[^>]+>/g, ""))}', ${s.inReplyTo ? `'${s.inReplyTo}'` : "NULL"}, 'sent', (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}), (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}))`,
+              `  ('${s.id}', '${s.personId}', '${sqlEscape(s.to)}', '${s.fromAddress}', '${sqlEscape(s.subject)}', '${s.bodyHtml}', '${sqlEscape(s.bodyText)}', ${s.inReplyTo ? `'${s.inReplyTo}'` : "NULL"}, 'sent', (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}), (CAST(strftime('%s','now') AS INTEGER) - ${s.sentOffsetSec}))`,
           )
           .join(",\n") + ";",
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ import InviteAcceptPage from "@/pages/InviteAcceptPage";
 import AdminUsersPage from "@/pages/AdminUsersPage";
 import ApiKeysPage from "@/pages/ApiKeysPage";
 import DashboardLayout from "@/components/DashboardLayout";
+import PublicLayout from "@/components/PublicLayout";
+import TermsPage from "@/pages/TermsPage";
+import PrivacyPage from "@/pages/PrivacyPage";
 import SequencesPage from "@/pages/SequencesPage";
 import SequenceDetailPage from "@/pages/SequenceDetailPage";
 import SequenceEditorPage from "@/pages/SequenceEditorPage";
@@ -111,11 +114,17 @@ function App() {
         <BrowserRouter>
           <NotificationClickListener />
           <Routes>
-            {/* Public routes */}
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/onboarding" element={<OnboardingPage />} />
-            <Route path="/invite/:token" element={<InviteAcceptPage />} />
-            <Route path="/setup-passkey" element={<SetupPasskeyPage />} />
+            {/* Public routes — shared dark backdrop + footer shell */}
+            <Route element={<PublicLayout />}>
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/onboarding" element={<OnboardingPage />} />
+              <Route path="/invite/:token" element={<InviteAcceptPage />} />
+              <Route path="/setup-passkey" element={<SetupPasskeyPage />} />
+            </Route>
+
+            {/* Public legal pages — light readable layout, no auth */}
+            <Route path="/terms" element={<TermsPage />} />
+            <Route path="/privacy" element={<PrivacyPage />} />
 
             {/* Authenticated routes with shared layout */}
             <Route element={<AuthGuard />}>

--- a/src/components/AdminInboxTable.tsx
+++ b/src/components/AdminInboxTable.tsx
@@ -7,8 +7,6 @@ import {
   Trash2,
   X,
   Loader2,
-  Pencil,
-  Check,
 } from "lucide-react";
 import {
   createInbox,
@@ -24,23 +22,19 @@ import { cn } from "@/lib/utils";
 
 /**
  * Admin "Inboxes" table. Real table layout with bulk select + bulk
- * actions, inline display-name editing, mode toggle per row, and a
- * collapsible member-assignment popover per row.
+ * actions, inline display-name editing (blur-to-save), mode toggle
+ * per row, and inline member-assignment chips.
  */
 export default function AdminInboxTable() {
   const [inboxes, setInboxes] = useState<AdminInbox[]>([]);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
-  const [createOpen, setCreateOpen] = useState(false);
   const [newEmail, setNewEmail] = useState("");
   const [newDisplayName, setNewDisplayName] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [editingName, setEditingName] = useState<string | null>(null);
-  const [editingValue, setEditingValue] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
-  const [memberPopover, setMemberPopover] = useState<string | null>(null);
 
   useEffect(() => {
     Promise.all([fetchAdminInboxes(), fetchAdminUsers()])
@@ -102,7 +96,6 @@ export default function AdminInboxTable() {
       );
       setNewEmail("");
       setNewDisplayName("");
-      setCreateOpen(false);
     } catch (err) {
       setCreateError(
         err instanceof Error ? err.message : "Failed to create inbox",
@@ -114,10 +107,7 @@ export default function AdminInboxTable() {
 
   async function commitName(inbox: AdminInbox, value: string) {
     const next = value.trim() === "" ? null : value.trim();
-    if (next === inbox.displayName) {
-      setEditingName(null);
-      return;
-    }
+    if (next === inbox.displayName) return;
     const res = await updateInboxSettings(inbox.email, { displayName: next });
     setInboxes((prev) =>
       prev.map((r) =>
@@ -126,7 +116,6 @@ export default function AdminInboxTable() {
           : r,
       ),
     );
-    setEditingName(null);
   }
 
   async function handleSetMode(inbox: AdminInbox, next: "thread" | "chat") {
@@ -213,122 +202,99 @@ export default function AdminInboxTable() {
 
   return (
     <div className="space-y-4">
-      {/* Top bar — Create button + (when armed) bulk action bar */}
-      <div className="flex flex-wrap items-center gap-2">
-        {selected.size === 0 ? (
+      {/* Create form — always visible */}
+      <form
+        onSubmit={handleCreate}
+        className="rounded-[8px] bg-card p-4 ring-1 ring-border"
+      >
+        <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+          Create inbox
+        </div>
+        <div className="flex flex-col gap-2 md:flex-row">
+          <input
+            type="email"
+            required
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.currentTarget.value)}
+            placeholder="inbox@example.com"
+            data-testid="inbox-create-email"
+            className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+          />
+          <input
+            type="text"
+            value={newDisplayName}
+            onChange={(e) => setNewDisplayName(e.currentTarget.value)}
+            placeholder="Display name (optional)"
+            data-testid="inbox-create-display-name"
+            className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+          />
           <button
-            onClick={() => setCreateOpen((v) => !v)}
-            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
+            type="submit"
+            data-testid="inbox-create-button"
+            disabled={creating || newEmail.trim() === ""}
+            className="inline-flex h-9 items-center gap-1.5 rounded-[6px] bg-text-primary px-4 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90 disabled:opacity-50"
           >
             <Plus size={14} />
-            New inbox
+            {creating ? "Creating…" : "Create"}
           </button>
-        ) : (
-          <div className="flex flex-wrap items-center gap-2 rounded-[8px] bg-text-primary px-3 py-2 text-sm text-white shadow-lg ring-1 ring-text-primary/20">
-            <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-white/15 px-2 text-xs font-bold tabular-nums">
-              {selected.size}
-            </span>
-            <span className="font-medium">selected</span>
-
-            <span className="mx-1 h-4 w-px bg-white/15" aria-hidden />
-
-            <button
-              onClick={() => handleBulkSetMode("thread")}
-              disabled={bulkBusy}
-              className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
-            >
-              <MessageSquare size={12} />
-              Thread mode
-            </button>
-            <button
-              onClick={() => handleBulkSetMode("chat")}
-              disabled={bulkBusy}
-              className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
-            >
-              <MessageCircle size={12} />
-              Chat mode
-            </button>
-            <button
-              onClick={() => handleDelete(Array.from(selected))}
-              disabled={bulkBusy}
-              className="inline-flex items-center gap-1.5 rounded-[6px] bg-red-500/[0.16] px-2.5 py-1.5 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/[0.25] disabled:opacity-50"
-            >
-              {bulkBusy ? (
-                <Loader2 size={12} className="animate-spin" />
-              ) : (
-                <Trash2 size={12} />
-              )}
-              Delete
-            </button>
-
-            <button
-              onClick={clearSelection}
-              className="ml-auto inline-flex items-center gap-1 rounded-[6px] px-2 py-1.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.08] hover:text-white"
-              aria-label="Clear selection"
-            >
-              <X size={12} />
-              Clear
-            </button>
-          </div>
+        </div>
+        {createError && (
+          <div className="mt-2 text-xs text-destructive">{createError}</div>
         )}
-      </div>
+      </form>
 
-      {/* Inline create form */}
-      {createOpen && (
-        <form
-          onSubmit={handleCreate}
-          className="rounded-[8px] bg-card p-4 ring-1 ring-border"
-        >
-          <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
-            Create inbox
-          </div>
-          <div className="flex flex-col gap-2 md:flex-row">
-            <input
-              type="email"
-              required
-              value={newEmail}
-              onChange={(e) => setNewEmail(e.currentTarget.value)}
-              placeholder="inbox@example.com"
-              data-testid="inbox-create-email"
-              className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
-            />
-            <input
-              type="text"
-              value={newDisplayName}
-              onChange={(e) => setNewDisplayName(e.currentTarget.value)}
-              placeholder="Display name (optional)"
-              data-testid="inbox-create-display-name"
-              className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  setCreateOpen(false);
-                  setCreateError(null);
-                }}
-                className="rounded-[6px] border border-border px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                data-testid="inbox-create-button"
-                disabled={creating || newEmail.trim() === ""}
-                className="rounded-[6px] bg-text-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-text-primary/90 disabled:opacity-50"
-              >
-                {creating ? "Creating…" : "Create"}
-              </button>
-            </div>
-          </div>
-          {createError && (
-            <div className="mt-2 text-xs text-destructive">{createError}</div>
-          )}
-        </form>
+      {/* Bulk action bar — visible when selection ≥ 1 */}
+      {selected.size > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-[8px] bg-text-primary px-3 py-2 text-sm text-white shadow-lg ring-1 ring-text-primary/20">
+          <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-white/15 px-2 text-xs font-bold tabular-nums">
+            {selected.size}
+          </span>
+          <span className="font-medium">selected</span>
+
+          <span className="mx-1 h-4 w-px bg-white/15" aria-hidden />
+
+          <button
+            onClick={() => handleBulkSetMode("thread")}
+            disabled={bulkBusy}
+            className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
+          >
+            <MessageSquare size={12} />
+            Thread mode
+          </button>
+          <button
+            onClick={() => handleBulkSetMode("chat")}
+            disabled={bulkBusy}
+            className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
+          >
+            <MessageCircle size={12} />
+            Chat mode
+          </button>
+          <button
+            onClick={() => handleDelete(Array.from(selected))}
+            disabled={bulkBusy}
+            className="inline-flex items-center gap-1.5 rounded-[6px] bg-red-500/[0.16] px-2.5 py-1.5 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/[0.25] disabled:opacity-50"
+          >
+            {bulkBusy ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Trash2 size={12} />
+            )}
+            Delete
+          </button>
+
+          <button
+            onClick={clearSelection}
+            className="ml-auto inline-flex items-center gap-1 rounded-[6px] px-2 py-1.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.08] hover:text-white"
+            aria-label="Clear selection"
+          >
+            <X size={12} />
+            Clear
+          </button>
+        </div>
       )}
 
       {/* Empty state */}
-      {inboxes.length === 0 && !createOpen && (
+      {inboxes.length === 0 && (
         <div className="rounded-[8px] bg-card p-10 text-center ring-1 ring-border">
           <span className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet/10">
             <InboxIcon size={20} style={{ color: "#7c5cfc" }} />
@@ -336,16 +302,9 @@ export default function AdminInboxTable() {
           <p className="mb-1 text-sm font-medium text-text-primary">
             No inboxes yet
           </p>
-          <p className="mb-4 text-xs font-light text-text-tertiary">
-            Create your first inbox or wait for inbound email.
+          <p className="text-xs font-light text-text-tertiary">
+            Use the form above to create your first inbox.
           </p>
-          <button
-            onClick={() => setCreateOpen(true)}
-            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
-          >
-            <Plus size={14} />
-            New inbox
-          </button>
         </div>
       )}
 
@@ -375,7 +334,6 @@ export default function AdminInboxTable() {
               <tbody>
                 {inboxes.map((inbox) => {
                   const isSelected = selected.has(inbox.email);
-                  const isEditing = editingName === inbox.email;
                   return (
                     <tr
                       key={inbox.email}
@@ -411,67 +369,12 @@ export default function AdminInboxTable() {
                         </div>
                       </td>
 
-                      {/* Display name (inline edit) */}
+                      {/* Display name (inline editable, blur to save) */}
                       <td className="px-3 py-2.5">
-                        {isEditing ? (
-                          <div className="flex items-center gap-1">
-                            <input
-                              autoFocus
-                              value={editingValue}
-                              onChange={(e) => setEditingValue(e.target.value)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter") {
-                                  e.preventDefault();
-                                  commitName(inbox, editingValue);
-                                } else if (e.key === "Escape") {
-                                  setEditingName(null);
-                                }
-                              }}
-                              data-testid="inbox-display-name-input"
-                              className="h-8 w-full rounded-[6px] border border-border bg-card px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
-                            />
-                            <button
-                              type="button"
-                              onClick={() => commitName(inbox, editingValue)}
-                              className="flex h-7 w-7 items-center justify-center rounded-[5px] text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-                              aria-label="Save"
-                            >
-                              <Check size={14} />
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setEditingName(null)}
-                              className="flex h-7 w-7 items-center justify-center rounded-[5px] text-text-tertiary hover:bg-bg-muted hover:text-text-secondary"
-                              aria-label="Cancel"
-                            >
-                              <X size={14} />
-                            </button>
-                          </div>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setEditingName(inbox.email);
-                              setEditingValue(inbox.displayName ?? "");
-                            }}
-                            className="group/name inline-flex h-7 max-w-full items-center gap-1.5 rounded-[5px] px-2 text-left text-sm transition-colors hover:bg-bg-muted"
-                          >
-                            <span
-                              className={cn(
-                                "truncate",
-                                inbox.displayName
-                                  ? "text-text-primary"
-                                  : "font-light italic text-text-tertiary",
-                              )}
-                            >
-                              {inbox.displayName || "Set a name…"}
-                            </span>
-                            <Pencil
-                              size={11}
-                              className="shrink-0 text-text-tertiary opacity-0 transition-opacity group-hover/name:opacity-100"
-                            />
-                          </button>
-                        )}
+                        <DisplayNameInput
+                          inbox={inbox}
+                          onCommit={(v) => commitName(inbox, v)}
+                        />
                       </td>
 
                       {/* Mode */}
@@ -505,22 +408,46 @@ export default function AdminInboxTable() {
                         </div>
                       </td>
 
-                      {/* Members */}
+                      {/* Members — inline chip toggles */}
                       <td className="px-3 py-2.5">
-                        <MemberCell
-                          inbox={inbox}
-                          members={members}
-                          open={memberPopover === inbox.email}
-                          onOpen={() =>
-                            setMemberPopover(
-                              memberPopover === inbox.email
-                                ? null
-                                : inbox.email,
-                            )
-                          }
-                          onClose={() => setMemberPopover(null)}
-                          onToggle={(uid) => handleToggleAssignment(inbox, uid)}
-                        />
+                        {members.length === 0 ? (
+                          <span className="text-xs font-light italic text-text-tertiary">
+                            Admins only
+                          </span>
+                        ) : (
+                          <div className="flex flex-wrap items-center gap-1">
+                            {members.map((u) => {
+                              const on = inbox.assignedUserIds.includes(u.id);
+                              return (
+                                <button
+                                  key={u.id}
+                                  type="button"
+                                  data-testid="inbox-member-toggle"
+                                  data-user-id={u.id}
+                                  data-assigned={on}
+                                  onClick={() =>
+                                    handleToggleAssignment(inbox, u.id)
+                                  }
+                                  title={u.email}
+                                  className={cn(
+                                    "inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] font-medium transition-colors",
+                                    on
+                                      ? "border-violet/30 bg-violet/10 text-violet"
+                                      : "border-border bg-bg-muted/40 text-text-tertiary hover:border-text-primary/30 hover:text-text-secondary",
+                                  )}
+                                  style={on ? { color: "#7c5cfc" } : undefined}
+                                >
+                                  <span className="flex h-4 w-4 items-center justify-center rounded-full bg-current/10 text-[9px] font-semibold">
+                                    {(u.name || u.email)[0]?.toUpperCase()}
+                                  </span>
+                                  <span className="truncate max-w-[120px]">
+                                    {u.name || u.email}
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
                       </td>
 
                       {/* Actions */}
@@ -544,6 +471,40 @@ export default function AdminInboxTable() {
         </div>
       )}
     </div>
+  );
+}
+
+interface DisplayNameInputProps {
+  inbox: AdminInbox;
+  onCommit: (value: string) => Promise<void>;
+}
+function DisplayNameInput({ inbox, onCommit }: DisplayNameInputProps) {
+  const [value, setValue] = useState(inbox.displayName ?? "");
+
+  // Resync when underlying inbox displayName changes (e.g. after refresh).
+  useEffect(() => {
+    setValue(inbox.displayName ?? "");
+  }, [inbox.displayName]);
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => setValue(e.currentTarget.value)}
+      onBlur={() => onCommit(value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          (e.currentTarget as HTMLInputElement).blur();
+        } else if (e.key === "Escape") {
+          setValue(inbox.displayName ?? "");
+          (e.currentTarget as HTMLInputElement).blur();
+        }
+      }}
+      placeholder="Set a name…"
+      data-testid="inbox-display-name-input"
+      className="h-8 w-full rounded-[6px] border border-transparent bg-transparent px-2 text-sm text-text-primary placeholder:font-light placeholder:italic placeholder:text-text-tertiary hover:border-border focus:border-border focus:bg-card focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+    />
   );
 }
 
@@ -582,124 +543,5 @@ function Checkbox({ checked, onChange, ariaLabel }: CheckboxProps) {
         </svg>
       )}
     </button>
-  );
-}
-
-interface MemberCellProps {
-  inbox: AdminInbox;
-  members: AdminUser[];
-  open: boolean;
-  onOpen: () => void;
-  onClose: () => void;
-  onToggle: (userId: string) => void;
-}
-
-function MemberCell({
-  inbox,
-  members,
-  open,
-  onOpen,
-  onClose,
-  onToggle,
-}: MemberCellProps) {
-  const assigned = members.filter((m) => inbox.assignedUserIds.includes(m.id));
-  const display = assigned.slice(0, 3);
-
-  return (
-    <div className="relative inline-block">
-      <button
-        type="button"
-        onClick={onOpen}
-        className="flex h-7 items-center gap-1.5 rounded-[5px] px-2 text-xs transition-colors hover:bg-bg-muted"
-      >
-        {display.length === 0 ? (
-          <span className="font-light text-text-tertiary">
-            Admins only · assign…
-          </span>
-        ) : (
-          <>
-            <div className="flex -space-x-1">
-              {display.map((u) => (
-                <span
-                  key={u.id}
-                  title={u.name || u.email}
-                  className="flex h-5 w-5 items-center justify-center rounded-full bg-bg-muted text-[9px] font-semibold text-text-secondary ring-2 ring-card"
-                >
-                  {(u.name || u.email)[0]?.toUpperCase()}
-                </span>
-              ))}
-            </div>
-            <span className="text-text-secondary">
-              {assigned.length} member{assigned.length !== 1 ? "s" : ""}
-            </span>
-          </>
-        )}
-      </button>
-
-      {open && (
-        <>
-          <button
-            type="button"
-            className="fixed inset-0 z-10"
-            aria-hidden
-            onClick={onClose}
-            tabIndex={-1}
-          />
-          <div className="absolute left-0 top-full z-20 mt-1 w-64 overflow-hidden rounded-[8px] border border-border bg-card py-1 shadow-lg">
-            <div className="border-b border-border px-3 py-2">
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
-                Members for {inbox.email.split("@")[0]}
-              </p>
-              <p className="mt-0.5 text-[11px] font-light text-text-tertiary">
-                Admins always have access.
-              </p>
-            </div>
-            <div className="max-h-56 overflow-y-auto smooth-scroll py-1">
-              {members.length === 0 ? (
-                <p className="px-3 py-2 text-xs font-light text-text-tertiary">
-                  No members to assign.
-                </p>
-              ) : (
-                members.map((u) => {
-                  const on = inbox.assignedUserIds.includes(u.id);
-                  return (
-                    <button
-                      key={u.id}
-                      type="button"
-                      data-testid="inbox-member-toggle"
-                      data-user-id={u.id}
-                      data-assigned={on}
-                      onClick={() => onToggle(u.id)}
-                      className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-bg-muted"
-                    >
-                      <div className="flex min-w-0 items-center gap-2">
-                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-muted text-[10px] font-semibold text-text-secondary">
-                          {(u.name || u.email)[0]?.toUpperCase()}
-                        </span>
-                        <span className="min-w-0">
-                          <span className="block truncate text-text-primary">
-                            {u.name || u.email}
-                          </span>
-                          {u.name && (
-                            <span className="block truncate text-[10px] font-light text-text-tertiary">
-                              {u.email}
-                            </span>
-                          )}
-                        </span>
-                      </div>
-                      <Checkbox
-                        checked={on}
-                        onChange={() => onToggle(u.id)}
-                        ariaLabel={`${on ? "Unassign" : "Assign"} ${u.name || u.email}`}
-                      />
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          </div>
-        </>
-      )}
-    </div>
   );
 }

--- a/src/components/AdminInboxTable.tsx
+++ b/src/components/AdminInboxTable.tsx
@@ -1,4 +1,15 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Plus,
+  Inbox as InboxIcon,
+  MessageSquare,
+  MessageCircle,
+  Trash2,
+  X,
+  Loader2,
+  Pencil,
+  Check,
+} from "lucide-react";
 import {
   createInbox,
   deleteInbox,
@@ -9,25 +20,61 @@ import {
   type AdminInbox,
   type AdminUser,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
+/**
+ * Admin "Inboxes" table. Real table layout with bulk select + bulk
+ * actions, inline display-name editing, mode toggle per row, and a
+ * collapsible member-assignment popover per row.
+ */
 export default function AdminInboxTable() {
   const [inboxes, setInboxes] = useState<AdminInbox[]>([]);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
   const [newEmail, setNewEmail] = useState("");
   const [newDisplayName, setNewDisplayName] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [memberPopover, setMemberPopover] = useState<string | null>(null);
 
   useEffect(() => {
-    Promise.all([fetchAdminInboxes(), fetchAdminUsers()]).then(([i, u]) => {
-      setInboxes(i);
-      setUsers(u);
-      setLoading(false);
-    });
+    Promise.all([fetchAdminInboxes(), fetchAdminUsers()])
+      .then(([i, u]) => {
+        setInboxes(i);
+        setUsers(u);
+      })
+      .finally(() => setLoading(false));
   }, []);
 
-  const members = users.filter((u) => u.role !== "admin");
+  const members = useMemo(
+    () => users.filter((u) => u.role !== "admin"),
+    [users],
+  );
+
+  const allSelected =
+    inboxes.length > 0 && inboxes.every((i) => selected.has(i.email));
+
+  function toggleSelected(email: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(email)) next.delete(email);
+      else next.add(email);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    setSelected(allSelected ? new Set() : new Set(inboxes.map((i) => i.email)));
+  }
+
+  function clearSelection() {
+    setSelected(new Set());
+  }
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -40,24 +87,22 @@ export default function AdminInboxTable() {
         email,
         displayName: newDisplayName.trim() || null,
       });
-      setInboxes((prev) => {
-        if (prev.some((r) => r.email === created.email)) {
-          return prev.map((r) =>
-            r.email === created.email
-              ? {
-                  ...r,
-                  displayName: created.displayName,
-                  displayMode: created.displayMode,
-                }
-              : r,
-          );
-        }
-        return [...prev, created].sort((a, b) =>
-          a.email.localeCompare(b.email),
-        );
-      });
+      setInboxes((prev) =>
+        prev.some((r) => r.email === created.email)
+          ? prev.map((r) =>
+              r.email === created.email
+                ? {
+                    ...r,
+                    displayName: created.displayName,
+                    displayMode: created.displayMode,
+                  }
+                : r,
+            )
+          : [...prev, created].sort((a, b) => a.email.localeCompare(b.email)),
+      );
       setNewEmail("");
       setNewDisplayName("");
+      setCreateOpen(false);
     } catch (err) {
       setCreateError(
         err instanceof Error ? err.message : "Failed to create inbox",
@@ -67,9 +112,12 @@ export default function AdminInboxTable() {
     }
   }
 
-  async function handleNameBlur(inbox: AdminInbox, value: string) {
+  async function commitName(inbox: AdminInbox, value: string) {
     const next = value.trim() === "" ? null : value.trim();
-    if (next === inbox.displayName) return;
+    if (next === inbox.displayName) {
+      setEditingName(null);
+      return;
+    }
     const res = await updateInboxSettings(inbox.email, { displayName: next });
     setInboxes((prev) =>
       prev.map((r) =>
@@ -78,6 +126,32 @@ export default function AdminInboxTable() {
           : r,
       ),
     );
+    setEditingName(null);
+  }
+
+  async function handleSetMode(inbox: AdminInbox, next: "thread" | "chat") {
+    if (inbox.displayMode === next) return;
+    const before = inbox.displayMode;
+    setInboxes((all) =>
+      all.map((r) =>
+        r.email === inbox.email ? { ...r, displayMode: next } : r,
+      ),
+    );
+    try {
+      const res = await updateInboxSettings(inbox.email, { displayMode: next });
+      setInboxes((all) =>
+        all.map((r) =>
+          r.email === inbox.email ? { ...r, displayMode: res.displayMode } : r,
+        ),
+      );
+    } catch (err) {
+      setInboxes((all) =>
+        all.map((r) =>
+          r.email === inbox.email ? { ...r, displayMode: before } : r,
+        ),
+      );
+      console.error("Failed to update inbox mode", err);
+    }
   }
 
   async function handleToggleAssignment(inbox: AdminInbox, userId: string) {
@@ -95,200 +169,537 @@ export default function AdminInboxTable() {
     );
   }
 
-  async function handleSetMode(inbox: AdminInbox, next: "thread" | "chat") {
-    if (inbox.displayMode === next) return;
-    // Optimistic update with rollback on error.
-    const prev = inbox.displayMode;
-    setInboxes((all) =>
-      all.map((r) =>
-        r.email === inbox.email ? { ...r, displayMode: next } : r,
-      ),
-    );
+  async function handleDelete(emails: string[]) {
+    const label =
+      emails.length === 1
+        ? `Delete inbox "${emails[0]}"?`
+        : `Delete ${emails.length} inboxes?`;
+    if (!window.confirm(`${label} This cannot be undone.`)) return;
+    setBulkBusy(true);
     try {
-      const res = await updateInboxSettings(inbox.email, { displayMode: next });
-      setInboxes((all) =>
-        all.map((r) =>
-          r.email === inbox.email ? { ...r, displayMode: res.displayMode } : r,
-        ),
-      );
-    } catch (err) {
-      setInboxes((all) =>
-        all.map((r) =>
-          r.email === inbox.email ? { ...r, displayMode: prev } : r,
-        ),
-      );
-      console.error("Failed to update inbox mode", err);
+      await Promise.all(emails.map((email) => deleteInbox(email)));
+      setInboxes((prev) => prev.filter((r) => !emails.includes(r.email)));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const e of emails) next.delete(e);
+        return next;
+      });
+    } finally {
+      setBulkBusy(false);
     }
   }
 
-  async function handleDelete(inbox: AdminInbox) {
-    if (
-      !window.confirm(`Delete inbox "${inbox.email}"? This cannot be undone.`)
-    )
-      return;
-    await deleteInbox(inbox.email);
-    setInboxes((prev) => prev.filter((r) => r.email !== inbox.email));
+  async function handleBulkSetMode(mode: "thread" | "chat") {
+    const targets = inboxes.filter(
+      (i) => selected.has(i.email) && i.displayMode !== mode,
+    );
+    if (targets.length === 0) return;
+    setBulkBusy(true);
+    setInboxes((all) =>
+      all.map((r) => (selected.has(r.email) ? { ...r, displayMode: mode } : r)),
+    );
+    try {
+      await Promise.all(
+        targets.map((t) => updateInboxSettings(t.email, { displayMode: mode })),
+      );
+    } finally {
+      setBulkBusy(false);
+    }
   }
 
   if (loading) {
-    return <p className="text-text-secondary">Loading…</p>;
-  }
-
-  const createForm = (
-    <form
-      onSubmit={handleCreate}
-      className="rounded-lg border border-border bg-white ring-1 ring-gray-200 p-4"
-    >
-      <div className="mb-2 text-xs uppercase tracking-wide text-text-tertiary">
-        Create inbox
-      </div>
-      <div className="flex flex-col gap-2 md:flex-row">
-        <input
-          type="email"
-          required
-          value={newEmail}
-          onChange={(e) => setNewEmail(e.currentTarget.value)}
-          placeholder="inbox@example.com"
-          data-testid="inbox-create-email"
-          className="flex-1 rounded bg-white ring-1 ring-gray-200 px-2 py-1 text-sm text-text-primary outline-none focus:ring-1 focus:ring-accent"
-        />
-        <input
-          type="text"
-          value={newDisplayName}
-          onChange={(e) => setNewDisplayName(e.currentTarget.value)}
-          placeholder="Display name (optional)"
-          data-testid="inbox-create-display-name"
-          className="flex-1 rounded bg-white ring-1 ring-gray-200 px-2 py-1 text-sm text-text-primary outline-none focus:ring-1 focus:ring-accent"
-        />
-        <button
-          type="submit"
-          data-testid="inbox-create-button"
-          disabled={creating || newEmail.trim() === ""}
-          className="rounded bg-accent px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
-        >
-          {creating ? "Creating…" : "Create"}
-        </button>
-      </div>
-      {createError && (
-        <div className="mt-2 text-xs text-red-600">{createError}</div>
-      )}
-    </form>
-  );
-
-  if (inboxes.length === 0) {
-    return (
-      <div className="space-y-6">
-        {createForm}
-        <p className="text-text-secondary">
-          No inboxes yet. Once you receive email or create one above, inboxes
-          will appear here.
-        </p>
-      </div>
-    );
+    return <p className="text-sm font-light text-text-tertiary">Loading…</p>;
   }
 
   return (
-    <div className="space-y-6">
-      {createForm}
-      {inboxes.map((inbox) => (
-        <div
-          key={inbox.email}
-          data-testid="inbox-row"
-          data-inbox-email={inbox.email}
-          className="rounded-lg border border-border bg-white ring-1 ring-gray-200 p-4"
-        >
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="flex-1">
-              <div className="text-sm font-medium text-text-primary">
-                {inbox.email}
-              </div>
-              <input
-                type="text"
-                defaultValue={inbox.displayName ?? ""}
-                placeholder="Display name (optional)"
-                onBlur={(e) => handleNameBlur(inbox, e.currentTarget.value)}
-                data-testid="inbox-display-name-input"
-                className="mt-1 w-full rounded bg-white ring-1 ring-gray-200 px-2 py-1 text-sm text-text-primary outline-none focus:ring-1 focus:ring-accent"
-              />
-            </div>
+    <div className="space-y-4">
+      {/* Top bar — Create button + (when armed) bulk action bar */}
+      <div className="flex flex-wrap items-center gap-2">
+        {selected.size === 0 ? (
+          <button
+            onClick={() => setCreateOpen((v) => !v)}
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
+          >
+            <Plus size={14} />
+            New inbox
+          </button>
+        ) : (
+          <div className="flex flex-wrap items-center gap-2 rounded-[8px] bg-text-primary px-3 py-2 text-sm text-white shadow-lg ring-1 ring-text-primary/20">
+            <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-white/15 px-2 text-xs font-bold tabular-nums">
+              {selected.size}
+            </span>
+            <span className="font-medium">selected</span>
+
+            <span className="mx-1 h-4 w-px bg-white/15" aria-hidden />
+
             <button
-              type="button"
-              data-testid="inbox-delete-button"
-              onClick={() => handleDelete(inbox)}
-              className="self-start rounded px-2 py-1 text-xs text-red-500 hover:bg-red-50"
-              aria-label={`Delete inbox ${inbox.email}`}
+              onClick={() => handleBulkSetMode("thread")}
+              disabled={bulkBusy}
+              className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
             >
+              <MessageSquare size={12} />
+              Thread mode
+            </button>
+            <button
+              onClick={() => handleBulkSetMode("chat")}
+              disabled={bulkBusy}
+              className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:opacity-50"
+            >
+              <MessageCircle size={12} />
+              Chat mode
+            </button>
+            <button
+              onClick={() => handleDelete(Array.from(selected))}
+              disabled={bulkBusy}
+              className="inline-flex items-center gap-1.5 rounded-[6px] bg-red-500/[0.16] px-2.5 py-1.5 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/[0.25] disabled:opacity-50"
+            >
+              {bulkBusy ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Trash2 size={12} />
+              )}
               Delete
             </button>
+
+            <button
+              onClick={clearSelection}
+              className="ml-auto inline-flex items-center gap-1 rounded-[6px] px-2 py-1.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.08] hover:text-white"
+              aria-label="Clear selection"
+            >
+              <X size={12} />
+              Clear
+            </button>
           </div>
-          <div className="mt-3">
-            <div className="mb-1 text-xs uppercase tracking-wide text-text-tertiary">
-              Mode
-            </div>
-            <div className="inline-flex rounded-md border border-border overflow-hidden">
-              {(["thread", "chat"] as const).map((m) => {
-                const active = inbox.displayMode === m;
-                return (
-                  <button
-                    key={m}
-                    type="button"
-                    data-testid="inbox-mode-toggle"
-                    data-mode={m}
-                    data-active={active}
-                    onClick={() => handleSetMode(inbox, m)}
-                    className={`px-3 py-1 text-xs font-medium ${
-                      active
-                        ? "bg-accent text-white"
-                        : "bg-white text-text-secondary hover:bg-bg-muted"
-                    }`}
-                    aria-pressed={active}
-                  >
-                    {m === "thread" ? "Thread" : "Chat"}
-                  </button>
-                );
-              })}
-            </div>
-            <div className="mt-1 text-xs text-text-tertiary">
-              Chat mode shows the last 5 messages as bubbles with an inline
-              reply.
+        )}
+      </div>
+
+      {/* Inline create form */}
+      {createOpen && (
+        <form
+          onSubmit={handleCreate}
+          className="rounded-[8px] bg-card p-4 ring-1 ring-border"
+        >
+          <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+            Create inbox
+          </div>
+          <div className="flex flex-col gap-2 md:flex-row">
+            <input
+              type="email"
+              required
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.currentTarget.value)}
+              placeholder="inbox@example.com"
+              data-testid="inbox-create-email"
+              className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+            />
+            <input
+              type="text"
+              value={newDisplayName}
+              onChange={(e) => setNewDisplayName(e.currentTarget.value)}
+              placeholder="Display name (optional)"
+              data-testid="inbox-create-display-name"
+              className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setCreateOpen(false);
+                  setCreateError(null);
+                }}
+                className="rounded-[6px] border border-border px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                data-testid="inbox-create-button"
+                disabled={creating || newEmail.trim() === ""}
+                className="rounded-[6px] bg-text-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-text-primary/90 disabled:opacity-50"
+              >
+                {creating ? "Creating…" : "Create"}
+              </button>
             </div>
           </div>
-          <div className="mt-4">
-            <div className="mb-2 text-xs uppercase tracking-wide text-text-tertiary">
-              Members
-            </div>
-            <div className="mb-2 text-xs text-text-secondary">
-              Admins have access to every inbox automatically.
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {members.map((u) => {
-                const on = inbox.assignedUserIds.includes(u.id);
-                return (
-                  <button
-                    key={u.id}
-                    data-testid="inbox-member-toggle"
-                    data-user-id={u.id}
-                    data-assigned={on}
-                    onClick={() => handleToggleAssignment(inbox, u.id)}
-                    className={`rounded-full px-3 py-1 text-xs ${
-                      on
-                        ? "bg-accent text-white"
-                        : "bg-bg-muted text-text-secondary"
-                    }`}
-                  >
-                    {u.name || u.email}
-                  </button>
-                );
-              })}
-              {members.length === 0 && (
-                <span className="text-xs text-text-tertiary">
-                  No members to assign.
+          {createError && (
+            <div className="mt-2 text-xs text-destructive">{createError}</div>
+          )}
+        </form>
+      )}
+
+      {/* Empty state */}
+      {inboxes.length === 0 && !createOpen && (
+        <div className="rounded-[8px] bg-card p-10 text-center ring-1 ring-border">
+          <span className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet/10">
+            <InboxIcon size={20} style={{ color: "#7c5cfc" }} />
+          </span>
+          <p className="mb-1 text-sm font-medium text-text-primary">
+            No inboxes yet
+          </p>
+          <p className="mb-4 text-xs font-light text-text-tertiary">
+            Create your first inbox or wait for inbound email.
+          </p>
+          <button
+            onClick={() => setCreateOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
+          >
+            <Plus size={14} />
+            New inbox
+          </button>
+        </div>
+      )}
+
+      {/* Table */}
+      {inboxes.length > 0 && (
+        <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="overflow-auto smooth-scroll">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-bg-subtle/40">
+                <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+                  <th className="w-10 px-4 py-2.5">
+                    <Checkbox
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                      ariaLabel="Select all inboxes"
+                    />
+                  </th>
+                  <th className="px-3 py-2.5 font-semibold">Address</th>
+                  <th className="px-3 py-2.5 font-semibold">Display name</th>
+                  <th className="px-3 py-2.5 font-semibold">Mode</th>
+                  <th className="px-3 py-2.5 font-semibold">Members</th>
+                  <th className="w-16 px-3 py-2.5 text-right font-semibold">
+                    {/* actions */}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {inboxes.map((inbox) => {
+                  const isSelected = selected.has(inbox.email);
+                  const isEditing = editingName === inbox.email;
+                  return (
+                    <tr
+                      key={inbox.email}
+                      data-testid="inbox-row"
+                      data-inbox-email={inbox.email}
+                      className={cn(
+                        "border-b border-border/60 transition-colors",
+                        isSelected
+                          ? "bg-text-primary/[0.04]"
+                          : "hover:bg-text-primary/[0.02]",
+                      )}
+                    >
+                      <td className="w-10 px-4 py-2.5">
+                        <Checkbox
+                          checked={isSelected}
+                          onChange={() => toggleSelected(inbox.email)}
+                          ariaLabel={`Select ${inbox.email}`}
+                        />
+                      </td>
+
+                      {/* Address */}
+                      <td className="px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px] bg-bg-muted">
+                            <InboxIcon
+                              size={12}
+                              className="text-text-tertiary"
+                            />
+                          </span>
+                          <span className="truncate font-mono text-xs text-text-primary">
+                            {inbox.email}
+                          </span>
+                        </div>
+                      </td>
+
+                      {/* Display name (inline edit) */}
+                      <td className="px-3 py-2.5">
+                        {isEditing ? (
+                          <div className="flex items-center gap-1">
+                            <input
+                              autoFocus
+                              value={editingValue}
+                              onChange={(e) => setEditingValue(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  commitName(inbox, editingValue);
+                                } else if (e.key === "Escape") {
+                                  setEditingName(null);
+                                }
+                              }}
+                              data-testid="inbox-display-name-input"
+                              className="h-8 w-full rounded-[6px] border border-border bg-card px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => commitName(inbox, editingValue)}
+                              className="flex h-7 w-7 items-center justify-center rounded-[5px] text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                              aria-label="Save"
+                            >
+                              <Check size={14} />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setEditingName(null)}
+                              className="flex h-7 w-7 items-center justify-center rounded-[5px] text-text-tertiary hover:bg-bg-muted hover:text-text-secondary"
+                              aria-label="Cancel"
+                            >
+                              <X size={14} />
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingName(inbox.email);
+                              setEditingValue(inbox.displayName ?? "");
+                            }}
+                            className="group/name inline-flex h-7 max-w-full items-center gap-1.5 rounded-[5px] px-2 text-left text-sm transition-colors hover:bg-bg-muted"
+                          >
+                            <span
+                              className={cn(
+                                "truncate",
+                                inbox.displayName
+                                  ? "text-text-primary"
+                                  : "font-light italic text-text-tertiary",
+                              )}
+                            >
+                              {inbox.displayName || "Set a name…"}
+                            </span>
+                            <Pencil
+                              size={11}
+                              className="shrink-0 text-text-tertiary opacity-0 transition-opacity group-hover/name:opacity-100"
+                            />
+                          </button>
+                        )}
+                      </td>
+
+                      {/* Mode */}
+                      <td className="px-3 py-2.5">
+                        <div className="inline-flex h-7 rounded-[5px] bg-bg-muted/60 p-0.5 ring-1 ring-border">
+                          {(["thread", "chat"] as const).map((m) => {
+                            const active = inbox.displayMode === m;
+                            const Icon =
+                              m === "thread" ? MessageSquare : MessageCircle;
+                            return (
+                              <button
+                                key={m}
+                                type="button"
+                                data-testid="inbox-mode-toggle"
+                                data-mode={m}
+                                data-active={active}
+                                onClick={() => handleSetMode(inbox, m)}
+                                aria-pressed={active}
+                                className={cn(
+                                  "inline-flex items-center gap-1 rounded-[3px] px-2 text-[11px] font-medium transition-all",
+                                  active
+                                    ? "bg-card text-text-primary shadow-sm"
+                                    : "text-text-secondary hover:text-text-primary",
+                                )}
+                              >
+                                <Icon size={10} />
+                                {m === "thread" ? "Thread" : "Chat"}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </td>
+
+                      {/* Members */}
+                      <td className="px-3 py-2.5">
+                        <MemberCell
+                          inbox={inbox}
+                          members={members}
+                          open={memberPopover === inbox.email}
+                          onOpen={() =>
+                            setMemberPopover(
+                              memberPopover === inbox.email
+                                ? null
+                                : inbox.email,
+                            )
+                          }
+                          onClose={() => setMemberPopover(null)}
+                          onToggle={(uid) => handleToggleAssignment(inbox, uid)}
+                        />
+                      </td>
+
+                      {/* Actions */}
+                      <td className="px-3 py-2.5 text-right">
+                        <button
+                          type="button"
+                          data-testid="inbox-delete-button"
+                          onClick={() => handleDelete([inbox.email])}
+                          aria-label={`Delete inbox ${inbox.email}`}
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-[5px] text-text-tertiary opacity-60 transition-all hover:bg-destructive/10 hover:text-destructive hover:opacity-100"
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CheckboxProps {
+  checked: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+}
+function Checkbox({ checked, onChange, ariaLabel }: CheckboxProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={(e) => {
+        e.stopPropagation();
+        onChange();
+      }}
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+        checked
+          ? "border-text-primary bg-text-primary text-white"
+          : "border-border bg-card hover:border-text-primary/40",
+      )}
+    >
+      {checked && (
+        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none">
+          <path
+            d="M2.5 6.5L4.75 8.75L9.5 4"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+interface MemberCellProps {
+  inbox: AdminInbox;
+  members: AdminUser[];
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onToggle: (userId: string) => void;
+}
+
+function MemberCell({
+  inbox,
+  members,
+  open,
+  onOpen,
+  onClose,
+  onToggle,
+}: MemberCellProps) {
+  const assigned = members.filter((m) => inbox.assignedUserIds.includes(m.id));
+  const display = assigned.slice(0, 3);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex h-7 items-center gap-1.5 rounded-[5px] px-2 text-xs transition-colors hover:bg-bg-muted"
+      >
+        {display.length === 0 ? (
+          <span className="font-light text-text-tertiary">
+            Admins only · assign…
+          </span>
+        ) : (
+          <>
+            <div className="flex -space-x-1">
+              {display.map((u) => (
+                <span
+                  key={u.id}
+                  title={u.name || u.email}
+                  className="flex h-5 w-5 items-center justify-center rounded-full bg-bg-muted text-[9px] font-semibold text-text-secondary ring-2 ring-card"
+                >
+                  {(u.name || u.email)[0]?.toUpperCase()}
                 </span>
+              ))}
+            </div>
+            <span className="text-text-secondary">
+              {assigned.length} member{assigned.length !== 1 ? "s" : ""}
+            </span>
+          </>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-10"
+            aria-hidden
+            onClick={onClose}
+            tabIndex={-1}
+          />
+          <div className="absolute left-0 top-full z-20 mt-1 w-64 overflow-hidden rounded-[8px] border border-border bg-card py-1 shadow-lg">
+            <div className="border-b border-border px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+                Members for {inbox.email.split("@")[0]}
+              </p>
+              <p className="mt-0.5 text-[11px] font-light text-text-tertiary">
+                Admins always have access.
+              </p>
+            </div>
+            <div className="max-h-56 overflow-y-auto smooth-scroll py-1">
+              {members.length === 0 ? (
+                <p className="px-3 py-2 text-xs font-light text-text-tertiary">
+                  No members to assign.
+                </p>
+              ) : (
+                members.map((u) => {
+                  const on = inbox.assignedUserIds.includes(u.id);
+                  return (
+                    <button
+                      key={u.id}
+                      type="button"
+                      data-testid="inbox-member-toggle"
+                      data-user-id={u.id}
+                      data-assigned={on}
+                      onClick={() => onToggle(u.id)}
+                      className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-bg-muted"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-muted text-[10px] font-semibold text-text-secondary">
+                          {(u.name || u.email)[0]?.toUpperCase()}
+                        </span>
+                        <span className="min-w-0">
+                          <span className="block truncate text-text-primary">
+                            {u.name || u.email}
+                          </span>
+                          {u.name && (
+                            <span className="block truncate text-[10px] font-light text-text-tertiary">
+                              {u.email}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                      <Checkbox
+                        checked={on}
+                        onChange={() => onToggle(u.id)}
+                        ariaLabel={`${on ? "Unassign" : "Assign"} ${u.name || u.email}`}
+                      />
+                    </button>
+                  );
+                })
               )}
             </div>
           </div>
-        </div>
-      ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,97 @@
+import { Link, useLocation, useParams } from "react-router-dom";
+import { ChevronRight, Home } from "lucide-react";
+
+interface Crumb {
+  label: string;
+  href?: string;
+}
+
+/**
+ * Builds breadcrumb trail from the current pathname. Top-level routes get
+ * a single crumb; edit/new sub-routes get a parent + child trail.
+ */
+function buildCrumbs(
+  pathname: string,
+  params: Record<string, string | undefined>,
+): Crumb[] {
+  // Inbox covers / and /inbox/:inbox/:personId — both render the same page
+  if (pathname === "/" || pathname.startsWith("/inbox/")) {
+    return [{ label: "Inbox" }];
+  }
+
+  if (pathname.startsWith("/templates")) {
+    if (pathname === "/templates") return [{ label: "Templates" }];
+    if (pathname === "/templates/new")
+      return [{ label: "Templates", href: "/templates" }, { label: "New" }];
+    if (pathname.endsWith("/edit"))
+      return [{ label: "Templates", href: "/templates" }, { label: "Edit" }];
+    return [{ label: "Templates" }];
+  }
+
+  if (pathname.startsWith("/sequences")) {
+    if (pathname === "/sequences") return [{ label: "Sequences" }];
+    if (pathname === "/sequences/new")
+      return [{ label: "Sequences", href: "/sequences" }, { label: "New" }];
+    if (pathname.endsWith("/edit"))
+      return [{ label: "Sequences", href: "/sequences" }, { label: "Edit" }];
+    if (params.id)
+      return [{ label: "Sequences", href: "/sequences" }, { label: "Detail" }];
+    return [{ label: "Sequences" }];
+  }
+
+  if (pathname === "/api-keys") return [{ label: "API Keys" }];
+  if (pathname === "/inboxes") return [{ label: "Inboxes" }];
+  if (pathname === "/admin/users") return [{ label: "Users" }];
+  if (pathname === "/settings") return [{ label: "Settings" }];
+
+  return [];
+}
+
+export default function Breadcrumbs() {
+  const { pathname } = useLocation();
+  const params = useParams();
+  const crumbs = buildCrumbs(pathname, params);
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <div className="relative z-10">
+      <nav
+        aria-label="Breadcrumb"
+        className="mx-auto flex h-10 max-w-[1600px] items-center px-4 pt-3 text-sm md:px-6"
+      >
+        <ol className="flex items-center gap-1.5">
+          <li>
+            <Link
+              to="/"
+              className="flex items-center gap-1.5 text-text-tertiary transition-colors hover:text-text-primary"
+              aria-label="Home"
+            >
+              <Home className="h-3.5 w-3.5" />
+            </Link>
+          </li>
+          {crumbs.map((crumb, i) => (
+            <li
+              key={`${crumb.label}-${i}`}
+              className="flex items-center gap-1.5"
+            >
+              <ChevronRight className="h-3.5 w-3.5 text-text-tertiary/60" />
+              {crumb.href ? (
+                <Link
+                  to={crumb.href}
+                  className="font-light text-text-secondary transition-colors hover:text-text-primary"
+                >
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span className="font-medium text-text-primary">
+                  {crumb.label}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/ChatInboxSection.tsx
+++ b/src/components/ChatInboxSection.tsx
@@ -1,5 +1,13 @@
-import { useState, useMemo } from "react";
-import { Inbox, Maximize2, Paperclip, Trash2 } from "lucide-react";
+import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import {
+  Inbox,
+  Maximize2,
+  Paperclip,
+  Trash2,
+  ArrowDown,
+  Check,
+  CheckCheck,
+} from "lucide-react";
 import type { Email } from "@/lib/api";
 import type { ThreadInboxGroup } from "@/components/ThreadInboxSection";
 import ChatQuickReply from "@/components/ChatQuickReply";
@@ -13,9 +21,7 @@ interface ChatInboxSectionProps {
   onSent: () => void;
 }
 
-const INITIAL_VISIBLE = 5;
-const PAGE_SIZE = 20;
-const BUBBLE_TRUNCATE_CHARS = 480; // ~6 lines
+const BUBBLE_TRUNCATE_CHARS = 480;
 
 function emailToText(email: Email): string {
   if (email.bodyText) return email.bodyText;
@@ -28,21 +34,32 @@ function emailToText(email: Email): string {
   return "";
 }
 
+function dayLabel(ts: number): string {
+  const d = new Date(ts * 1000);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  const dDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  if (dDay.getTime() === today.getTime()) return "Today";
+  if (dDay.getTime() === yesterday.getTime()) return "Yesterday";
+  if (now.getTime() - dDay.getTime() < 6 * 86_400_000) {
+    return d.toLocaleDateString([], { weekday: "long" });
+  }
+  return d.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() === now.getFullYear() ? undefined : "numeric",
+  });
+}
+
 interface BubbleProps {
   email: Email;
-  personEmail: string;
   onOpenHtml: (email: Email) => void;
   onMarkRead: (email: Email) => void;
   onDelete: (emailId: string) => void;
 }
 
-function Bubble({
-  email,
-  personEmail,
-  onOpenHtml,
-  onMarkRead,
-  onDelete,
-}: BubbleProps) {
+function Bubble({ email, onOpenHtml, onMarkRead, onDelete }: BubbleProps) {
   const [expanded, setExpanded] = useState(false);
   const isSent = email.type === "sent";
   const isUnread = email.type === "received" && email.isRead === 0;
@@ -54,10 +71,10 @@ function Bubble({
     : text;
 
   const ts = new Date(email.timestamp * 1000);
-  const stamp =
-    ts.toLocaleDateString([], { month: "short", day: "numeric" }) +
-    " " +
-    ts.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  const stamp = ts.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 
   const downloadable = (email.attachments ?? []).filter((a) => !a.contentId);
 
@@ -68,21 +85,23 @@ function Bubble({
   return (
     <div
       data-testid="chat-bubble"
-      className={`group flex flex-col px-4 sm:px-6 py-1 ${
+      className={`group flex flex-col px-4 py-1 sm:px-6 ${
         isSent ? "items-end" : "items-start"
       }`}
       onClick={handleClick}
       title={email.subject ?? undefined}
     >
       <div
-        className={`max-w-[78%] rounded-2xl px-3 py-2 text-xs leading-relaxed ${
-          isSent ? "bg-accent text-white" : "bg-bg-muted text-text-primary"
-        } ${isUnread ? "ring-1 ring-accent" : ""}`}
+        className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed shadow-sm sm:max-w-[78%] ${
+          isSent
+            ? "bg-text-primary text-white"
+            : "bg-white text-text-primary ring-1 ring-border"
+        } ${isUnread ? "outline outline-2 outline-violet/40" : ""}`}
       >
         {displayText ? (
-          <p className="whitespace-pre-wrap">{displayText}</p>
+          <p className="whitespace-pre-wrap break-words">{displayText}</p>
         ) : (
-          <p className="italic opacity-70">(no text content)</p>
+          <p className="italic opacity-60">(no text content)</p>
         )}
         {text.length > BUBBLE_TRUNCATE_CHARS && (
           <button
@@ -91,8 +110,8 @@ function Bubble({
               e.stopPropagation();
               setExpanded(!expanded);
             }}
-            className={`mt-1 text-[11px] underline ${
-              isSent ? "text-white/80" : "text-accent"
+            className={`mt-1.5 text-xs font-medium underline-offset-2 hover:underline ${
+              isSent ? "text-white/85" : "text-text-secondary"
             }`}
           >
             {expanded ? "Show less" : "Show more"}
@@ -102,7 +121,7 @@ function Bubble({
 
       {downloadable.length > 0 && (
         <div
-          className={`mt-1 flex flex-wrap gap-1.5 max-w-[78%] ${
+          className={`mt-1.5 flex max-w-[85%] flex-wrap gap-1.5 sm:max-w-[78%] ${
             isSent ? "justify-end" : "justify-start"
           }`}
         >
@@ -111,124 +130,240 @@ function Bubble({
               key={att.id}
               href={`/api/attachments/${att.id}`}
               onClick={(e) => e.stopPropagation()}
-              className="flex items-center gap-1 rounded border border-border bg-white px-2 py-1 text-[10px] text-text-secondary hover:bg-bg-muted"
+              className="flex items-center gap-1 rounded-[6px] border border-border bg-card px-2 py-1 text-[11px] text-text-secondary transition-colors hover:bg-bg-muted"
             >
-              <Paperclip size={10} />
+              <Paperclip size={11} />
               {att.filename}
             </a>
           ))}
         </div>
       )}
 
-      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-text-tertiary">
+      <div
+        className={`mt-1 flex items-center gap-2 text-[10px] text-text-tertiary ${isSent ? "flex-row-reverse" : ""}`}
+      >
         <span>{stamp}</span>
-        {email.bodyHtml && (
+        {isSent &&
+          (email.deliveredAt ? (
+            <CheckCheck size={11} className="text-text-tertiary" />
+          ) : (
+            <Check size={11} className="text-text-tertiary" />
+          ))}
+        <div className="flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100">
+          {email.bodyHtml && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenHtml(email);
+              }}
+              className="flex items-center gap-1 hover:text-text-secondary"
+              title="View original"
+            >
+              <Maximize2 size={10} />
+              View original
+            </button>
+          )}
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onOpenHtml(email);
+              onDelete(email.id);
             }}
-            className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity hover:text-text-secondary"
-            title="View original"
+            className="flex items-center gap-1 hover:text-red-500"
+            title="Delete email"
           >
-            <Maximize2 size={10} />
-            View original
+            <Trash2 size={10} />
           </button>
+        </div>
+        {isUnread && !isSent && (
+          <span
+            className="h-1.5 w-1.5 rounded-full"
+            style={{ backgroundColor: "#7c5cfc" }}
+          />
         )}
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete(email.id);
-          }}
-          className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity hover:text-red-400"
-          title="Delete email"
-        >
-          <Trash2 size={10} />
-        </button>
-        {isUnread && <span className="h-1.5 w-1.5 rounded-full bg-accent" />}
       </div>
+    </div>
+  );
+}
+
+interface DaySeparatorProps {
+  label: string;
+}
+function DaySeparator({ label }: DaySeparatorProps) {
+  return (
+    <div className="flex items-center gap-2 px-6 py-3">
+      <span className="h-px flex-1 bg-border" />
+      <span className="rounded-full bg-bg-muted px-3 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-border" />
     </div>
   );
 }
 
 export default function ChatInboxSection({
   group,
-  personEmail,
+  personEmail: _personEmail,
   onOpenHtml,
   onMarkRead,
   onDelete,
   onSent,
 }: ChatInboxSectionProps) {
-  // group.emails is newest-first. Chat displays chronological (oldest → newest)
-  // with the most recent at the bottom.
+  // Chronological order — oldest at top, newest at bottom.
   const chronological = useMemo(
     () => [...group.emails].reverse(),
     [group.emails],
   );
-  const total = chronological.length;
-  // Track the hidden-count (start index) instead of a visible-count so that
-  // when new messages arrive (e.g. after sending a reply) they append to the
-  // bottom without re-collapsing previously-visible earlier messages.
-  const [hiddenCount, setHiddenCount] = useState(() =>
-    Math.max(0, total - INITIAL_VISIBLE),
-  );
-  const start = Math.min(hiddenCount, Math.max(0, total - 1));
-  const visibleEmails = chronological.slice(start);
-  const effectiveHidden = start;
 
-  // Latest received email — the target of the quick reply.
-  // group.emails is newest-first, so .find returns the most recent received.
+  // Group items by day for separators.
+  const items = useMemo(() => {
+    const out: Array<
+      | { kind: "day"; key: string; label: string }
+      | { kind: "msg"; email: Email }
+    > = [];
+    let lastDay = "";
+    for (const email of chronological) {
+      const label = dayLabel(email.timestamp);
+      if (label !== lastDay) {
+        out.push({ kind: "day", key: `day-${label}-${email.id}`, label });
+        lastDay = label;
+      }
+      out.push({ kind: "msg", email });
+    }
+    return out;
+  }, [chronological]);
+
   const replyTarget = useMemo(
     () => group.emails.find((e) => e.type === "received") ?? null,
     [group.emails],
   );
 
+  // Scroll state for the messages pane
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [hasNewBelow, setHasNewBelow] = useState(false);
+  const previousMsgIdsRef = useRef<Set<string>>(new Set());
+
+  function scrollToBottom(behavior: ScrollBehavior = "smooth") {
+    bottomRef.current?.scrollIntoView({ block: "end", behavior });
+    setHasNewBelow(false);
+    setIsAtBottom(true);
+  }
+
+  useLayoutEffect(() => {
+    // Initial mount: jump to latest without animation
+    scrollToBottom("auto");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const ids = new Set(chronological.map((e) => e.id));
+    const prev = previousMsgIdsRef.current;
+    let hasNew = false;
+    for (const id of ids) {
+      if (!prev.has(id)) {
+        hasNew = true;
+        break;
+      }
+    }
+    previousMsgIdsRef.current = ids;
+    if (!hasNew) return;
+    if (isAtBottom) {
+      // User is already at bottom: keep them pinned to latest.
+      requestAnimationFrame(() => scrollToBottom("smooth"));
+    } else {
+      // User scrolled up: surface a "new message" indicator instead.
+      setHasNewBelow(true);
+    }
+  }, [chronological, isAtBottom]);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const atBottom = distanceFromBottom < 24;
+    setIsAtBottom(atBottom);
+    if (atBottom) setHasNewBelow(false);
+  }
+
   return (
-    <section className="border-b-4 border-border-subtle flex flex-col">
-      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-bg-subtle px-4 sm:px-6 py-2">
-        <Inbox size={12} className="text-text-tertiary" />
-        <span className="text-[11px] font-medium text-text-secondary">
+    <div className="flex h-full min-h-0 flex-col bg-bg-subtle/40">
+      {/* Inbox header — sticky at top of section */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-card/80 px-6 py-2.5 backdrop-blur-sm">
+        <Inbox size={13} className="text-text-tertiary" />
+        <span className="text-sm font-medium text-text-primary">
           {group.inbox}
         </span>
-        <span className="text-[11px] text-text-tertiary">
-          · {total} email{total !== 1 ? "s" : ""} · chat mode
+        <span className="text-xs text-text-tertiary">
+          · {group.emails.length} message
+          {group.emails.length !== 1 ? "s" : ""} · chat
         </span>
       </div>
 
-      <div className="flex flex-col py-2 gap-1">
-        {effectiveHidden > 0 && (
-          <div className="px-4 sm:px-6 py-1">
-            <button
-              type="button"
-              onClick={() => setHiddenCount((h) => Math.max(0, h - PAGE_SIZE))}
-              className="text-xs text-accent hover:underline"
-            >
-              Show {Math.min(PAGE_SIZE, effectiveHidden)} earlier message
-              {Math.min(PAGE_SIZE, effectiveHidden) !== 1 ? "s" : ""}
-            </button>
-          </div>
+      {/* Scrollable messages area */}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        {/* Top fade — hints at scrollable content above */}
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-bg-subtle/60 to-transparent"
+          aria-hidden
+        />
+
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="smooth-scroll flex-1 overflow-y-auto py-2"
+        >
+          {items.map((item) =>
+            item.kind === "day" ? (
+              <DaySeparator key={item.key} label={item.label} />
+            ) : (
+              <Bubble
+                key={item.email.id}
+                email={item.email}
+                onOpenHtml={onOpenHtml}
+                onMarkRead={onMarkRead}
+                onDelete={onDelete}
+              />
+            ),
+          )}
+          <div ref={bottomRef} className="h-2" />
+        </div>
+
+        {/* Bottom fade — hints at scrollable content below */}
+        {!isAtBottom && (
+          <div
+            className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-12 bg-gradient-to-t from-bg-subtle/70 to-transparent"
+            aria-hidden
+          />
         )}
 
-        {visibleEmails.map((email) => (
-          <Bubble
-            key={email.id}
-            email={email}
-            personEmail={personEmail}
-            onOpenHtml={onOpenHtml}
-            onMarkRead={onMarkRead}
-            onDelete={onDelete}
-          />
-        ))}
+        {/* Floating "Jump to latest" pill */}
+        {!isAtBottom && (
+          <button
+            type="button"
+            onClick={() => scrollToBottom("smooth")}
+            className={`absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium shadow-lg transition-all ${
+              hasNewBelow
+                ? "bg-text-primary text-white"
+                : "bg-card text-text-primary ring-1 ring-border"
+            }`}
+          >
+            <ArrowDown size={12} />
+            {hasNewBelow ? "New messages" : "Jump to latest"}
+          </button>
+        )}
       </div>
 
-      <ChatQuickReply
-        inboxAddress={group.inbox}
-        latestReceivedEmailId={replyTarget?.id ?? null}
-        personEmail={personEmail}
-        onSent={onSent}
-      />
-    </section>
+      {/* Sticky reply at the bottom of the section */}
+      <div className="shrink-0">
+        <ChatQuickReply
+          inboxAddress={group.inbox}
+          latestReceivedEmailId={replyTarget?.id ?? null}
+          personEmail={_personEmail}
+          onSent={onSent}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/ChatQuickReply.tsx
+++ b/src/components/ChatQuickReply.tsx
@@ -90,8 +90,8 @@ export default function ChatQuickReply({
   }
 
   return (
-    <div className="border-t border-border bg-white px-4 py-2">
-      <div className="flex items-end gap-2">
+    <div className="border-t border-border bg-card px-4 py-3 sm:px-6">
+      <div className="flex items-end gap-2 rounded-[10px] bg-bg-subtle/60 p-2 ring-1 ring-border focus-within:ring-2 focus-within:ring-text-primary/15">
         <textarea
           ref={ref}
           value={text}
@@ -101,23 +101,24 @@ export default function ChatQuickReply({
           placeholder={
             latestReceivedEmailId ? "Type a reply…" : "Type a message…"
           }
-          className="flex-1 resize-none rounded-md border border-border bg-white px-2 py-1.5 text-xs text-text-primary outline-none focus:ring-1 focus:ring-accent disabled:bg-bg-muted disabled:text-text-tertiary"
+          className="flex-1 resize-none border-0 bg-transparent px-2 py-1.5 text-sm text-text-primary outline-none placeholder:text-text-tertiary disabled:text-text-tertiary"
         />
         <button
           type="button"
           onClick={handleSend}
           disabled={!canSend}
-          className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+          className="shrink-0 rounded-[8px] bg-text-primary px-3.5 py-2 text-xs font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {sending ? "Sending…" : "Send"}
         </button>
       </div>
-      <div className="mt-1 flex items-center justify-between">
+      <div className="mt-1.5 flex items-center justify-between">
         {error ? (
           <span className="text-xs text-destructive">{error}</span>
         ) : (
-          <span className="text-[11px] text-text-tertiary">
-            Plain text · sent from {inboxAddress} · ⌘/Ctrl+Enter to send
+          <span className="text-[11px] font-light text-text-tertiary">
+            Sending from <span className="font-medium">{inboxAddress}</span> ·
+            ⌘/Ctrl + Enter to send
           </span>
         )}
       </div>

--- a/src/components/ComposeFab.tsx
+++ b/src/components/ComposeFab.tsx
@@ -1,0 +1,27 @@
+import { PenSquare } from "lucide-react";
+
+interface ComposeFabProps {
+  onClick: () => void;
+}
+
+/**
+ * Mobile-only floating action button for Compose.
+ * Hidden on sm+ where the header has an inline Compose button.
+ * Sits bottom-right with safe-area-aware spacing so it clears the
+ * iOS home indicator and footer.
+ */
+export default function ComposeFab({ onClick }: ComposeFabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Compose new email"
+      className="fixed bottom-5 right-5 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-text-primary text-white shadow-2xl ring-1 ring-black/10 transition-all active:scale-95 sm:hidden"
+      style={{
+        bottom: "max(1.25rem, env(safe-area-inset-bottom))",
+      }}
+    >
+      <PenSquare className="h-5 w-5" strokeWidth={2.25} />
+    </button>
+  );
+}

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,17 +1,44 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
-import Sidebar from "./Sidebar";
+import TopNav from "@/components/TopNav";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import Footer from "@/components/Footer";
+import ComposeFab from "@/components/ComposeFab";
 import ComposeModal from "@/pages/ComposeModal";
+import { useReducedAnimations } from "@/hooks/useReducedAnimations";
 
 export default function DashboardLayout() {
   const [composeOpen, setComposeOpen] = useState(false);
+  const reduced = useReducedAnimations();
 
   return (
-    <div className="flex h-screen bg-bg">
-      <Sidebar onCompose={() => setComposeOpen(true)} />
-      <div className="flex flex-1 overflow-hidden">
-        <Outlet />
+    <div className="relative flex min-h-screen flex-col bg-background pt-16">
+      {/* Faded gradient backdrop. Animates by default; falls back to a
+          static version on low-spec devices or when the user prefers
+          reduced motion. */}
+      <div
+        className={
+          reduced
+            ? "dashboard-backdrop dashboard-backdrop-static"
+            : "dashboard-backdrop"
+        }
+        aria-hidden
+      />
+      <div className="dashboard-backdrop-mask" aria-hidden />
+
+      <TopNav />
+      <Breadcrumbs />
+
+      <main className="relative z-10 flex flex-1 flex-col">
+        <Outlet context={{ onCompose: () => setComposeOpen(true) }} />
+      </main>
+
+      <div className="relative z-10">
+        <Footer />
       </div>
+
+      <ComposeFab onClick={() => setComposeOpen(true)} />
+
       <ComposeModal
         open={composeOpen}
         onClose={() => setComposeOpen(false)}

--- a/src/components/EmailHtmlModal.tsx
+++ b/src/components/EmailHtmlModal.tsx
@@ -1,12 +1,22 @@
-import { sanitizeEmailHtml } from "@/lib/sanitize-html";
-import { Paperclip } from "lucide-react";
+import { useState, useMemo } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  X,
+  Paperclip,
+  Download,
+  Copy,
+  CheckCircle2,
+  Inbox as InboxIcon,
+  Send,
+  Hash,
+  Calendar,
+  AtSign,
+  FileText,
+  Code,
+} from "lucide-react";
+import { sanitizeEmailHtml } from "@/lib/sanitize-html";
 import type { Email } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 interface EmailHtmlModalProps {
   email: Email | null;
@@ -14,66 +24,280 @@ interface EmailHtmlModalProps {
   onClose: () => void;
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function avatarInitial(addr: string | null): string {
+  if (!addr) return "?";
+  return addr[0]?.toUpperCase() ?? "?";
+}
+
+function avatarColor(seed: string) {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  const palette = [
+    { bg: "rgba(124, 92, 252, 0.14)", fg: "#5b3ce6" },
+    { bg: "rgba(34, 197, 94, 0.14)", fg: "#15803d" },
+    { bg: "rgba(244, 114, 182, 0.16)", fg: "#be185d" },
+    { bg: "rgba(56, 189, 248, 0.16)", fg: "#0369a1" },
+    { bg: "rgba(168, 85, 247, 0.14)", fg: "#7e22ce" },
+  ];
+  return palette[h % palette.length];
+}
+
+interface DetailRowProps {
+  icon: React.ElementType;
+  label: string;
+  value: React.ReactNode;
+  monospace?: boolean;
+}
+function DetailRow({ icon: Icon, label, value, monospace }: DetailRowProps) {
+  return (
+    <div className="grid grid-cols-[80px_1fr] items-baseline gap-3 py-1">
+      <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+        <Icon size={11} />
+        {label}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 break-words text-sm text-text-primary",
+          monospace && "font-mono text-xs",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
 export default function EmailHtmlModal({
   email,
   open,
   onClose,
 }: EmailHtmlModalProps) {
+  const [view, setView] = useState<"rendered" | "plain">("rendered");
+  const [copied, setCopied] = useState(false);
+
+  // Reset internal state when the email changes
+  useMemo(() => {
+    setView("rendered");
+    setCopied(false);
+  }, [email?.id]);
+
   if (!email) return null;
 
-  const downloadableAttachments = (email.attachments ?? []).filter(
-    (att) => !att.contentId,
-  );
+  const isSent = email.type === "sent";
+  const downloadable = (email.attachments ?? []).filter((a) => !a.contentId);
+  const fromAddr = isSent ? email.fromAddress : email.fromAddress;
+  const toAddr = isSent ? email.toAddress : email.recipient;
+  const senderForAvatar = isSent ? "you" : (fromAddr ?? email.recipient ?? "?");
+  const color = avatarColor(senderForAvatar);
 
-  const senderLabel =
-    email.type === "sent"
-      ? `You → ${email.toAddress}`
-      : (email.fromAddress ?? email.recipient ?? "Unknown");
+  const ts = new Date(email.timestamp * 1000);
+  const fullDate = ts.toLocaleDateString([], {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const fullTime = ts.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  const plainText =
+    email.bodyText ||
+    (email.bodyHtml
+      ? (new DOMParser().parseFromString(email.bodyHtml, "text/html").body
+          .textContent ?? "")
+      : "");
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(plainText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  }
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden border-border bg-white ring-1 ring-gray-200 p-0 text-text-primary">
-        <DialogHeader className="border-b border-border px-6 py-4">
-          <DialogTitle className="text-sm text-text-primary">
-            {email.subject || "(no subject)"}
-          </DialogTitle>
-          <p className="text-xs text-text-secondary">{senderLabel}</p>
-          <p className="text-[11px] text-text-tertiary">
-            {new Date(email.timestamp * 1000).toLocaleString()}
-          </p>
-        </DialogHeader>
-        {downloadableAttachments.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 border-b border-border px-6 py-3">
-            {downloadableAttachments.map((att) => (
-              <a
-                key={att.id}
-                href={`/api/attachments/${att.id}`}
-                className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-text-secondary hover:bg-bg-muted"
+    <DialogPrimitive.Root open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="drawer-overlay fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-[2px]" />
+        <DialogPrimitive.Content className="drawer-content fixed right-0 top-0 z-50 flex h-full w-full flex-col bg-card shadow-2xl ring-1 ring-border focus:outline-none sm:max-w-[680px]">
+          {/* Header */}
+          <div className="shrink-0 border-b border-border bg-card px-6 pb-4 pt-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
+                  style={{ backgroundColor: color.bg, color: color.fg }}
+                >
+                  {avatarInitial(senderForAvatar)}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <DialogPrimitive.Title className="truncate text-lg font-extrabold tracking-tight text-text-primary">
+                    {email.subject || "(no subject)"}
+                  </DialogPrimitive.Title>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-secondary">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 rounded-[6px] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider",
+                        isSent
+                          ? "bg-bg-muted text-text-secondary"
+                          : "bg-violet/10",
+                      )}
+                      style={!isSent ? { color: "#7c5cfc" } : undefined}
+                    >
+                      {isSent ? <Send size={10} /> : <InboxIcon size={10} />}
+                      {isSent ? "Sent" : "Received"}
+                    </span>
+                    <span className="font-light text-text-tertiary">
+                      {fullDate} · {fullTime}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <DialogPrimitive.Close
+                className="shrink-0 rounded-[8px] p-1.5 text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                aria-label="Close"
               >
-                <Paperclip size={10} />
-                {att.filename}
-              </a>
-            ))}
+                <X size={18} />
+              </DialogPrimitive.Close>
+            </div>
           </div>
-        )}
-        <div
-          className="overflow-auto"
-          style={{ maxHeight: "calc(90vh - 120px)" }}
-        >
-          {email.bodyHtml ? (
-            <div
-              className="prose prose-sm max-w-none bg-white p-6 text-black"
-              dangerouslySetInnerHTML={{
-                __html: sanitizeEmailHtml(email.bodyHtml),
-              }}
+
+          {/* Metadata */}
+          <div className="shrink-0 border-b border-border bg-bg-subtle/40 px-6 py-3">
+            <DetailRow
+              icon={AtSign}
+              label="From"
+              value={fromAddr || (isSent ? "you" : "—")}
             />
-          ) : (
-            <pre className="whitespace-pre-wrap bg-white p-6 text-sm text-black">
-              {email.bodyText || "(empty)"}
-            </pre>
+            <DetailRow icon={Send} label="To" value={toAddr || "—"} />
+            <DetailRow icon={Hash} label="ID" value={email.id} monospace />
+            <DetailRow
+              icon={Calendar}
+              label="Time"
+              value={ts.toISOString()}
+              monospace
+            />
+          </div>
+
+          {/* Attachments */}
+          {downloadable.length > 0 && (
+            <div className="shrink-0 border-b border-border bg-card px-6 py-3">
+              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-text-tertiary">
+                {downloadable.length} attachment
+                {downloadable.length !== 1 ? "s" : ""}
+              </p>
+              <ul className="space-y-1.5">
+                {downloadable.map((att) => (
+                  <li key={att.id}>
+                    <a
+                      href={`/api/attachments/${att.id}`}
+                      className="flex items-center justify-between gap-3 rounded-[8px] border border-border bg-card px-3 py-2 text-xs transition-colors hover:bg-bg-muted"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <Paperclip
+                          size={14}
+                          className="shrink-0 text-text-tertiary"
+                        />
+                        <span className="truncate font-medium text-text-primary">
+                          {att.filename}
+                        </span>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2 text-text-tertiary">
+                        <span>{formatBytes(att.size)}</span>
+                        <Download size={12} />
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
-        </div>
-      </DialogContent>
-    </Dialog>
+
+          {/* Body view toggle + actions */}
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-card px-6 py-2.5">
+            <div className="inline-flex rounded-[8px] bg-bg-muted/70 p-0.5 ring-1 ring-border">
+              <button
+                onClick={() => setView("rendered")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1 text-xs font-medium transition-all",
+                  view === "rendered"
+                    ? "bg-card text-text-primary shadow-sm"
+                    : "text-text-secondary hover:text-text-primary",
+                )}
+              >
+                <FileText size={12} />
+                Rendered
+              </button>
+              <button
+                onClick={() => setView("plain")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1 text-xs font-medium transition-all",
+                  view === "plain"
+                    ? "bg-card text-text-primary shadow-sm"
+                    : "text-text-secondary hover:text-text-primary",
+                )}
+              >
+                <Code size={12} />
+                Plain text
+              </button>
+            </div>
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 rounded-[8px] px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+            >
+              {copied ? (
+                <>
+                  <CheckCircle2 size={12} className="text-success" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={12} />
+                  Copy text
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="smooth-scroll min-h-0 flex-1 overflow-y-auto bg-card">
+            {view === "rendered" && email.bodyHtml ? (
+              <div
+                className="prose prose-sm max-w-none px-8 py-6 text-text-primary [&_a]:text-violet [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-text-secondary [&_p]:my-2"
+                style={{ "--tw-prose-links": "#7c5cfc" } as React.CSSProperties}
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeEmailHtml(email.bodyHtml),
+                }}
+              />
+            ) : (
+              <pre className="whitespace-pre-wrap break-words px-8 py-6 font-sans text-sm leading-relaxed text-text-primary">
+                {plainText || "(empty)"}
+              </pre>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="shrink-0 border-t border-border bg-bg-subtle/40 px-6 py-2.5">
+            <p className="text-[11px] font-light text-text-tertiary">
+              Original message · Press{" "}
+              <kbd className="rounded border border-border bg-card px-1 text-[10px] font-medium text-text-secondary">
+                Esc
+              </kbd>{" "}
+              to close
+            </p>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,81 @@
+import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+interface FooterProps {
+  /** "light" (default) for dashboard pages on white-ish bg.
+   *  "dark" for auth pages on the near-black gradient backdrop. */
+  variant?: "light" | "dark";
+}
+
+/**
+ * Single-row minimal footer matching givefeedback.dev's app footer.
+ * Adapts to dark vs light parent bg via the `variant` prop so the same
+ * markup works on both the dashboard and auth screens.
+ */
+export default function Footer({ variant = "light" }: FooterProps) {
+  const dark = variant === "dark";
+
+  return (
+    <footer
+      className={cn("border-t", dark ? "border-white/10" : "border-border/60")}
+    >
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col items-center gap-3 px-4 py-5 text-xs sm:flex-row sm:justify-between md:px-6">
+        {/* Left: Privacy / Terms pills */}
+        <div className="flex items-center gap-2">
+          <Link
+            to="/privacy"
+            className={cn(
+              "rounded-[8px] px-3 py-1 font-semibold uppercase tracking-wider ring-1 transition-colors",
+              dark
+                ? "text-white/60 ring-white/15 hover:bg-white/5 hover:text-white"
+                : "text-text-secondary ring-border hover:bg-bg-subtle hover:text-text-primary",
+            )}
+          >
+            Privacy
+          </Link>
+          <Link
+            to="/terms"
+            className={cn(
+              "rounded-[8px] px-3 py-1 font-semibold uppercase tracking-wider ring-1 transition-colors",
+              dark
+                ? "text-white/60 ring-white/15 hover:bg-white/5 hover:text-white"
+                : "text-text-secondary ring-border hover:bg-bg-subtle hover:text-text-primary",
+            )}
+          >
+            Terms
+          </Link>
+        </div>
+
+        {/* Center: copyright */}
+        <div className={dark ? "text-white/50" : "text-text-tertiary"}>
+          © {new Date().getFullYear()} saasmail
+        </div>
+
+        {/* Right: sponsor */}
+        <div
+          className={cn(
+            "flex items-center gap-2",
+            dark ? "text-white/50" : "text-text-tertiary",
+          )}
+        >
+          <span>Sponsored by</span>
+          <a
+            href="https://givefeedback.dev/saas"
+            target="_blank"
+            rel="noreferrer"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[8px] px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider ring-1 transition-colors",
+              dark
+                ? "bg-white/[0.06] text-white ring-white/15 hover:bg-white/[0.1]"
+                : "bg-violet/10 text-violet ring-violet/20 hover:bg-violet/15",
+            )}
+            style={!dark ? { color: "#7c5cfc" } : undefined}
+          >
+            <span style={{ color: "#bfff00" }}>✦</span>
+            givefeedback.dev
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/InboxFilterBar.tsx
+++ b/src/components/InboxFilterBar.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Inbox, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface InboxFilters {
+  recipient?: string;
+  unread?: boolean;
+  hasAttachment?: boolean;
+}
+
+interface InboxOption {
+  email: string;
+  displayName?: string | null;
+}
+
+interface InboxFilterBarProps {
+  filters: InboxFilters;
+  onChange: (next: InboxFilters) => void;
+  inboxes: InboxOption[];
+}
+
+function inboxLabel(o: InboxOption) {
+  return o.displayName || o.email.split("@")[0] || o.email;
+}
+
+export default function InboxFilterBar({
+  filters,
+  onChange,
+  inboxes,
+}: InboxFilterBarProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function close(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  const activeInbox = inboxes.find((i) => i.email === filters.recipient);
+  const activeLabel = activeInbox ? inboxLabel(activeInbox) : "All inboxes";
+  const hasActiveFilters =
+    !!filters.recipient || !!filters.unread || !!filters.hasAttachment;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+        Filter
+      </span>
+
+      {/* Inbox dropdown */}
+      <div ref={wrapRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-[8px] border px-3 py-1.5 text-xs font-medium transition-colors",
+            filters.recipient
+              ? "border-text-primary/15 bg-text-primary/[0.04] text-text-primary"
+              : "border-border bg-card text-text-secondary hover:bg-bg-muted hover:text-text-primary",
+          )}
+        >
+          <Inbox size={12} />
+          {activeLabel}
+          <ChevronDown size={12} className="opacity-60" />
+        </button>
+        {open && (
+          <div className="absolute left-0 top-full z-30 mt-1 w-56 overflow-hidden rounded-[8px] border border-border bg-card py-1 shadow-lg">
+            <button
+              type="button"
+              onClick={() => {
+                onChange({ ...filters, recipient: undefined });
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center justify-between px-3 py-2 text-xs transition-colors hover:bg-bg-muted",
+                !filters.recipient && "bg-bg-subtle font-medium",
+              )}
+            >
+              <span>All inboxes</span>
+              {!filters.recipient && (
+                <span className="text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
+                  active
+                </span>
+              )}
+            </button>
+            <div className="my-1 h-px bg-border" />
+            {inboxes.length === 0 ? (
+              <p className="px-3 py-2 text-xs font-light text-text-tertiary">
+                No inboxes available
+              </p>
+            ) : (
+              inboxes.map((inbox) => {
+                const active = filters.recipient === inbox.email;
+                return (
+                  <button
+                    key={inbox.email}
+                    type="button"
+                    onClick={() => {
+                      onChange({ ...filters, recipient: inbox.email });
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 px-3 py-2 text-xs transition-colors hover:bg-bg-muted",
+                      active && "bg-bg-subtle font-medium",
+                    )}
+                  >
+                    <div className="flex flex-col items-start min-w-0">
+                      <span className="truncate text-text-primary">
+                        {inboxLabel(inbox)}
+                      </span>
+                      <span className="truncate text-[10px] font-light text-text-tertiary">
+                        {inbox.email}
+                      </span>
+                    </div>
+                    {active && (
+                      <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
+                        active
+                      </span>
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Toggle chips */}
+      <FilterChip
+        label="Unread only"
+        active={!!filters.unread}
+        onToggle={() => onChange({ ...filters, unread: !filters.unread })}
+      />
+      <FilterChip
+        label="Has attachments"
+        active={!!filters.hasAttachment}
+        onToggle={() =>
+          onChange({ ...filters, hasAttachment: !filters.hasAttachment })
+        }
+      />
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={() =>
+            onChange({
+              recipient: undefined,
+              unread: false,
+              hasAttachment: false,
+            })
+          }
+          className="ml-1 inline-flex items-center gap-1 rounded-[8px] px-2 py-1 text-xs font-medium text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+        >
+          <X size={12} />
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+}
+function FilterChip({ label, active, onToggle }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[8px] border px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "border-text-primary/15 bg-text-primary/[0.04] text-text-primary"
+          : "border-border bg-card text-text-secondary hover:bg-bg-muted hover:text-text-primary",
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 rounded-full transition-colors",
+          active ? "bg-violet" : "bg-text-tertiary/30",
+        )}
+        style={active ? { backgroundColor: "#7c5cfc" } : undefined}
+        aria-hidden
+      />
+      {label}
+    </button>
+  );
+}

--- a/src/components/InboxToolbar.tsx
+++ b/src/components/InboxToolbar.tsx
@@ -71,14 +71,16 @@ export default function InboxToolbar({
       <div className="relative w-full min-w-[180px] flex-1 sm:w-auto sm:max-w-xs">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" />
         <input
+          data-testid="person-search-input"
           type="text"
-          placeholder="Search people, subjects, emails…"
+          placeholder="Search..."
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           className="h-10 w-full rounded-[6px] border-0 bg-transparent pl-9 pr-8 text-base text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15 sm:h-8 sm:pl-8 sm:pr-7 sm:text-sm"
         />
         {search && (
           <button
+            data-testid="person-search-clear"
             onClick={() => onSearchChange("")}
             className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
             aria-label="Clear search"

--- a/src/components/InboxToolbar.tsx
+++ b/src/components/InboxToolbar.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ChevronDown,
+  Inbox,
+  X,
+  Search,
+  LayoutList,
+  LayoutGrid,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface InboxFilters {
+  recipient?: string;
+  unread?: boolean;
+  hasAttachment?: boolean;
+}
+
+export type InboxView = "list" | "table";
+
+interface InboxOption {
+  email: string;
+  displayName?: string | null;
+}
+
+interface InboxToolbarProps {
+  filters: InboxFilters;
+  onFiltersChange: (next: InboxFilters) => void;
+  inboxes: InboxOption[];
+  search: string;
+  onSearchChange: (q: string) => void;
+  view: InboxView;
+  onViewChange: (v: InboxView) => void;
+}
+
+function inboxOptionLabel(o: InboxOption) {
+  return o.displayName || o.email.split("@")[0] || o.email;
+}
+
+export default function InboxToolbar({
+  filters,
+  onFiltersChange,
+  inboxes,
+  search,
+  onSearchChange,
+  view,
+  onViewChange,
+}: InboxToolbarProps) {
+  const [inboxOpen, setInboxOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!inboxOpen) return;
+    function close(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) setInboxOpen(false);
+    }
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [inboxOpen]);
+
+  const activeInbox = inboxes.find((i) => i.email === filters.recipient);
+  const activeLabel = activeInbox
+    ? inboxOptionLabel(activeInbox)
+    : "All inboxes";
+  const hasActiveFilters =
+    !!filters.recipient || !!filters.unread || !!filters.hasAttachment;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 rounded-[10px] bg-card p-1.5 ring-1 ring-border">
+      {/* Search — borderless inside the unified bar. On mobile takes full
+          width, on desktop sits inline with filters. */}
+      <div className="relative w-full min-w-[180px] flex-1 sm:w-auto sm:max-w-xs">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" />
+        <input
+          type="text"
+          placeholder="Search people, subjects, emails…"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="h-10 w-full rounded-[6px] border-0 bg-transparent pl-9 pr-8 text-base text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15 sm:h-8 sm:pl-8 sm:pr-7 sm:text-sm"
+        />
+        {search && (
+          <button
+            onClick={() => onSearchChange("")}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4 sm:h-3 sm:w-3" />
+          </button>
+        )}
+      </div>
+
+      {/* Vertical divider — desktop only */}
+      <span className="mx-0.5 hidden h-5 w-px bg-border sm:block" aria-hidden />
+
+      {/* Inbox dropdown — ghost button inside bar */}
+      <div ref={wrapRef} className="relative">
+        <ToolbarButton
+          active={!!filters.recipient}
+          onClick={() => setInboxOpen((v) => !v)}
+        >
+          <Inbox size={12} />
+          {activeLabel}
+          <ChevronDown size={12} className="opacity-60" />
+        </ToolbarButton>
+        {inboxOpen && (
+          <div className="absolute left-0 top-full z-30 mt-1.5 w-56 overflow-hidden rounded-[8px] border border-border bg-card py-1 shadow-lg">
+            <button
+              type="button"
+              onClick={() => {
+                onFiltersChange({ ...filters, recipient: undefined });
+                setInboxOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center justify-between px-3 py-2 text-xs transition-colors hover:bg-bg-muted",
+                !filters.recipient && "bg-bg-subtle font-medium",
+              )}
+            >
+              <span>All inboxes</span>
+              {!filters.recipient && (
+                <span className="text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
+                  active
+                </span>
+              )}
+            </button>
+            <div className="my-1 h-px bg-border" />
+            {inboxes.length === 0 ? (
+              <p className="px-3 py-2 text-xs font-light text-text-tertiary">
+                No inboxes available
+              </p>
+            ) : (
+              inboxes.map((inbox) => {
+                const active = filters.recipient === inbox.email;
+                return (
+                  <button
+                    key={inbox.email}
+                    type="button"
+                    onClick={() => {
+                      onFiltersChange({ ...filters, recipient: inbox.email });
+                      setInboxOpen(false);
+                    }}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 px-3 py-2 text-xs transition-colors hover:bg-bg-muted",
+                      active && "bg-bg-subtle font-medium",
+                    )}
+                  >
+                    <div className="flex min-w-0 flex-col items-start">
+                      <span className="truncate text-text-primary">
+                        {inboxOptionLabel(inbox)}
+                      </span>
+                      <span className="truncate text-[10px] font-light text-text-tertiary">
+                        {inbox.email}
+                      </span>
+                    </div>
+                    {active && (
+                      <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
+                        active
+                      </span>
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        )}
+      </div>
+
+      <ToolbarToggle
+        label="Unread"
+        active={!!filters.unread}
+        onClick={() => onFiltersChange({ ...filters, unread: !filters.unread })}
+      />
+      <ToolbarToggle
+        label="Attachments"
+        active={!!filters.hasAttachment}
+        onClick={() =>
+          onFiltersChange({
+            ...filters,
+            hasAttachment: !filters.hasAttachment,
+          })
+        }
+      />
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={() =>
+            onFiltersChange({
+              recipient: undefined,
+              unread: false,
+              hasAttachment: false,
+            })
+          }
+          className="inline-flex h-8 items-center gap-1 rounded-[6px] px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+        >
+          <X size={12} />
+          Clear
+        </button>
+      )}
+
+      {/* View toggle — pinned to the right edge. Hidden on mobile (the
+          table view is unusable at narrow widths). */}
+      <span className="ml-auto" />
+      <span className="mx-0.5 hidden h-5 w-px bg-border sm:block" aria-hidden />
+      <div className="hidden h-8 rounded-[6px] bg-bg-muted/70 p-0.5 sm:inline-flex">
+        <ViewToggleButton
+          icon={LayoutList}
+          label="List"
+          active={view === "list"}
+          onClick={() => onViewChange("list")}
+        />
+        <ViewToggleButton
+          icon={LayoutGrid}
+          label="Table"
+          active={view === "table"}
+          onClick={() => onViewChange("table")}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ToolbarButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+function ToolbarButton({ active, onClick, children }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-text-primary/[0.06] text-text-primary"
+          : "text-text-secondary hover:bg-bg-muted hover:text-text-primary",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface ToolbarToggleProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+function ToolbarToggle({ label, active, onClick }: ToolbarToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-text-primary/[0.06] text-text-primary"
+          : "text-text-secondary hover:bg-bg-muted hover:text-text-primary",
+      )}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full transition-colors"
+        style={{ backgroundColor: active ? "#7c5cfc" : "rgba(0,0,0,0.18)" }}
+        aria-hidden
+      />
+      {label}
+    </button>
+  );
+}
+
+interface ViewToggleButtonProps {
+  icon: React.ElementType;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+function ViewToggleButton({
+  icon: Icon,
+  label,
+  active,
+  onClick,
+}: ViewToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={`${label} view`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[5px] px-2.5 text-xs font-medium transition-all",
+        active
+          ? "bg-card text-text-primary shadow-sm ring-1 ring-border/60"
+          : "text-text-secondary hover:text-text-primary",
+      )}
+    >
+      <Icon size={13} />
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}

--- a/src/components/LegalLayout.tsx
+++ b/src/components/LegalLayout.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import { Mail } from "lucide-react";
+import Footer from "@/components/Footer";
+
+interface LegalLayoutProps {
+  title: string;
+  lastUpdated: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Public, readable layout for legal pages (Terms, Privacy). Light pastel
+ * backdrop with a centered prose column. No auth required.
+ */
+export default function LegalLayout({
+  title,
+  lastUpdated,
+  children,
+}: LegalLayoutProps) {
+  return (
+    <div className="relative flex min-h-screen flex-col bg-background">
+      <div className="dashboard-backdrop" aria-hidden />
+      <div className="dashboard-backdrop-mask" aria-hidden />
+
+      {/* Brand strip */}
+      <header className="relative z-10">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-6 md:px-6">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-text-primary transition-opacity hover:opacity-80"
+          >
+            <Mail
+              className="h-5 w-5"
+              strokeWidth={2.5}
+              style={{ color: "#7c5cfc" }}
+              aria-hidden
+            />
+            <span className="text-lg font-extrabold uppercase tracking-tight">
+              saasmail
+            </span>
+          </Link>
+          <Link
+            to="/login"
+            className="text-xs font-medium text-text-secondary transition-colors hover:text-text-primary"
+          >
+            Sign in →
+          </Link>
+        </div>
+      </header>
+
+      <main className="relative z-10 flex-1">
+        <article className="mx-auto max-w-3xl px-4 py-12 md:px-6 md:py-16">
+          <header className="mb-10 border-b border-border pb-8">
+            <h1 className="text-4xl font-extrabold tracking-tight text-text-primary md:text-5xl">
+              {title}
+            </h1>
+            <p className="mt-3 text-sm font-light text-text-tertiary">
+              Last updated · {lastUpdated}
+            </p>
+          </header>
+
+          <div className="prose prose-slate max-w-none [&_a]:font-medium [&_a]:text-violet [&_a:hover]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-4 [&_blockquote]:text-text-secondary [&_code]:rounded [&_code]:bg-bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_h2]:mb-3 [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-extrabold [&_h2]:tracking-tight [&_h2]:text-text-primary [&_h3]:mb-2 [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-text-primary [&_li]:my-1 [&_li]:text-[15px] [&_li]:leading-relaxed [&_p]:my-3 [&_p]:text-[15px] [&_p]:leading-relaxed [&_p]:text-text-secondary [&_strong]:font-semibold [&_strong]:text-text-primary [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-6">
+            {children}
+          </div>
+        </article>
+      </main>
+
+      <div className="relative z-10">
+        <Footer variant="light" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Consistent page header used across dashboard pages.
+ * Big extrabold title + optional subtitle + optional right-side action.
+ * Mobile-compact, desktop-expansive — matches the Inbox page treatment.
+ */
+export default function PageHeader({
+  title,
+  subtitle,
+  action,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "mb-6 flex flex-wrap items-end justify-between gap-4 pt-4 sm:mb-8 sm:pt-6",
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        <h1 className="text-2xl font-extrabold tracking-tight text-text-primary sm:text-3xl md:text-4xl">
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="mt-0.5 max-w-2xl text-xs font-light text-text-secondary sm:mt-1 sm:text-sm">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}
+
+interface PageContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Standard width-capped, padded container for dashboard pages.
+ * Caps at 1600px on desktop so the chrome lines up with the inbox + nav.
+ */
+export function PageContainer({ children, className }: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-[1600px] flex-1 px-4 pb-12 md:px-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/PeopleTable.tsx
+++ b/src/components/PeopleTable.tsx
@@ -1,0 +1,315 @@
+import { useMemo } from "react";
+import { Paperclip, CheckCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { GroupedPerson } from "@/lib/api";
+
+interface PeopleTableProps {
+  people: GroupedPerson[];
+  loading?: boolean;
+  onSelectPerson: (person: GroupedPerson) => void;
+  selectedIds?: Set<string>;
+  onToggleSelected?: (id: string) => void;
+  onToggleSelectAll?: () => void;
+  onMarkPersonRead?: (id: string) => void;
+}
+
+const AVATAR_PALETTE = [
+  { bg: "rgba(124, 92, 252, 0.12)", fg: "#5b3ce6" },
+  { bg: "rgba(34, 197, 94, 0.12)", fg: "#15803d" },
+  { bg: "rgba(244, 114, 182, 0.14)", fg: "#be185d" },
+  { bg: "rgba(251, 146, 60, 0.14)", fg: "#c2410c" },
+  { bg: "rgba(56, 189, 248, 0.14)", fg: "#0369a1" },
+  { bg: "rgba(168, 85, 247, 0.14)", fg: "#7e22ce" },
+];
+function avatarColor(seed: string) {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  return AVATAR_PALETTE[h % AVATAR_PALETTE.length];
+}
+function initials(name: string | null, email: string) {
+  const source = name || email.split("@")[0];
+  const parts = source.split(/[\s.\-_]+/).filter(Boolean);
+  return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase() || "?";
+}
+function relTime(ts: number): string {
+  const d = new Date(ts * 1000);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffH = diffMs / 3_600_000;
+  if (diffH < 1) return `${Math.max(1, Math.floor(diffMs / 60_000))}m ago`;
+  if (diffH < 24) return `${Math.floor(diffH)}h ago`;
+  const diffD = diffH / 24;
+  if (diffD < 7) return `${Math.floor(diffD)}d ago`;
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+interface RowCheckboxProps {
+  checked: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+}
+function RowCheckbox({ checked, onChange, ariaLabel }: RowCheckboxProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={(e) => {
+        e.stopPropagation();
+        onChange();
+      }}
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+        checked
+          ? "border-text-primary bg-text-primary text-white"
+          : "border-border bg-card hover:border-text-primary/40",
+      )}
+    >
+      {checked && (
+        <svg
+          className="h-3 w-3"
+          viewBox="0 0 12 12"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2.5 6.5L4.75 8.75L9.5 4"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+export default function PeopleTable({
+  people,
+  loading,
+  onSelectPerson,
+  selectedIds,
+  onToggleSelected,
+  onToggleSelectAll,
+  onMarkPersonRead,
+}: PeopleTableProps) {
+  const stats = useMemo(() => {
+    let unread = 0;
+    let withAttachments = 0;
+    let multiInbox = 0;
+    for (const p of people) {
+      unread += p.unreadCount;
+      if (p.hasAttachment === 1) withAttachments++;
+      if (p.recipientCount > 1) multiInbox++;
+    }
+    return {
+      total: people.length,
+      unread,
+      withAttachments,
+      multiInbox,
+    };
+  }, [people]);
+
+  const allOnPageSelected =
+    people.length > 0 &&
+    selectedIds !== undefined &&
+    people.every((p) => selectedIds.has(p.id));
+
+  const someOnPageSelected =
+    selectedIds !== undefined &&
+    people.some((p) => selectedIds.has(p.id)) &&
+    !allOnPageSelected;
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col">
+      {/* Stats strip */}
+      <div className="grid shrink-0 grid-cols-4 gap-px border-b border-border bg-border">
+        <StatTile label="People" value={stats.total} />
+        <StatTile label="Unread" value={stats.unread} accent />
+        <StatTile label="Multi-inbox" value={stats.multiInbox} />
+        <StatTile label="With attachments" value={stats.withAttachments} />
+      </div>
+
+      {/* Table */}
+      <div className="smooth-scroll min-h-0 flex-1 overflow-auto">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+            Loading…
+          </div>
+        ) : people.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <p className="text-sm font-medium text-text-primary">
+              No people match your filters
+            </p>
+            <p className="text-xs font-light text-text-tertiary">
+              Try clearing a filter or broadening your search.
+            </p>
+          </div>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead className="sticky top-0 z-10 bg-card/90 backdrop-blur-sm">
+              <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+                {selectedIds !== undefined && (
+                  <th className="w-10 px-4 py-2.5">
+                    <RowCheckbox
+                      checked={allOnPageSelected}
+                      onChange={() => onToggleSelectAll?.()}
+                      ariaLabel={
+                        allOnPageSelected
+                          ? "Deselect all on page"
+                          : "Select all on page"
+                      }
+                    />
+                    {someOnPageSelected && (
+                      <span className="sr-only">Some selected</span>
+                    )}
+                  </th>
+                )}
+                <th className="px-4 py-2.5 font-semibold">Person</th>
+                <th className="px-3 py-2.5 font-semibold">Inboxes</th>
+                <th className="px-3 py-2.5 text-right font-semibold">Emails</th>
+                <th className="px-3 py-2.5 text-right font-semibold">Unread</th>
+                <th className="px-3 py-2.5 text-right font-semibold">Last</th>
+              </tr>
+            </thead>
+            <tbody>
+              {people.map((person) => {
+                const color = avatarColor(person.email);
+                const isSelected = selectedIds?.has(person.id) ?? false;
+                return (
+                  <tr
+                    key={person.id}
+                    onClick={() => onSelectPerson(person)}
+                    className={cn(
+                      "group cursor-pointer border-b border-border/60 transition-colors",
+                      isSelected
+                        ? "bg-text-primary/[0.04]"
+                        : "hover:bg-text-primary/[0.025]",
+                    )}
+                  >
+                    {selectedIds !== undefined && (
+                      <td className="w-10 px-4 py-2.5">
+                        <RowCheckbox
+                          checked={isSelected}
+                          onChange={() => onToggleSelected?.(person.id)}
+                          ariaLabel={`Select ${person.name || person.email}`}
+                        />
+                      </td>
+                    )}
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-3">
+                        <span
+                          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+                          style={{
+                            backgroundColor: color.bg,
+                            color: color.fg,
+                          }}
+                        >
+                          {initials(person.name, person.email)}
+                        </span>
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-text-primary">
+                            {person.name || person.email}
+                          </p>
+                          {person.name && (
+                            <p className="truncate text-xs font-light text-text-tertiary">
+                              {person.email}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <div className="flex flex-wrap gap-1">
+                        {(person.recipients ?? []).slice(0, 3).map((r) => (
+                          <span
+                            key={r}
+                            className="inline-flex items-center rounded-[5px] bg-bg-muted px-2 py-0.5 text-[11px] font-medium text-text-secondary"
+                            title={r}
+                          >
+                            {r.split("@")[0]}
+                          </span>
+                        ))}
+                        {(person.recipients?.length ?? 0) > 3 && (
+                          <span className="inline-flex items-center rounded-[5px] px-2 py-0.5 text-[11px] font-medium text-text-tertiary">
+                            +{(person.recipients?.length ?? 0) - 3}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2.5 text-right">
+                      <span className="inline-flex items-center gap-1.5 text-xs tabular-nums text-text-secondary">
+                        {person.hasAttachment === 1 && (
+                          <Paperclip
+                            size={11}
+                            className="text-text-tertiary"
+                            aria-label="Has attachment"
+                          />
+                        )}
+                        {person.totalCount}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5 text-right">
+                      {person.unreadCount > 0 ? (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onMarkPersonRead?.(person.id);
+                          }}
+                          title="Mark all as read"
+                          className="group/badge inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[10px] font-bold tabular-nums text-white transition-all hover:scale-110"
+                          style={{ backgroundColor: "#7c5cfc" }}
+                        >
+                          <span className="group-hover/badge:hidden">
+                            {person.unreadCount}
+                          </span>
+                          <CheckCheck
+                            size={11}
+                            className="hidden group-hover/badge:block"
+                          />
+                        </button>
+                      ) : (
+                        <span className="text-xs text-text-tertiary">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 text-right">
+                      <span className="text-xs font-light tabular-nums text-text-tertiary">
+                        {relTime(person.lastEmailAt)}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface StatTileProps {
+  label: string;
+  value: number;
+  accent?: boolean;
+}
+function StatTile({ label, value, accent }: StatTileProps) {
+  return (
+    <div className="bg-card px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+        {label}
+      </p>
+      <p
+        className={cn(
+          "mt-0.5 text-xl font-extrabold tabular-nums tracking-tight text-text-primary",
+        )}
+        style={accent && value > 0 ? { color: "#7c5cfc" } : undefined}
+      >
+        {value.toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,0 +1,77 @@
+import { lazy, Suspense } from "react";
+import { Outlet } from "react-router-dom";
+import Footer from "@/components/Footer";
+import { useReducedAnimations } from "@/hooks/useReducedAnimations";
+
+// Lazy-load the shader so the auth pages can paint instantly while the
+// (small) shader chunk fetches in the background. Only requested when the
+// device can afford the GPU work.
+const GrainGradient = lazy(() =>
+  import("@paper-design/shaders-react").then((mod) => ({
+    default: mod.GrainGradient,
+  })),
+);
+
+/**
+ * Wraps every public route (login, onboarding, invite, setup-passkey)
+ * with the same animated shader backdrop givefeedback.dev uses on its
+ * auth screen — violet/lime grain gradient on a near-black canvas.
+ *
+ * On lower-spec devices (Save-Data, slow connection, low memory/cores) or
+ * when the user prefers reduced motion, we render a static CSS gradient
+ * instead. Same look, zero ongoing GPU/CPU cost.
+ */
+export default function PublicLayout() {
+  const reduced = useReducedAnimations();
+
+  return (
+    <div className="relative flex min-h-screen flex-col overflow-hidden text-white">
+      {/* Backdrop layer */}
+      <div className="absolute inset-0 z-0">
+        <div className="absolute inset-0 bg-[#0a0a0a]" />
+        {reduced ? (
+          <div className="brand-backdrop absolute inset-0" aria-hidden />
+        ) : (
+          <Suspense
+            fallback={
+              <div className="brand-backdrop absolute inset-0" aria-hidden />
+            }
+          >
+            <GrainGradient
+              colors={["#7C5CFC", "#BFFF00", "#6366f1", "#3b0764"]}
+              colorBack="#0a0a0a"
+              softness={0.4}
+              intensity={0.7}
+              noise={0.2}
+              shape="circle"
+              speed={0.4}
+              scale={1.2}
+              rotation={200}
+              offsetX={-0.1}
+              offsetY={0.15}
+              style={{ width: "100%", height: "100%" }}
+            />
+          </Suspense>
+        )}
+      </div>
+
+      {/* Dark overlays for depth and contrast */}
+      <div
+        className="pointer-events-none absolute inset-0 z-[1] bg-black/30"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-t from-black/50 via-transparent to-black/20"
+        aria-hidden
+      />
+
+      <main className="relative z-10 flex flex-1 items-center justify-center px-4 py-16">
+        <Outlet />
+      </main>
+
+      <div className="relative z-10">
+        <Footer variant="dark" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -1,8 +1,28 @@
 import { useState, useEffect, useMemo } from "react";
-import { X } from "lucide-react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  X,
+  Send,
+  AtSign,
+  Reply as ReplyIcon,
+  FileText,
+  Sparkles,
+  Inbox as InboxIcon,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import TiptapEditor from "@/components/TiptapEditor";
-import { replyToEmail, fetchTemplates, type EmailTemplate } from "@/lib/api";
+import {
+  replyToEmail,
+  fetchTemplates,
+  fetchEmail,
+  fetchPersonEmails,
+  type EmailTemplate,
+  type Email,
+} from "@/lib/api";
+import { sanitizeEmailHtml } from "@/lib/sanitize-html";
 import { getFromLabel } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 interface ReplyComposerProps {
   emailId: string;
@@ -43,12 +63,47 @@ export default function ReplyComposer({
   const [sending, setSending] = useState(false);
   const [error, setError] = useState("");
 
+  // Thread context — the email being replied to + prior messages from the
+  // same person/inbox so the user can reference them while drafting.
+  const [originalEmail, setOriginalEmail] = useState<Email | null>(null);
+  const [threadEmails, setThreadEmails] = useState<Email[]>([]);
+  const [threadExpanded, setThreadExpanded] = useState(false);
+
   // Template state
   const [templates, setTemplates] = useState<EmailTemplate[]>([]);
   const [selectedSlug, setSelectedSlug] = useState("");
   const [templateVars, setTemplateVars] = useState<Record<string, string>>({});
   const [templatesLoading, setTemplatesLoading] = useState(false);
   const [templatesError, setTemplatesError] = useState("");
+
+  // Load the email being replied to + the surrounding thread on mount.
+  useEffect(() => {
+    let cancelled = false;
+    fetchEmail(emailId)
+      .then(async (email) => {
+        if (cancelled) return;
+        setOriginalEmail(email);
+        // If we have a personId, fetch the person's recent emails in this inbox.
+        if (email.personId) {
+          try {
+            const recipient = email.recipient ?? email.fromAddress ?? undefined;
+            const res = await fetchPersonEmails(email.personId, {
+              recipient,
+              limit: 12,
+            });
+            if (!cancelled) setThreadEmails(res.emails);
+          } catch {
+            /* non-fatal */
+          }
+        }
+      })
+      .catch(() => {
+        /* original may have been deleted — composer still works */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [emailId]);
 
   const selectedTemplate =
     templates.find((t) => t.slug === selectedSlug) ?? null;
@@ -61,23 +116,18 @@ export default function ReplyComposer({
     );
   }, [selectedTemplate]);
 
-  // Auto-fill variables when template or person changes
   useEffect(() => {
     if (!selectedTemplate) return;
     const vars: Record<string, string> = {};
     for (const v of requiredVars) {
-      if (v.toLowerCase() === "name" && personName) {
-        vars[v] = personName;
-      } else if (v.toLowerCase() === "email") {
-        vars[v] = personEmail;
-      } else {
-        vars[v] = templateVars[v] ?? "";
-      }
+      if (v.toLowerCase() === "name" && personName) vars[v] = personName;
+      else if (v.toLowerCase() === "email") vars[v] = personEmail;
+      else vars[v] = templateVars[v] ?? "";
     }
     setTemplateVars(vars);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedSlug, requiredVars.join(",")]);
 
-  // Fetch templates when switching to template tab
   useEffect(() => {
     if (tab !== "template" || templates.length > 0) return;
     setTemplatesLoading(true);
@@ -86,7 +136,7 @@ export default function ReplyComposer({
       .then(setTemplates)
       .catch(() => setTemplatesError("Failed to load templates"))
       .finally(() => setTemplatesLoading(false));
-  }, [tab]);
+  }, [tab, templates.length]);
 
   async function handleSend() {
     setSending(true);
@@ -115,154 +165,421 @@ export default function ReplyComposer({
     }
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  const recipientLabel = personName
+    ? `${personName} <${personEmail}>`
+    : personEmail;
+
   return (
-    <div
-      data-testid="reply-composer"
-      className="border-t border-border bg-white shrink-0"
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border">
-        <span className="text-xs font-semibold text-text-primary">Reply</span>
-        <button
-          onClick={onClose}
-          className="text-text-tertiary hover:text-text-secondary"
+    <DialogPrimitive.Root open onOpenChange={(v) => !v && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="drawer-overlay fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-[2px]" />
+        <DialogPrimitive.Content
+          onKeyDown={handleKeyDown}
+          className="drawer-content fixed right-0 top-0 z-50 flex h-full w-full flex-col bg-card shadow-2xl ring-1 ring-border focus:outline-none sm:max-w-[920px]"
         >
-          <X size={14} />
-        </button>
-      </div>
-
-      <div className="px-4 py-2 space-y-2">
-        {/* From picker */}
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-text-tertiary shrink-0">From</label>
-          <select
-            value={fromAddress}
-            onChange={(e) => setFromAddress(e.target.value)}
-            className="flex-1 bg-transparent border border-border rounded-md px-2 py-1 text-xs text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
-          >
-            {recipients.map((r) => (
-              <option key={r} value={r}>
-                {getFromLabel(r, senderIdentities)}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Tab toggle */}
-        <div className="flex gap-1">
-          <button
-            onClick={() => setTab("freeform")}
-            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-              tab === "freeform"
-                ? "bg-accent text-white"
-                : "text-text-secondary hover:bg-bg-muted"
-            }`}
-          >
-            Freeform
-          </button>
-          <button
-            onClick={() => setTab("template")}
-            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-              tab === "template"
-                ? "bg-accent text-white"
-                : "text-text-secondary hover:bg-bg-muted"
-            }`}
-          >
-            Template
-          </button>
-        </div>
-
-        {/* Content area */}
-        {tab === "freeform" ? (
-          <TiptapEditor
-            content={bodyHtml}
-            onUpdate={setBodyHtml}
-            placeholder="Write your reply..."
-          />
-        ) : (
-          <div className="space-y-2">
-            {templatesLoading ? (
-              <p className="text-xs text-text-tertiary">Loading templates...</p>
-            ) : templatesError ? (
-              <p className="text-xs text-destructive">{templatesError}</p>
-            ) : (
-              <>
-                <select
-                  value={selectedSlug}
-                  onChange={(e) => setSelectedSlug(e.target.value)}
-                  className="w-full bg-transparent border border-border rounded-md px-2 py-1.5 text-xs text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+          {/* Header */}
+          <div className="shrink-0 border-b border-border bg-card px-6 pb-4 pt-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+                  style={{
+                    backgroundColor: "rgba(124, 92, 252, 0.12)",
+                    color: "#5b3ce6",
+                  }}
                 >
-                  <option value="">Select a template...</option>
-                  {templates.map((t) => (
-                    <option key={t.slug} value={t.slug}>
-                      {t.name}
-                    </option>
-                  ))}
-                </select>
+                  <ReplyIcon size={18} />
+                </span>
+                <div className="min-w-0">
+                  <DialogPrimitive.Title className="text-lg font-extrabold tracking-tight text-text-primary">
+                    Reply
+                  </DialogPrimitive.Title>
+                  <p className="mt-0.5 truncate text-sm font-light text-text-tertiary">
+                    To {recipientLabel}
+                  </p>
+                </div>
+              </div>
+              <DialogPrimitive.Close
+                className="shrink-0 rounded-[8px] p-1.5 text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                aria-label="Close"
+              >
+                <X size={18} />
+              </DialogPrimitive.Close>
+            </div>
+          </div>
 
-                {selectedTemplate && (
+          {/* Metadata: From / To */}
+          <div className="shrink-0 border-b border-border bg-bg-subtle/40 px-6 py-3">
+            <div className="grid grid-cols-[60px_1fr] items-center gap-3 py-1">
+              <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                <AtSign size={11} />
+                From
+              </span>
+              <select
+                value={fromAddress}
+                onChange={(e) => setFromAddress(e.target.value)}
+                className="rounded-[6px] border border-border bg-card px-2 py-1.5 text-sm text-text-primary outline-none focus:ring-2 focus:ring-text-primary/15"
+              >
+                {recipients.map((r) => (
+                  <option key={r} value={r}>
+                    {getFromLabel(r, senderIdentities)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="grid grid-cols-[60px_1fr] items-center gap-3 py-1">
+              <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                <Send size={11} />
+                To
+              </span>
+              <span className="truncate text-sm text-text-primary">
+                {recipientLabel}
+              </span>
+            </div>
+          </div>
+
+          {/* Mode toggle */}
+          <div className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-6 py-2.5">
+            <div className="inline-flex rounded-[8px] bg-bg-muted/70 p-0.5 ring-1 ring-border">
+              <ModeButton
+                active={tab === "freeform"}
+                onClick={() => setTab("freeform")}
+                icon={Sparkles}
+                label="Freeform"
+              />
+              <ModeButton
+                active={tab === "template"}
+                onClick={() => setTab("template")}
+                icon={FileText}
+                label="Template"
+              />
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="smooth-scroll min-h-0 flex-1 overflow-y-auto bg-card">
+            {tab === "freeform" ? (
+              <div className="flex h-full min-h-[320px] flex-col gap-4 p-6">
+                {/* Thread context — what you're replying to */}
+                {originalEmail && (
+                  <ThreadContext
+                    original={originalEmail}
+                    thread={threadEmails}
+                    expanded={threadExpanded}
+                    onToggle={() => setThreadExpanded((v) => !v)}
+                  />
+                )}
+                <div className="min-h-[260px] flex-1">
+                  <TiptapEditor
+                    content={bodyHtml}
+                    onUpdate={setBodyHtml}
+                    placeholder="Write your reply…"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-4 p-6">
+                {templatesLoading ? (
+                  <p className="text-sm font-light text-text-tertiary">
+                    Loading templates…
+                  </p>
+                ) : templatesError ? (
+                  <p className="text-sm text-destructive">{templatesError}</p>
+                ) : (
                   <>
-                    {/* Subject preview */}
-                    <div className="text-xs text-text-secondary">
-                      <span className="text-text-tertiary">Subject: </span>
-                      {selectedTemplate.subject}
+                    <div>
+                      <label className="mb-1.5 block text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                        Template
+                      </label>
+                      <select
+                        value={selectedSlug}
+                        onChange={(e) => setSelectedSlug(e.target.value)}
+                        className="w-full rounded-[8px] border border-border bg-card px-3 py-2 text-sm text-text-primary outline-none focus:ring-2 focus:ring-text-primary/15"
+                      >
+                        <option value="">Select a template…</option>
+                        {templates.map((t) => (
+                          <option key={t.slug} value={t.slug}>
+                            {t.name}
+                          </option>
+                        ))}
+                      </select>
                     </div>
 
-                    {/* Body preview */}
-                    <div
-                      className="rounded-md border border-border bg-white p-3 text-xs text-text-secondary max-h-32 overflow-auto"
-                      dangerouslySetInnerHTML={{
-                        __html: selectedTemplate.bodyHtml,
-                      }}
-                    />
-
-                    {/* Variable inputs */}
-                    {requiredVars.length > 0 && (
-                      <div className="space-y-1.5">
-                        <span className="text-[10px] text-text-tertiary uppercase tracking-wider">
-                          Variables
-                        </span>
-                        {requiredVars.map((v) => (
-                          <div key={v} className="flex items-center gap-2">
-                            <label className="text-xs text-text-tertiary font-mono shrink-0 w-20 truncate">
-                              {`{{${v}}}`}
-                            </label>
-                            <input
-                              value={templateVars[v] ?? ""}
-                              onChange={(e) =>
-                                setTemplateVars((prev) => ({
-                                  ...prev,
-                                  [v]: e.target.value,
-                                }))
-                              }
-                              className="flex-1 bg-transparent border border-border rounded-md px-2 py-1 text-xs text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+                    {selectedTemplate && (
+                      <>
+                        <div className="rounded-[8px] bg-bg-subtle/60 p-4 ring-1 ring-border">
+                          <p className="mb-1 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                            Subject
+                          </p>
+                          <p className="text-sm font-medium text-text-primary">
+                            {selectedTemplate.subject}
+                          </p>
+                          <div className="mt-3 border-t border-border pt-3">
+                            <p className="mb-1 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                              Body preview
+                            </p>
+                            <div
+                              className="prose prose-sm max-h-48 max-w-none overflow-auto text-sm text-text-secondary"
+                              dangerouslySetInnerHTML={{
+                                __html: selectedTemplate.bodyHtml,
+                              }}
                             />
                           </div>
-                        ))}
-                      </div>
+                        </div>
+
+                        {requiredVars.length > 0 && (
+                          <div>
+                            <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+                              Variables
+                            </p>
+                            <div className="space-y-2">
+                              {requiredVars.map((v) => (
+                                <div
+                                  key={v}
+                                  className="grid grid-cols-[120px_1fr] items-center gap-3"
+                                >
+                                  <label className="truncate font-mono text-xs text-text-tertiary">
+                                    {`{{${v}}}`}
+                                  </label>
+                                  <input
+                                    value={templateVars[v] ?? ""}
+                                    onChange={(e) =>
+                                      setTemplateVars((prev) => ({
+                                        ...prev,
+                                        [v]: e.target.value,
+                                      }))
+                                    }
+                                    className="rounded-[6px] border border-border bg-card px-2.5 py-1.5 text-sm text-text-primary outline-none focus:ring-2 focus:ring-text-primary/15"
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </>
                     )}
                   </>
                 )}
-              </>
+              </div>
             )}
           </div>
-        )}
 
-        {/* Footer */}
-        <div className="flex items-center justify-between pt-1">
-          {error && <span className="text-xs text-destructive">{error}</span>}
-          <div className="ml-auto">
-            <button
-              onClick={handleSend}
-              data-testid="reply-send-button"
-              disabled={sending}
-              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50 transition-colors"
-            >
-              {sending ? "Sending..." : "Send"}
-            </button>
+          {/* Footer */}
+          <div className="shrink-0 border-t border-border bg-bg-subtle/40 px-6 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[11px] font-light text-text-tertiary">
+                {error ? (
+                  <span className="text-destructive">{error}</span>
+                ) : (
+                  <>
+                    <kbd className="rounded border border-border bg-card px-1 text-[10px] font-medium text-text-secondary">
+                      ⌘
+                    </kbd>{" "}
+                    +{" "}
+                    <kbd className="rounded border border-border bg-card px-1 text-[10px] font-medium text-text-secondary">
+                      Enter
+                    </kbd>{" "}
+                    to send
+                  </>
+                )}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={onClose}
+                  className="rounded-[8px] px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSend}
+                  data-testid="reply-send-button"
+                  disabled={sending}
+                  className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-xs font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Send size={12} />
+                  {sending ? "Sending…" : "Send reply"}
+                </button>
+              </div>
+            </div>
           </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+interface ModeButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ElementType;
+  label: string;
+}
+function ModeButton({ active, onClick, icon: Icon, label }: ModeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[6px] px-3 py-1 text-xs font-medium transition-all",
+        active
+          ? "bg-card text-text-primary shadow-sm"
+          : "text-text-secondary hover:text-text-primary",
+      )}
+    >
+      <Icon size={12} />
+      {label}
+    </button>
+  );
+}
+
+interface ThreadContextProps {
+  original: Email;
+  thread: Email[];
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Renders the email being replied to with a collapsible older thread above
+ * it. Lets the user reference the conversation while drafting without
+ * leaving the composer.
+ */
+function ThreadContext({
+  original,
+  thread,
+  expanded,
+  onToggle,
+}: ThreadContextProps) {
+  // Older messages (everything except the original), oldest → newest.
+  const olderEmails = useMemo(() => {
+    const others = thread.filter((e) => e.id !== original.id);
+    return [...others].sort((a, b) => a.timestamp - b.timestamp);
+  }, [thread, original.id]);
+
+  return (
+    <div className="rounded-[8px] bg-bg-subtle/60 ring-1 ring-border">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <ReplyIcon size={13} className="shrink-0 text-text-tertiary" />
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-text-tertiary">
+            Replying to
+          </span>
+          {original.subject && (
+            <span className="truncate text-xs font-medium text-text-secondary">
+              · {original.subject}
+            </span>
+          )}
+        </div>
+        {olderEmails.length > 0 && (
+          <button
+            type="button"
+            onClick={onToggle}
+            className="inline-flex items-center gap-1 rounded-[6px] px-2 py-1 text-[11px] font-medium text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+          >
+            {expanded ? (
+              <>
+                <ChevronUp size={12} />
+                Hide history
+              </>
+            ) : (
+              <>
+                <ChevronDown size={12} />
+                Show {olderEmails.length} earlier
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      <div className="max-h-[360px] overflow-y-auto smooth-scroll">
+        {expanded && olderEmails.length > 0 && (
+          <div className="divide-y divide-border/60">
+            {olderEmails.map((e) => (
+              <ThreadMessage key={e.id} email={e} muted />
+            ))}
+          </div>
+        )}
+        <div className={olderEmails.length > 0 ? "border-t border-border" : ""}>
+          <ThreadMessage email={original} highlight />
         </div>
       </div>
+    </div>
+  );
+}
+
+interface ThreadMessageProps {
+  email: Email;
+  muted?: boolean;
+  highlight?: boolean;
+}
+
+function ThreadMessage({ email, muted, highlight }: ThreadMessageProps) {
+  const isSent = email.type === "sent";
+  const sender = isSent
+    ? `you (${email.fromAddress ?? "—"})`
+    : (email.fromAddress ?? "Unknown");
+  const recipient = isSent ? email.toAddress : email.recipient;
+  const ts = new Date(email.timestamp * 1000);
+  const fullStamp = `${ts.toLocaleDateString([], { month: "short", day: "numeric" })} · ${ts.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
+
+  return (
+    <div
+      className={cn(
+        "px-4 py-3",
+        highlight ? "bg-card" : "bg-transparent",
+        muted && "opacity-90",
+      )}
+    >
+      <div className="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-0.5 text-[11px]">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider",
+            isSent
+              ? "bg-bg-muted text-text-secondary"
+              : "bg-violet/10 text-violet",
+          )}
+          style={!isSent ? { color: "#7c5cfc" } : undefined}
+        >
+          {isSent ? (
+            <>
+              <Send size={9} />
+              Sent
+            </>
+          ) : (
+            <>
+              <InboxIcon size={9} />
+              Received
+            </>
+          )}
+        </span>
+        <span className="truncate font-medium text-text-primary">{sender}</span>
+        {recipient && (
+          <span className="truncate text-text-tertiary">→ {recipient}</span>
+        )}
+        <span className="ml-auto shrink-0 text-text-tertiary">{fullStamp}</span>
+      </div>
+      {email.bodyHtml ? (
+        <div
+          className={cn(
+            "prose prose-sm max-w-none text-[13px] leading-relaxed [&_p]:my-1.5",
+            highlight ? "text-text-primary" : "text-text-secondary",
+          )}
+          dangerouslySetInnerHTML={{
+            __html: sanitizeEmailHtml(email.bodyHtml),
+          }}
+        />
+      ) : (
+        <pre className="whitespace-pre-wrap break-words font-sans text-[13px] leading-relaxed text-text-secondary">
+          {email.bodyText || "(no text)"}
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -182,6 +182,7 @@ export default function ReplyComposer({
         <DialogPrimitive.Overlay className="drawer-overlay fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-[2px]" />
         <DialogPrimitive.Content
           onKeyDown={handleKeyDown}
+          data-testid="reply-composer"
           className="drawer-content fixed right-0 top-0 z-50 flex h-full w-full flex-col bg-card shadow-2xl ring-1 ring-border focus:outline-none sm:max-w-[920px]"
         >
           {/* Header */}

--- a/src/components/SelectionBar.tsx
+++ b/src/components/SelectionBar.tsx
@@ -1,0 +1,65 @@
+import { CheckCheck, X, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SelectionBarProps {
+  count: number;
+  busy?: boolean;
+  onMarkRead: () => void;
+  onClear: () => void;
+  className?: string;
+}
+
+/**
+ * Floating bar that appears above the inbox card when one or more people
+ * are selected. Hosts bulk actions (mark read, clear). Sticky-positioned
+ * via the parent so it doesn't shift content.
+ */
+export default function SelectionBar({
+  count,
+  busy,
+  onMarkRead,
+  onClear,
+  className,
+}: SelectionBarProps) {
+  if (count === 0) return null;
+  return (
+    <div
+      data-testid="selection-bar"
+      className={cn(
+        "flex items-center gap-2 rounded-[8px] bg-text-primary px-3 py-2 text-sm text-white shadow-lg ring-1 ring-text-primary/20",
+        className,
+      )}
+    >
+      <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-white/15 px-2 text-xs font-bold tabular-nums">
+        {count}
+      </span>
+      <span className="font-medium">selected</span>
+
+      <span className="mx-1 h-4 w-px bg-white/15" aria-hidden />
+
+      <button
+        type="button"
+        onClick={onMarkRead}
+        disabled={busy}
+        className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <CheckCheck size={12} />
+        )}
+        Mark as read
+      </button>
+
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-auto inline-flex items-center gap-1 rounded-[6px] px-2 py-1.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/[0.08] hover:text-white"
+        aria-label="Clear selection"
+      >
+        <X size={12} />
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { signOut, useSession } from "@/lib/auth-client";
 import { useSidebarCollapsed } from "@/lib/useSidebarCollapsed";
+import { Wordmark } from "@/components/Wordmark";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -104,19 +105,18 @@ export default function Sidebar({ onCompose }: SidebarProps) {
     >
       {/* Header */}
       <div
-        className={`flex items-center ${collapsed ? "justify-center px-0" : "px-3"} py-3`}
+        className={`flex items-center ${collapsed ? "justify-center px-0" : "px-3"} py-4`}
       >
         {collapsed ? (
-          // Collapsed: crop the logo to show just the icon portion on the left.
-          <div className="h-8 w-8 shrink-0 overflow-hidden">
-            <img
-              src="/saasmail-logo.png"
-              alt="saasmail"
-              className="h-8 w-auto max-w-none object-left"
-            />
-          </div>
+          <span
+            className="text-2xl leading-none text-violet"
+            style={{ color: "#7c5cfc" }}
+            aria-label="saasmail"
+          >
+            ✦
+          </span>
         ) : (
-          <img src="/saasmail-logo.png" alt="saasmail" className="h-7 w-auto" />
+          <Wordmark className="text-text-primary" />
         )}
       </div>
 

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -115,7 +115,10 @@ export default function TopNav() {
             {/* User dropdown — also holds secondary nav (API, Inboxes, Users, Settings) */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="flex items-center gap-2 rounded-[8px] px-3 py-2 text-sm font-medium text-white/80 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white">
+                <button
+                  title={session?.user?.email}
+                  className="flex items-center gap-2 rounded-[8px] px-3 py-2 text-sm font-medium text-white/80 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white"
+                >
                   <span className="flex h-6 w-6 items-center justify-center rounded-[8px] bg-white/[0.12]">
                     <User className="h-3.5 w-3.5 text-white/60" />
                   </span>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -179,6 +179,15 @@ export default function TopNav() {
                     Admin tools
                   </DropdownMenuItem>
                 )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  data-testid="logout-button"
+                  onClick={() => signOut()}
+                  className="cursor-pointer text-red-500 focus:bg-red-500/10 focus:text-red-500"
+                >
+                  <LogOut className="h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
 

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useState } from "react";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
+import {
+  Mail,
+  Inbox as InboxIcon,
+  FileText,
+  ListOrdered,
+  Key,
+  Settings as SettingsIcon,
+  Shield,
+  Users,
+  Menu,
+  User,
+  LogOut,
+} from "lucide-react";
+import { signOut, useSession } from "@/lib/auth-client";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface NavItem {
+  label: string;
+  path: string;
+  icon: React.ElementType;
+  end?: boolean;
+}
+
+// Top-level nav: just the daily-driver tabs. Admin/settings stuff lives
+// in the user dropdown so the nav stays scannable.
+const PRIMARY_NAV: NavItem[] = [
+  { label: "Inbox", path: "/", icon: Mail, end: true },
+  { label: "Templates", path: "/templates", icon: FileText },
+  { label: "Sequences", path: "/sequences", icon: ListOrdered },
+];
+
+export default function TopNav() {
+  const { data: session } = useSession();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    function onScroll() {
+      setScrolled(window.scrollY > 10);
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  const isAdmin = session?.user?.role === "admin";
+
+  return (
+    <div className="fixed left-0 right-0 top-0 z-50 flex justify-center px-4 pt-3 md:px-6">
+      <nav
+        className={`w-full max-w-[1600px] rounded-[8px] border border-white/[0.08] bg-[#0a0a0a]/90 backdrop-blur-xl transition-shadow duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)] ${
+          scrolled ? "shadow-2xl shadow-black/40" : ""
+        }`}
+      >
+        <div className="flex items-center justify-between px-2 py-1.5">
+          {/* Brand — Mail glyph in lime; keeps the SAASMAIL wordmark */}
+          <Link
+            to="/"
+            className="flex items-center gap-2 pl-3 text-xl font-extrabold uppercase tracking-tight text-white transition-opacity duration-150 hover:opacity-80"
+          >
+            <Mail
+              className="h-[18px] w-[18px]"
+              strokeWidth={2.5}
+              style={{ color: "#BFFF00" }}
+              aria-hidden
+            />
+            saasmail
+          </Link>
+
+          {/* Primary nav (desktop) */}
+          <div className="hidden items-center gap-1 sm:flex">
+            {PRIMARY_NAV.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  end={item.end}
+                  className={({ isActive }) =>
+                    `flex items-center gap-1.5 rounded-[8px] px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+                      isActive
+                        ? "bg-white/[0.12] text-white"
+                        : "text-white/60 hover:bg-white/[0.08] hover:text-white"
+                    }`
+                  }
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {item.label}
+                </NavLink>
+              );
+            })}
+          </div>
+
+          {/* Right cluster */}
+          <div className="flex items-center gap-1">
+            {isAdmin && (
+              <span className="hidden items-center rounded-[8px] bg-rose-500/90 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white sm:inline-flex">
+                Admin
+              </span>
+            )}
+
+            {/* User dropdown — also holds secondary nav (API, Inboxes, Users, Settings) */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="flex items-center gap-2 rounded-[8px] px-3 py-2 text-sm font-medium text-white/80 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-[8px] bg-white/[0.12]">
+                    <User className="h-3.5 w-3.5 text-white/60" />
+                  </span>
+                  <span className="hidden max-w-[160px] truncate sm:inline">
+                    {session?.user?.name || session?.user?.email}
+                  </span>
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <div className="px-2 py-1.5 text-sm">
+                  <p className="font-medium text-text-primary">
+                    {session?.user?.name || "Account"}
+                  </p>
+                  <p className="truncate text-xs text-text-secondary">
+                    {session?.user?.email}
+                  </p>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => navigate("/api-keys")}
+                  className="cursor-pointer"
+                >
+                  <Key className="h-4 w-4" />
+                  API keys
+                </DropdownMenuItem>
+                {isAdmin && (
+                  <>
+                    <DropdownMenuItem
+                      onClick={() => navigate("/inboxes")}
+                      className="cursor-pointer"
+                    >
+                      <InboxIcon className="h-4 w-4" />
+                      Inboxes
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => navigate("/admin/users")}
+                      className="cursor-pointer"
+                    >
+                      <Users className="h-4 w-4" />
+                      Users
+                    </DropdownMenuItem>
+                  </>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => navigate("/settings")}
+                  className="cursor-pointer"
+                >
+                  <SettingsIcon className="h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                {isAdmin && (
+                  <DropdownMenuItem
+                    onClick={() => navigate("/admin/users")}
+                    className="cursor-pointer"
+                  >
+                    <Shield className="h-4 w-4" />
+                    Admin tools
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Sign-out (always-visible icon button on desktop) */}
+            <button
+              onClick={() => signOut()}
+              className="hidden items-center gap-1.5 rounded-[8px] px-3 py-2 text-sm font-medium text-white/60 transition-colors duration-150 hover:bg-red-500/10 hover:text-red-400 sm:flex"
+              aria-label="Sign out"
+            >
+              <LogOut className="h-3.5 w-3.5" />
+            </button>
+
+            {/* Mobile hamburger */}
+            <button
+              onClick={() => setMobileOpen((v) => !v)}
+              aria-label="Open menu"
+              className="flex items-center gap-1.5 rounded-[8px] px-3 py-2 text-white/80 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white sm:hidden"
+            >
+              <Menu className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile slide-down menu */}
+        {mobileOpen && (
+          <div className="border-t border-white/[0.06] sm:hidden">
+            <div className="flex flex-col py-2">
+              {PRIMARY_NAV.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <NavLink
+                    key={item.path}
+                    to={item.path}
+                    end={item.end}
+                    className={({ isActive }) =>
+                      `flex items-center gap-2 px-4 py-2.5 text-sm font-medium ${
+                        isActive
+                          ? "bg-white/[0.08] text-white"
+                          : "text-white/60 hover:text-white"
+                      }`
+                    }
+                  >
+                    <Icon className="h-4 w-4" />
+                    {item.label}
+                  </NavLink>
+                );
+              })}
+              <div className="my-2 border-t border-white/[0.06]" />
+              <button
+                onClick={() => navigate("/api-keys")}
+                className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+              >
+                <Key className="h-4 w-4" />
+                API keys
+              </button>
+              {isAdmin && (
+                <>
+                  <button
+                    onClick={() => navigate("/inboxes")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+                  >
+                    <InboxIcon className="h-4 w-4" />
+                    Inboxes
+                  </button>
+                  <button
+                    onClick={() => navigate("/admin/users")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+                  >
+                    <Users className="h-4 w-4" />
+                    Users
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => navigate("/settings")}
+                className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+              >
+                <SettingsIcon className="h-4 w-4" />
+                Settings
+              </button>
+              <div className="my-2 border-t border-white/[0.06]" />
+              <button
+                onClick={() => signOut()}
+                className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-red-400"
+              >
+                <LogOut className="h-4 w-4" />
+                Sign out
+              </button>
+            </div>
+          </div>
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/Wordmark.tsx
+++ b/src/components/Wordmark.tsx
@@ -1,0 +1,47 @@
+import { Mail } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface WordmarkProps {
+  className?: string;
+}
+
+/**
+ * Inline wordmark — used in sidebar header, footer brand line, and as the
+ * default text-logo replacement for the legacy /saasmail-logo.png image.
+ * Inherits color from parent so it reads on both light and dark surfaces.
+ */
+export function Wordmark({ className }: WordmarkProps) {
+  return (
+    <span
+      className={cn(
+        "text-lg font-light tracking-wide whitespace-nowrap",
+        className,
+      )}
+    >
+      saasmail
+    </span>
+  );
+}
+
+/**
+ * Larger ✦ + uppercase wordmark for auth/onboarding hero. Mirrors
+ * givefeedback.dev's auth treatment: bright lime sparkle, extrabold
+ * uppercase brand line. Sits above the auth card on the dark backdrop.
+ */
+export function WordmarkLarge({ className }: WordmarkProps) {
+  return (
+    <div
+      className={cn("flex flex-col items-center gap-3 text-white", className)}
+    >
+      <Mail
+        className="h-12 w-12"
+        strokeWidth={2}
+        style={{ color: "#BFFF00" }}
+        aria-hidden
+      />
+      <h1 className="text-2xl font-extrabold uppercase tracking-tight">
+        saasmail
+      </h1>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,24 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/25 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "bg-accent text-white shadow-sm hover:bg-accent-hover",
+        cta: "bg-accent text-white shadow-sm hover:bg-accent-hover rounded-full",
         destructive: "bg-destructive text-white shadow-sm hover:bg-red-700",
         outline:
-          "bg-white text-text-primary ring-1 ring-gray-200 hover:bg-bg-muted",
+          "bg-white text-text-primary ring-1 ring-border hover:bg-bg-muted",
         secondary:
-          "bg-white text-text-primary ring-1 ring-gray-200 hover:bg-bg-muted",
+          "bg-white text-text-primary ring-1 ring-border hover:bg-bg-muted",
         ghost: "text-text-secondary hover:bg-bg-muted hover:text-text-primary",
         link: "text-accent underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-8 px-3 py-1.5",
-        sm: "h-7 rounded-md px-2.5 text-xs",
-        lg: "h-10 rounded-lg px-5",
-        icon: "h-8 w-8",
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-11 rounded-lg px-6",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl bg-white text-text-primary ring-1 ring-gray-200 shadow-sm",
+      "rounded-xl bg-card text-card-foreground ring-1 ring-border shadow-sm",
       className,
     )}
     {...props}

--- a/src/hooks/useReducedAnimations.ts
+++ b/src/hooks/useReducedAnimations.ts
@@ -59,6 +59,13 @@ export function useReducedAnimations(): boolean {
 function evaluate(): boolean {
   if (typeof window === "undefined") return false;
 
+  // Headless browsers (Playwright, Selenium, etc.) report navigator.webdriver
+  // as true. The WebGL shader causes GPU stalls under CI Chromium that can
+  // freeze the page mid-test, so always fall back to the static backdrop.
+  if (typeof navigator !== "undefined" && navigator.webdriver) {
+    return true;
+  }
+
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
     return true;
   }

--- a/src/hooks/useReducedAnimations.ts
+++ b/src/hooks/useReducedAnimations.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+
+// Augment Navigator with the Network Information API + Device Memory API
+// types that are not yet in the standard lib.dom.d.ts.
+interface NetworkInformationLike {
+  saveData?: boolean;
+  effectiveType?: "slow-2g" | "2g" | "3g" | "4g";
+  addEventListener?: (type: "change", handler: () => void) => void;
+  removeEventListener?: (type: "change", handler: () => void) => void;
+}
+
+interface NavigatorWithCapability extends Navigator {
+  connection?: NetworkInformationLike;
+  deviceMemory?: number;
+}
+
+/**
+ * Returns `true` when we should drop heavy animations / shaders / blur
+ * filters. Triggers on:
+ *   - User preference: `prefers-reduced-motion: reduce`
+ *   - Save-Data header (`navigator.connection.saveData`)
+ *   - Slow connection (`2g`/`slow-2g`/`3g`)
+ *   - Low memory device (< 4 GB via `navigator.deviceMemory`)
+ *   - Few CPU cores (< 4 via `navigator.hardwareConcurrency`)
+ *
+ * Re-evaluates when the user toggles their motion preference.
+ */
+export function useReducedAnimations(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => evaluate());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setReduced(evaluate());
+
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onChange);
+    } else if (mql.addListener) {
+      // Safari < 14 fallback.
+      mql.addListener(onChange);
+    }
+
+    const conn = (navigator as NavigatorWithCapability).connection;
+    conn?.addEventListener?.("change", onChange);
+
+    return () => {
+      if (mql.removeEventListener) {
+        mql.removeEventListener("change", onChange);
+      } else if (mql.removeListener) {
+        mql.removeListener(onChange);
+      }
+      conn?.removeEventListener?.("change", onChange);
+    };
+  }, []);
+
+  return reduced;
+}
+
+function evaluate(): boolean {
+  if (typeof window === "undefined") return false;
+
+  if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+    return true;
+  }
+
+  const nav = navigator as NavigatorWithCapability;
+  const conn = nav.connection;
+  if (conn?.saveData) return true;
+  if (
+    conn?.effectiveType &&
+    ["slow-2g", "2g", "3g"].includes(conn.effectiveType)
+  ) {
+    return true;
+  }
+
+  if (typeof nav.deviceMemory === "number" && nav.deviceMemory < 4) {
+    return true;
+  }
+  if (
+    typeof nav.hardwareConcurrency === "number" &&
+    nav.hardwareConcurrency > 0 &&
+    nav.hardwareConcurrency < 4
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,56 +1,309 @@
 @import "tailwindcss";
 
 @theme {
+  /* ──────────────────────────────────────────────────────────────
+     Brand palette — matches givefeedback.dev
+     Lime primary + violet accent on near-white surfaces.
+     ──────────────────────────────────────────────────────────── */
+
   /* Surfaces */
-  --color-bg: #ffffff;
-  --color-bg-subtle: #f9fafb;
-  --color-bg-muted: #f3f4f6;
+  --color-background: hsl(0 0% 99%);
+  --color-bg: hsl(0 0% 99%);
+  --color-bg-subtle: hsl(220 14% 96%);
+  --color-bg-muted: hsl(220 13% 91%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(222 47% 11%);
 
   /* Borders */
-  --color-border: #e5e7eb;
-  --color-border-subtle: #f1f5f9;
+  --color-border: hsl(220 13% 91%);
+  --color-border-subtle: hsl(220 14% 96%);
+  --color-input: hsl(220 13% 91%);
 
   /* Text */
-  --color-text-primary: #0f172a;
-  --color-text-secondary: #475569;
-  --color-text-tertiary: #94a3b8;
+  --color-foreground: hsl(222 47% 11%);
+  --color-text-primary: hsl(222 47% 11%);
+  --color-text-secondary: hsl(215 16% 47%);
+  --color-text-tertiary: hsl(215 16% 65%);
+  --color-muted-foreground: hsl(215 16% 47%);
 
-  /* Accent (blue-600 system) */
-  --color-accent: #2563eb;
-  --color-accent-hover: #1d4ed8;
-  --color-accent-subtle: #eff6ff;
-  --color-accent-subtle-fg: #1d4ed8;
+  /* Primary (lime) — used for CTAs */
+  --color-primary: hsl(75 100% 32%);
+  --color-primary-foreground: hsl(0 0% 100%);
+
+  /* Saasmail's existing 'accent' name aliases the primary lime
+     so existing components (bg-accent, text-accent) inherit the
+     new brand color without rewriting every call site. */
+  --color-accent: hsl(75 100% 32%);
+  --color-accent-hover: hsl(75 100% 26%);
+  --color-accent-subtle: hsl(75 70% 94%);
+  --color-accent-subtle-fg: hsl(75 100% 22%);
+  --color-accent-foreground: hsl(0 0% 100%);
+
+  /* Brand pure-tones (used for the ✦ sparkle and footer brand line) */
+  --color-lime: #bfff00;
+  --color-violet: #7c5cfc;
+
+  /* Violet accent — focus rings, highlights, unread indicators */
+  --color-ring: hsl(254 95% 55%);
+  --color-unread: hsl(254 95% 55%);
 
   /* Semantic */
-  --color-destructive: #dc2626;
-  --color-destructive-subtle: #fee2e2;
-  --color-success: #16a34a;
-  --color-warning-bg: #fffbeb;
-  --color-warning-border: #fde68a;
-  --color-warning-text: #b45309;
+  --color-secondary: hsl(220 14% 96%);
+  --color-secondary-foreground: hsl(222 47% 11%);
+  --color-muted: hsl(220 14% 96%);
+  --color-destructive: hsl(0 72% 51%);
+  --color-destructive-subtle: hsl(0 72% 95%);
+  --color-success: hsl(142 60% 38%);
+  --color-warning-bg: hsl(48 100% 96%);
+  --color-warning-border: hsl(48 96% 76%);
+  --color-warning-text: hsl(35 91% 33%);
 
-  /* Back-compat aliases for shadcn primitives (same value as primary tokens) */
-  --color-unread: #2563eb;
+  /* Fonts */
+  --font-sans:
+    "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Helvetica, Arial, sans-serif;
+  --font-script: "Caveat", cursive;
 
   /* Radii */
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
 }
 
 html {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 body {
-  background-color: #ffffff;
-  color: #0f172a;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Helvetica, Arial,
-    sans-serif;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
   font-feature-settings: "cv11", "ss01";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Brand utilities ─────────────────────────────────────────── */
+
+.font-script {
+  font-family: var(--font-script);
+}
+
+/* Subtle animated grain backdrop for public/auth surfaces */
+.brand-backdrop {
+  background-color: #0a0a0a;
+  background-image:
+    radial-gradient(
+      ellipse 80% 60% at 20% 10%,
+      rgba(124, 92, 252, 0.35),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 70% 50% at 80% 20%,
+      rgba(191, 255, 0, 0.12),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 60% 60% at 50% 100%,
+      rgba(99, 102, 241, 0.25),
+      transparent 70%
+    );
+}
+
+/* Animated faded-out backdrop for the dashboard.
+   Matches givefeedback.dev's app — soft lavender + lime + indigo bloom
+   that gently drifts. CSS-only, no shader runtime, no extra deps. */
+.dashboard-backdrop {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-color: #f8f8f8;
+  background-image:
+    radial-gradient(
+      ellipse 50% 40% at 8% 12%,
+      rgba(196, 181, 253, 0.55),
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 45% 35% at 92% 8%,
+      rgba(163, 230, 53, 0.35),
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 55% 40% at 100% 65%,
+      rgba(129, 140, 248, 0.4),
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 60% 45% at 35% 90%,
+      rgba(233, 213, 255, 0.55),
+      transparent 65%
+    );
+  background-size:
+    140% 140%,
+    140% 140%,
+    140% 140%,
+    140% 140%;
+  background-position:
+    0% 0%,
+    100% 0%,
+    100% 50%,
+    0% 100%;
+  animation: backdrop-drift 28s ease-in-out infinite alternate;
+  filter: blur(40px) saturate(1.05);
+  z-index: 0;
+}
+
+.dashboard-backdrop::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.45'/%3E%3C/svg%3E");
+  mix-blend-mode: overlay;
+  opacity: 0.25;
+  pointer-events: none;
+}
+
+/* Static variant — same gradient, no drift / no expensive blur / no
+   noise overlay. Used by useReducedAnimations() on low-spec devices. */
+.dashboard-backdrop-static {
+  animation: none !important;
+  filter: blur(24px) saturate(1) !important;
+}
+.dashboard-backdrop-static::after {
+  display: none !important;
+}
+
+/* Honor the user's reduced-motion preference globally — kills CSS
+   animations + transitions, drops scroll smoothing, neutralizes the
+   dashboard-backdrop drift and noise overlay. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.05ms !important;
+    scroll-behavior: auto !important;
+  }
+  .dashboard-backdrop {
+    animation: none !important;
+    filter: blur(24px) saturate(1) !important;
+  }
+  .dashboard-backdrop::after {
+    display: none !important;
+  }
+}
+
+/* Fade the backdrop from full strength at top to plain background at bottom,
+   so content lower on the page reads on a clean white surface. Stops at
+   ~60vh so the footer area remains transparent (not painted over). */
+.dashboard-backdrop-mask {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(248, 248, 248, 0.35) 35%,
+    rgba(248, 248, 248, 0.7) 60%,
+    rgba(248, 248, 248, 0.7) 100%
+  );
+}
+
+/* Slide-in / slide-out keyframes for the right-side drawer.
+   Pure CSS so we don't depend on tailwindcss-animate's exact set. */
+@keyframes drawer-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes drawer-slide-out {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+@keyframes drawer-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes drawer-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.drawer-content[data-state="open"] {
+  animation: drawer-slide-in 320ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.drawer-content[data-state="closed"] {
+  animation: drawer-slide-out 240ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.drawer-overlay[data-state="open"] {
+  animation: drawer-overlay-in 200ms ease-out;
+}
+.drawer-overlay[data-state="closed"] {
+  animation: drawer-overlay-out 160ms ease-in;
+}
+
+/* Smooth, refined scrollbars on overflow containers.
+   Webkit + Firefox styling. Used by the inbox panes for independent,
+   non-jarring scroll. */
+.smooth-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(15, 23, 42, 0.18) transparent;
+  scroll-behavior: smooth;
+  overscroll-behavior: contain;
+}
+.smooth-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.smooth-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.smooth-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(15, 23, 42, 0.14);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background-color 200ms ease;
+}
+.smooth-scroll:hover::-webkit-scrollbar-thumb {
+  background-color: rgba(15, 23, 42, 0.28);
+}
+
+@keyframes backdrop-drift {
+  0% {
+    background-position:
+      0% 0%,
+      100% 0%,
+      100% 50%,
+      0% 100%;
+  }
+  100% {
+    background-position:
+      20% 15%,
+      80% 20%,
+      85% 65%,
+      15% 85%;
+  }
 }
 
 /* ── Rich Text Editor Styles ── */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,6 +17,7 @@ export interface GroupedPerson {
   unreadCount: number;
   totalCount: number;
   recipientCount: number;
+  recipients: string[];
   hasAttachment: number;
 }
 
@@ -113,11 +114,17 @@ export interface PaginatedGroupedPeople {
 
 export async function fetchGroupedPeople(params?: {
   q?: string;
+  recipient?: string;
+  unread?: boolean;
+  hasAttachment?: boolean;
   page?: number;
   limit?: number;
 }): Promise<PaginatedGroupedPeople> {
   const qs = new URLSearchParams();
   if (params?.q) qs.set("q", params.q);
+  if (params?.recipient) qs.set("recipient", params.recipient);
+  if (params?.unread) qs.set("unread", "1");
+  if (params?.hasAttachment) qs.set("hasAttachment", "1");
   if (params?.page) qs.set("page", params.page.toString());
   if (params?.limit) qs.set("limit", params.limit.toString());
   return apiFetch(`/api/people/grouped?${qs}`);
@@ -158,6 +165,19 @@ export async function deleteEmail(
 
 export async function deletePerson(id: string): Promise<{ success: boolean }> {
   return apiFetch(`/api/people/${id}`, { method: "DELETE" });
+}
+
+/** Mark all unread emails for the given people as read.
+ *  Optional `recipient` narrows the scope to a single inbox. */
+export async function markPeopleRead(
+  personIds: string[],
+  recipient?: string,
+): Promise<{ success: boolean; affected: number }> {
+  return apiFetch(`/api/people/mark-read`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ personIds, recipient }),
+  });
 }
 
 export async function sendEmail(data: {

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 export default function AdminUsersPage() {
   const { data: session } = useSession();
@@ -102,11 +103,116 @@ export default function AdminUsersPage() {
   }
 
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <div className="mx-auto max-w-4xl space-y-6">
-        <div className="rounded-lg border border-border bg-white ring-1 ring-gray-200">
-          <div className="flex items-center justify-between border-b border-border px-4 py-3">
-            <h2 className="text-xs font-semibold text-text-primary">Users</h2>
+    <PageContainer>
+      <PageHeader
+        title="Users"
+        subtitle="Invite teammates, manage roles, and track passkey adoption."
+        action={
+          <Dialog
+            open={inviteDialogOpen}
+            onOpenChange={(open) => {
+              setInviteDialogOpen(open);
+              if (!open) {
+                setGeneratedLink("");
+                setInviteEmail("");
+                setInviteRole("member");
+                setInviteExpiry("7");
+              }
+            }}
+          >
+            <DialogTrigger asChild>
+              <button className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90">
+                Invite user
+              </button>
+            </DialogTrigger>
+            <DialogContent className="border-border bg-card ring-1 ring-border text-text-primary">
+              <DialogHeader>
+                <DialogTitle className="text-text-primary">
+                  Create invitation
+                </DialogTitle>
+              </DialogHeader>
+              {!generatedLink ? (
+                <div className="space-y-3">
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-text-secondary">
+                      Role
+                    </label>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setInviteRole("member")}
+                        className={`rounded-[6px] px-3 py-1.5 text-xs ${inviteRole === "member" ? "bg-text-primary text-white" : "border border-border text-text-secondary hover:bg-bg-muted"}`}
+                      >
+                        Member
+                      </button>
+                      <button
+                        onClick={() => setInviteRole("admin")}
+                        className={`rounded-[6px] px-3 py-1.5 text-xs ${inviteRole === "admin" ? "bg-text-primary text-white" : "border border-border text-text-secondary hover:bg-bg-muted"}`}
+                      >
+                        Admin
+                      </button>
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-text-secondary">
+                      Email (optional)
+                    </label>
+                    <input
+                      type="email"
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                      placeholder="user@example.com"
+                      className="h-9 w-full rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-text-secondary">
+                      Expires in (days)
+                    </label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="30"
+                      value={inviteExpiry}
+                      onChange={(e) => setInviteExpiry(e.target.value)}
+                      className="h-9 w-full rounded-[6px] border border-border bg-card px-3 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-text-primary/15"
+                    />
+                  </div>
+                  <button
+                    onClick={handleCreateInvite}
+                    disabled={inviteLoading}
+                    className="w-full rounded-[8px] bg-text-primary py-2 text-sm font-medium text-white hover:bg-text-primary/90 disabled:opacity-50"
+                  >
+                    {inviteLoading ? "Creating…" : "Create invite"}
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <p className="text-xs text-text-secondary">
+                    Share this link with the user:
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      value={generatedLink}
+                      readOnly
+                      className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 text-xs text-text-primary focus:outline-none"
+                    />
+                    <button
+                      onClick={handleCopy}
+                      className="rounded-[6px] border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                    >
+                      {copied ? "Copied!" : "Copy"}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </DialogContent>
+          </Dialog>
+        }
+      />
+
+      <div className="max-w-4xl space-y-6">
+        <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="hidden">
             <Dialog
               open={inviteDialogOpen}
               onOpenChange={(open) => {
@@ -215,6 +321,11 @@ export default function AdminUsersPage() {
               </DialogContent>
             </Dialog>
           </div>
+          <div className="border-b border-border px-5 py-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+              Members
+            </h2>
+          </div>
           <div>
             {loading ? (
               <p className="p-4 text-xs text-text-tertiary">Loading...</p>
@@ -292,9 +403,9 @@ export default function AdminUsersPage() {
           </div>
         </div>
 
-        <div className="rounded-lg border border-border bg-white ring-1 ring-gray-200">
-          <div className="border-b border-border px-4 py-3">
-            <h2 className="text-xs font-semibold text-text-primary">
+        <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="border-b border-border px-5 py-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">
               Invitations
             </h2>
           </div>
@@ -338,6 +449,6 @@ export default function AdminUsersPage() {
           </div>
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/pages/ApiKeysPage.tsx
+++ b/src/pages/ApiKeysPage.tsx
@@ -108,7 +108,6 @@ export default function ApiKeysPage() {
                     <div>
                       <p className="font-mono text-sm font-medium text-text-primary">
                         {keyInfo.prefix}
-                        <span className="text-text-tertiary">...</span>
                       </p>
                       <p className="mt-0.5 text-xs font-light text-text-tertiary">
                         Created{" "}

--- a/src/pages/ApiKeysPage.tsx
+++ b/src/pages/ApiKeysPage.tsx
@@ -108,7 +108,7 @@ export default function ApiKeysPage() {
                     <div>
                       <p className="font-mono text-sm font-medium text-text-primary">
                         {keyInfo.prefix}
-                        <span className="text-text-tertiary">…</span>
+                        <span className="text-text-tertiary">...</span>
                       </p>
                       <p className="mt-0.5 text-xs font-light text-text-tertiary">
                         Created{" "}
@@ -153,7 +153,7 @@ export default function ApiKeysPage() {
                   onClick={handleGenerate}
                   className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
                 >
-                  Generate API key
+                  Generate API Key
                 </button>
               </div>
             )}
@@ -199,8 +199,8 @@ export default function ApiKeysPage() {
           <DialogHeader>
             <DialogTitle className="text-text-primary">
               {confirmAction === "regenerate"
-                ? "Regenerate API key?"
-                : "Revoke API key?"}
+                ? "Regenerate API Key?"
+                : "Revoke API Key?"}
             </DialogTitle>
           </DialogHeader>
           <p className="text-sm font-light text-text-secondary">

--- a/src/pages/ApiKeysPage.tsx
+++ b/src/pages/ApiKeysPage.tsx
@@ -5,22 +5,23 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Copy, Check, Key, RefreshCw, Trash2 } from "lucide-react";
 import { fetchApiKeyInfo, generateApiKey, revokeApiKey } from "@/lib/api";
 import type { ApiKeyInfo } from "@/lib/api";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 export default function ApiKeysPage() {
   const [keyInfo, setKeyInfo] = useState<ApiKeyInfo | null>(null);
   const [newKey, setNewKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
   const [confirmAction, setConfirmAction] = useState<
     "regenerate" | "revoke" | null
   >(null);
 
   useEffect(() => {
     fetchApiKeyInfo()
-      .then((keyRes) => {
-        setKeyInfo(keyRes.key);
-      })
+      .then((keyRes) => setKeyInfo(keyRes.key))
       .finally(() => setLoading(false));
   }, []);
 
@@ -39,162 +40,196 @@ export default function ApiKeysPage() {
   }
 
   function handleCopy() {
-    if (newKey) navigator.clipboard.writeText(newKey);
-  }
-
-  if (loading) {
-    return (
-      <div className="flex-1 p-6">
-        <p className="text-xs text-text-tertiary">Loading...</p>
-      </div>
-    );
+    if (!newKey) return;
+    navigator.clipboard.writeText(newKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   }
 
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <div className="mx-auto max-w-2xl">
-        <h1 className="mb-6 text-sm font-semibold text-text-primary">
-          API Access
-        </h1>
+    <PageContainer>
+      <PageHeader
+        title="API keys"
+        subtitle="Issue scoped API keys for programmatic access — send email, manage templates, enroll contacts, and query inbox data."
+      />
 
-        {/* --- API Keys Section --- */}
-        {newKey && (
-          <div className="mb-6 rounded-lg border border-warning-border bg-warning-bg px-4 py-3">
-            <p className="mb-2 text-xs font-medium text-warning-text">
-              Your API key (copy it now — it won't be shown again):
-            </p>
-            <div className="flex items-center gap-2">
-              <input
-                readOnly
-                data-testid="api-key-revealed"
-                value={newKey}
-                className="h-8 flex-1 rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 font-mono text-xs text-text-primary focus:outline-none"
-              />
-              <button
-                onClick={handleCopy}
-                className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-              >
-                Copy
-              </button>
-            </div>
-            <button
-              onClick={() => setNewKey(null)}
-              className="mt-2 text-xs text-text-tertiary hover:text-text-secondary"
-            >
-              Done
-            </button>
-          </div>
-        )}
-
-        {keyInfo && !newKey && (
-          <div className="mb-6 rounded-lg border border-border bg-white ring-1 ring-gray-200 px-4 py-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-mono text-xs text-text-primary">
-                  {keyInfo.prefix}
+      <div className="max-w-3xl space-y-5">
+        {loading ? (
+          <p className="text-sm font-light text-text-tertiary">Loading…</p>
+        ) : (
+          <>
+            {/* Newly generated key — must copy now */}
+            {newKey && (
+              <div className="rounded-[8px] border border-warning-border bg-warning-bg px-4 py-3">
+                <p className="mb-2 text-xs font-medium text-warning-text">
+                  Your API key — copy it now, it won't be shown again.
                 </p>
-                <p className="text-[11px] text-text-tertiary">
-                  Created{" "}
-                  {new Date(keyInfo.createdAt * 1000).toLocaleDateString()}
-                </p>
-              </div>
-              <div className="flex gap-2">
+                <div className="flex items-center gap-2">
+                  <input
+                    readOnly
+                    data-testid="api-key-revealed"
+                    value={newKey}
+                    className="h-9 flex-1 rounded-[6px] border border-border bg-card px-3 font-mono text-xs text-text-primary focus:outline-none"
+                  />
+                  <button
+                    onClick={handleCopy}
+                    className="inline-flex h-9 items-center gap-1.5 rounded-[6px] border border-border px-3 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                  >
+                    {copied ? (
+                      <>
+                        <Check size={12} />
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy size={12} />
+                        Copy
+                      </>
+                    )}
+                  </button>
+                </div>
                 <button
-                  onClick={() => setConfirmAction("regenerate")}
-                  className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                  onClick={() => setNewKey(null)}
+                  className="mt-2 text-xs font-light text-text-tertiary transition-colors hover:text-text-secondary"
                 >
-                  Regenerate
-                </button>
-                <button
-                  onClick={() => setConfirmAction("revoke")}
-                  className="rounded-md border border-border px-3 py-1.5 text-xs text-destructive hover:bg-bg-muted"
-                >
-                  Revoke
+                  Done
                 </button>
               </div>
+            )}
+
+            {/* Existing key */}
+            {keyInfo && !newKey && (
+              <div className="rounded-[8px] bg-card p-5 ring-1 ring-border">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start gap-3">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-violet/10 text-violet">
+                      <Key size={16} style={{ color: "#7c5cfc" }} />
+                    </span>
+                    <div>
+                      <p className="font-mono text-sm font-medium text-text-primary">
+                        {keyInfo.prefix}
+                        <span className="text-text-tertiary">…</span>
+                      </p>
+                      <p className="mt-0.5 text-xs font-light text-text-tertiary">
+                        Created{" "}
+                        {new Date(
+                          keyInfo.createdAt * 1000,
+                        ).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <button
+                      onClick={() => setConfirmAction("regenerate")}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] border border-border px-3 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                    >
+                      <RefreshCw size={12} />
+                      Regenerate
+                    </button>
+                    <button
+                      onClick={() => setConfirmAction("revoke")}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] border border-border px-3 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+                    >
+                      <Trash2 size={12} />
+                      Revoke
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {!keyInfo && !newKey && (
+              <div className="rounded-[8px] bg-card p-8 text-center ring-1 ring-border">
+                <span className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet/10 text-violet">
+                  <Key size={20} style={{ color: "#7c5cfc" }} />
+                </span>
+                <p className="mb-1 text-sm font-medium text-text-primary">
+                  No API key yet
+                </p>
+                <p className="mb-4 text-xs font-light text-text-tertiary">
+                  Generate a key to start using the API programmatically.
+                </p>
+                <button
+                  onClick={handleGenerate}
+                  className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
+                >
+                  Generate API key
+                </button>
+              </div>
+            )}
+
+            {/* Usage */}
+            <div className="rounded-[8px] bg-card p-5 ring-1 ring-border">
+              <h2 className="mb-2 text-sm font-semibold text-text-primary">
+                Usage
+              </h2>
+              <p className="mb-3 text-xs font-light text-text-secondary">
+                Include your API key in the{" "}
+                <code className="rounded bg-bg-muted px-1 py-0.5 font-mono">
+                  Authorization
+                </code>{" "}
+                header.
+              </p>
+              <pre className="overflow-x-auto rounded-[6px] bg-bg-subtle p-3 text-[12px] font-mono text-text-secondary ring-1 ring-border">
+                {`curl -H "Authorization: Bearer sk_..." \\
+  ${typeof window !== "undefined" ? window.location.origin : "https://your-instance"}/api/people`}
+              </pre>
+              <p className="mt-3 text-xs font-light text-text-secondary">
+                The key grants full access to the API as your user account. See{" "}
+                <a
+                  href="/swagger-ui"
+                  className="font-medium text-violet hover:underline"
+                  style={{ color: "#7c5cfc" }}
+                >
+                  API docs
+                </a>{" "}
+                for available endpoints.
+              </p>
             </div>
-          </div>
+          </>
         )}
-
-        {!keyInfo && !newKey && (
-          <div className="mb-6 rounded-lg border border-border bg-white ring-1 ring-gray-200 px-4 py-4 text-center">
-            <p className="mb-3 text-xs text-text-tertiary">
-              No API key generated yet.
-            </p>
-            <button
-              onClick={handleGenerate}
-              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
-            >
-              Generate API Key
-            </button>
-          </div>
-        )}
-
-        <div className="mb-6 rounded-lg border border-border bg-white ring-1 ring-gray-200 p-4">
-          <h2 className="mb-2 text-xs font-semibold text-text-primary">
-            API Key Usage
-          </h2>
-          <p className="mb-2 text-xs text-text-secondary">
-            Include your API key in the{" "}
-            <code className="text-accent">Authorization</code> header:
-          </p>
-          <pre className="rounded bg-bg-subtle p-3 text-[11px] text-text-secondary">
-            {`curl -H "Authorization: Bearer sk_..." \\
-  ${window.location.origin}/api/people`}
-          </pre>
-          <p className="mt-2 text-xs text-text-secondary">
-            The key grants full access to the API as your user account. See{" "}
-            <a
-              href="/swagger-ui"
-              className="text-accent hover:text-accent-hover"
-            >
-              API docs
-            </a>{" "}
-            for available endpoints.
-          </p>
-        </div>
-
-        {/* Confirmation Dialog */}
-        <Dialog
-          open={confirmAction !== null}
-          onOpenChange={() => setConfirmAction(null)}
-        >
-          <DialogContent className="border-border bg-white ring-1 ring-gray-200 text-text-primary">
-            <DialogHeader>
-              <DialogTitle className="text-text-primary">
-                {confirmAction === "regenerate"
-                  ? "Regenerate API Key?"
-                  : "Revoke API Key?"}
-              </DialogTitle>
-            </DialogHeader>
-            <p className="text-xs text-text-secondary">
-              {confirmAction === "regenerate"
-                ? "This will invalidate your current key and generate a new one. Any integrations using the old key will stop working."
-                : "This will permanently delete your API key. Any integrations using it will stop working."}
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setConfirmAction(null)}
-                className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={
-                  confirmAction === "regenerate" ? handleGenerate : handleRevoke
-                }
-                className={`rounded-md px-3 py-1.5 text-xs font-medium text-white ${
-                  confirmAction === "revoke"
-                    ? "bg-destructive hover:bg-destructive/90"
-                    : "bg-accent hover:bg-accent-hover"
-                }`}
-              >
-                {confirmAction === "regenerate" ? "Regenerate" : "Revoke"}
-              </button>
-            </div>
-          </DialogContent>
-        </Dialog>
       </div>
-    </div>
+
+      {/* Confirmation dialog */}
+      <Dialog
+        open={confirmAction !== null}
+        onOpenChange={() => setConfirmAction(null)}
+      >
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">
+              {confirmAction === "regenerate"
+                ? "Regenerate API key?"
+                : "Revoke API key?"}
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-light text-text-secondary">
+            {confirmAction === "regenerate"
+              ? "This will invalidate your current key and generate a new one. Any integrations using the old key will stop working."
+              : "This will permanently delete your API key. Any integrations using it will stop working."}
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              onClick={() => setConfirmAction(null)}
+              className="rounded-[6px] border border-border px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={
+                confirmAction === "regenerate" ? handleGenerate : handleRevoke
+              }
+              className={`rounded-[6px] px-3 py-1.5 text-xs font-medium text-white ${
+                confirmAction === "revoke"
+                  ? "bg-destructive hover:bg-destructive/90"
+                  : "bg-text-primary hover:bg-text-primary/90"
+              }`}
+            >
+              {confirmAction === "regenerate" ? "Regenerate" : "Revoke"}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </PageContainer>
   );
 }

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,12 +1,23 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import { useParams } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useParams, useOutletContext } from "react-router-dom";
+import { ArrowLeft, PenSquare } from "lucide-react";
+
+interface InboxOutletContext {
+  onCompose: () => void;
+}
 import PersonList from "./PersonList";
 import PersonDetail from "./PersonDetail";
-import ComposeModal from "./ComposeModal";
+import InboxToolbar, {
+  type InboxFilters,
+  type InboxView,
+} from "@/components/InboxToolbar";
+import PeopleTable from "@/components/PeopleTable";
+import SelectionBar from "@/components/SelectionBar";
 import {
   fetchPerson,
   fetchStats,
+  fetchGroupedPeople,
+  markPeopleRead,
   type GroupedPerson,
   type Stats,
 } from "@/lib/api";
@@ -15,13 +26,114 @@ import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
 import { PushOptInBanner } from "@/components/PushOptInBanner";
 import { isPushSupported, hasDismissedPrompt } from "@/lib/push";
 
+const PEOPLE_PAGE_SIZE = 40;
+
 export default function InboxPage() {
+  const outlet = useOutletContext<InboxOutletContext | null>();
+  const onCompose = outlet?.onCompose ?? (() => {});
   const [selectedPerson, setSelectedPerson] = useState<GroupedPerson | null>(
     null,
   );
   const [people, setPeople] = useState<GroupedPerson[]>([]);
-  const [composeOpen, setComposeOpen] = useState(false);
+  const [peopleTotal, setPeopleTotal] = useState(0);
+  const [peoplePage, setPeoplePage] = useState(1);
+  const [peopleLoading, setPeopleLoading] = useState(true);
   const [stats, setStats] = useState<Stats | null>(null);
+  const [filters, setFilters] = useState<InboxFilters>({});
+  const [search, setSearch] = useState("");
+  const [view, setView] = useState<InboxView>("table");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  // Reset to page 1 whenever the query inputs change.
+  useEffect(() => {
+    setPeoplePage(1);
+  }, [search, filters.recipient, filters.unread, filters.hasAttachment]);
+
+  // Fetch the people list at the InboxPage level so both Table view
+  // (PeopleTable) and List view (PersonList sidebar) see the same data.
+  // Previously the fetch lived inside PersonList, which meant Table view
+  // showed an empty state because PersonList wasn't mounted.
+  useEffect(() => {
+    setPeopleLoading(true);
+    const t = setTimeout(() => {
+      fetchGroupedPeople({
+        q: search || undefined,
+        recipient: filters.recipient,
+        unread: filters.unread,
+        hasAttachment: filters.hasAttachment,
+        page: peoplePage,
+        limit: PEOPLE_PAGE_SIZE,
+      })
+        .then((res) => {
+          setPeople(res.data);
+          setPeopleTotal(res.total);
+        })
+        .finally(() => setPeopleLoading(false));
+    }, 200);
+    return () => clearTimeout(t);
+  }, [
+    search,
+    peoplePage,
+    filters.recipient,
+    filters.unread,
+    filters.hasAttachment,
+  ]);
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const allOnPage = people.every((p) => prev.has(p.id));
+      if (allOnPage) {
+        const next = new Set(prev);
+        for (const p of people) next.delete(p.id);
+        return next;
+      }
+      const next = new Set(prev);
+      for (const p of people) next.add(p.id);
+      return next;
+    });
+  }, [people]);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
+
+  // Optimistic mark-read: clear unread locally, fire API, refresh on success.
+  async function applyMarkRead(personIds: string[]) {
+    if (personIds.length === 0) return;
+    setBulkBusy(true);
+    const before = people;
+    setPeople(
+      people.map((p) =>
+        personIds.includes(p.id) ? { ...p, unreadCount: 0 } : p,
+      ),
+    );
+    try {
+      await markPeopleRead(personIds);
+      incrementRefreshKey();
+    } catch {
+      setPeople(before);
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
+  function handleMarkPersonRead(id: string) {
+    applyMarkRead([id]);
+  }
+
+  function handleBulkMarkRead() {
+    const ids = Array.from(selectedIds);
+    applyMarkRead(ids);
+    clearSelection();
+  }
   const [refreshKey, setRefreshKey] = useState(0);
   const [showBanner, setShowBanner] = useState(false);
   const { data: session } = useSession();
@@ -125,8 +237,8 @@ export default function InboxPage() {
 
   if (stats && stats.recipients.length === 0 && !isAdmin) {
     return (
-      <div className="flex flex-1 items-center justify-center p-10 text-center">
-        <div>
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1 items-center justify-center px-4 py-16 md:px-6">
+        <div className="rounded-2xl bg-card p-12 text-center ring-1 ring-border">
           <h2 className="text-lg font-semibold text-text-primary">
             No inboxes assigned yet
           </h2>
@@ -139,60 +251,199 @@ export default function InboxPage() {
   }
 
   return (
-    <>
-      {/* Middle panel — person list (hidden on mobile when a person is selected) */}
+    <div className="mx-auto flex w-full max-w-[1600px] flex-1 flex-col px-4 pb-12 md:px-6">
+      {/* Page header — compact on mobile, expansive on desktop. Compose
+          button is hidden on mobile (the floating FAB replaces it).
+          On mobile we hide the header entirely when a person is open so
+          the conversation gets full-screen real estate. */}
       <div
-        className={`w-full md:w-80 shrink-0 border-r border-border bg-bg-subtle ${
-          selectedPerson ? "hidden md:block" : "block"
-        }`}
+        className={`mb-3 items-end justify-between gap-4 pt-4 sm:mb-4 sm:pt-6 ${selectedPerson ? "hidden sm:flex" : "flex"}`}
       >
-        {showBanner && <PushOptInBanner onClose={() => setShowBanner(false)} />}
-        <PersonList
-          people={people}
-          setPeople={setPeople}
-          selectedPersonId={selectedPerson?.id ?? null}
-          onSelectPerson={setSelectedPerson}
-          onPersonDeleted={(id) => {
-            if (selectedPerson?.id === id) setSelectedPerson(null);
-          }}
-          refreshKey={refreshKey}
-          isAdmin={isAdmin}
-        />
+        <div>
+          <h1 className="text-2xl font-extrabold tracking-tight text-text-primary sm:text-3xl md:text-4xl">
+            Inbox
+          </h1>
+          <p className="mt-0.5 text-xs font-light text-text-secondary sm:mt-1 sm:text-sm">
+            One unified timeline per customer.
+          </p>
+        </div>
+        <button
+          onClick={onCompose}
+          className="hidden shrink-0 items-center gap-2 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90 sm:inline-flex"
+        >
+          <PenSquare className="h-3.5 w-3.5" />
+          Compose
+        </button>
       </div>
 
-      {/* Right panel — email detail (hidden on mobile when no person selected) */}
+      {/* Toolbar — search + filters + view toggle, all on one row.
+          Hidden when a person is open in table view to keep the focus on
+          the conversation. (Toggle stays accessible via the back button.) */}
+      {!(view === "table" && selectedPerson) && (
+        <div className={`mb-3 ${selectedPerson ? "hidden sm:block" : ""}`}>
+          <InboxToolbar
+            filters={filters}
+            onFiltersChange={setFilters}
+            inboxes={stats?.senderIdentities ?? []}
+            search={search}
+            onSearchChange={setSearch}
+            view={view}
+            onViewChange={(v) => {
+              setView(v);
+              setSelectedPerson(null);
+              clearSelection();
+            }}
+          />
+        </div>
+      )}
+
+      {/* Selection bar — desktop: above the inbox card. Mobile: floats at
+          the bottom of the screen so the user's thumb can reach it. */}
+      {selectedIds.size > 0 && !selectedPerson && (
+        <>
+          <div className="mb-3 hidden sm:block">
+            <SelectionBar
+              count={selectedIds.size}
+              busy={bulkBusy}
+              onMarkRead={handleBulkMarkRead}
+              onClear={clearSelection}
+            />
+          </div>
+          <div
+            className="fixed inset-x-3 bottom-3 z-40 sm:hidden"
+            style={{ bottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+          >
+            <SelectionBar
+              count={selectedIds.size}
+              busy={bulkBusy}
+              onMarkRead={handleBulkMarkRead}
+              onClear={clearSelection}
+            />
+          </div>
+        </>
+      )}
+
       <div
-        className={`flex-1 bg-white min-w-0 ${
-          selectedPerson ? "block" : "hidden md:block"
+        className={`-mx-4 flex flex-col overflow-hidden rounded-none bg-card shadow-sm ring-0 sm:mx-0 sm:rounded-[8px] sm:ring-1 sm:ring-border ${
+          selectedPerson
+            ? "h-[calc(100vh-7rem)] min-h-[420px] sm:h-[calc(100vh-19rem)] sm:min-h-[520px]"
+            : "h-[calc(100vh-19rem)] min-h-[480px] sm:h-[calc(100vh-19rem)] sm:min-h-[520px]"
         }`}
       >
-        {selectedPerson ? (
-          <div className="flex h-full flex-col">
-            {/* Mobile back button */}
-            <button
-              onClick={() => setSelectedPerson(null)}
-              className="flex items-center gap-1.5 px-4 py-2 text-xs text-text-secondary hover:text-text-primary md:hidden border-b border-border"
-            >
-              <ArrowLeft size={14} />
-              Back
-            </button>
-            <div className="flex-1 overflow-hidden">
-              <PersonDetail
-                person={selectedPerson}
-                onEmailRead={handleEmailRead}
-                onEmailDelete={handleEmailDelete}
-                refreshKey={refreshKey}
+        {view === "table" ? (
+          selectedPerson ? (
+            // Table view + person open → full-width person detail.
+            <div className="flex h-full min-h-0 flex-col">
+              <div className="flex shrink-0 items-center gap-3 border-b border-border bg-bg-subtle/60 px-4 py-2">
+                <button
+                  onClick={() => setSelectedPerson(null)}
+                  className="inline-flex items-center gap-1.5 rounded-[6px] px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                >
+                  <ArrowLeft size={13} />
+                  Back to all
+                </button>
+                <span className="text-[11px] font-light text-text-tertiary">
+                  Viewing {selectedPerson.name || selectedPerson.email}
+                </span>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <PersonDetail
+                  person={selectedPerson}
+                  onEmailRead={handleEmailRead}
+                  onEmailDelete={handleEmailDelete}
+                  refreshKey={refreshKey}
+                />
+              </div>
+            </div>
+          ) : (
+            // Table view, no selection → full table. `min-h-0 overflow-hidden`
+            // is required so the inner ScrollArea actually constrains and the
+            // table can scroll instead of pushing the page taller.
+            <div className="flex min-h-0 flex-1 overflow-hidden bg-card">
+              <PeopleTable
+                people={people}
+                onSelectPerson={(p) => setSelectedPerson(p)}
+                selectedIds={selectedIds}
+                onToggleSelected={toggleSelected}
+                onToggleSelectAll={toggleSelectAll}
+                onMarkPersonRead={handleMarkPersonRead}
               />
             </div>
-          </div>
+          )
         ) : (
-          <div className="flex h-full items-center justify-center text-text-tertiary">
-            Select a person to view emails
+          // List view — sidebar + detail (or empty state).
+          <div className="flex h-full min-h-0">
+            <div
+              className={`w-full shrink-0 border-r border-border bg-bg-subtle md:w-96 ${
+                selectedPerson ? "hidden md:block" : "block"
+              }`}
+            >
+              {showBanner && (
+                <PushOptInBanner onClose={() => setShowBanner(false)} />
+              )}
+              <PersonList
+                people={people}
+                setPeople={setPeople}
+                loading={peopleLoading}
+                total={peopleTotal}
+                pageSize={PEOPLE_PAGE_SIZE}
+                page={peoplePage}
+                onPageChange={setPeoplePage}
+                selectedPersonId={selectedPerson?.id ?? null}
+                onSelectPerson={setSelectedPerson}
+                onPersonDeleted={(id) => {
+                  if (selectedPerson?.id === id) setSelectedPerson(null);
+                }}
+                isAdmin={isAdmin}
+                selectedIds={selectedIds}
+                onToggleSelected={toggleSelected}
+                onMarkPersonRead={handleMarkPersonRead}
+              />
+            </div>
+
+            <div
+              className={`min-w-0 flex-1 bg-card ${
+                selectedPerson ? "block" : "hidden md:block"
+              }`}
+            >
+              {selectedPerson ? (
+                <div className="flex h-full flex-col">
+                  <button
+                    onClick={() => setSelectedPerson(null)}
+                    className="flex items-center gap-1.5 border-b border-border px-4 py-2 text-xs text-text-secondary hover:text-text-primary md:hidden"
+                  >
+                    <ArrowLeft size={14} />
+                    Back
+                  </button>
+                  <div className="flex-1 overflow-hidden">
+                    <PersonDetail
+                      person={selectedPerson}
+                      onEmailRead={handleEmailRead}
+                      onEmailDelete={handleEmailDelete}
+                      refreshKey={refreshKey}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
+                  <span
+                    className="text-3xl leading-none"
+                    style={{ color: "#7c5cfc" }}
+                    aria-hidden
+                  >
+                    ✦
+                  </span>
+                  <p className="max-w-[280px] text-sm font-light text-text-tertiary">
+                    Pick a person from the list to read their full timeline, or
+                    switch to <span className="font-medium">Table</span> view
+                    for an overview.
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>
-
-      <ComposeModal open={composeOpen} onClose={() => setComposeOpen(false)} />
-    </>
+    </div>
   );
 }

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useOutletContext } from "react-router-dom";
 import { ArrowLeft, PenSquare } from "lucide-react";
 
@@ -41,7 +41,7 @@ export default function InboxPage() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [filters, setFilters] = useState<InboxFilters>({});
   const [search, setSearch] = useState("");
-  const [view, setView] = useState<InboxView>("table");
+  const [view, setView] = useState<InboxView>("list");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
 
@@ -434,9 +434,9 @@ export default function InboxPage() {
                     ✦
                   </span>
                   <p className="max-w-[280px] text-sm font-light text-text-tertiary">
-                    Pick a person from the list to read their full timeline, or
-                    switch to <span className="font-medium">Table</span> view
-                    for an overview.
+                    Select a person to view emails, or switch to{" "}
+                    <span className="font-medium">Table</span> view for an
+                    overview.
                   </p>
                 </div>
               )}

--- a/src/pages/InboxesPage.tsx
+++ b/src/pages/InboxesPage.tsx
@@ -1,6 +1,7 @@
 import { useSession } from "@/lib/auth-client";
 import { Navigate } from "react-router-dom";
 import AdminInboxTable from "@/components/AdminInboxTable";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 export default function InboxesPage() {
   const { data: session } = useSession();
@@ -8,12 +9,12 @@ export default function InboxesPage() {
     return <Navigate to="/" replace />;
   }
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <h1 className="text-lg font-semibold text-text-primary mb-2">Inboxes</h1>
-      <p className="mb-6 text-sm text-text-secondary">
-        Set display names and control which members can access each inbox.
-      </p>
+    <PageContainer>
+      <PageHeader
+        title="Inboxes"
+        subtitle="Set display names, choose chat or thread mode, and assign which members can access each inbox."
+      />
       <AdminInboxTable />
-    </div>
+    </PageContainer>
   );
 }

--- a/src/pages/InviteAcceptPage.tsx
+++ b/src/pages/InviteAcceptPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { signIn } from "@/lib/auth-client";
 import { validateInvite, acceptInvite } from "@/lib/api";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { WordmarkLarge } from "@/components/Wordmark";
 import { useBranding } from "@/lib/branding";
 
 export default function InviteAcceptPage() {
@@ -71,118 +71,110 @@ export default function InviteAcceptPage() {
   }
 
   if (status === "loading") {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-bg-subtle">
-        <p className="text-text-secondary">Validating invitation...</p>
-      </div>
-    );
+    return <p className="text-sm text-white/60">Validating invitation…</p>;
   }
 
   if (status === "invalid") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-bg-subtle">
-        <Card className="w-full max-w-sm border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">
-              Invalid Invitation
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xs text-text-secondary">
-              This invitation link is invalid, expired, or has already been
-              used.
-            </p>
-          </CardContent>
-        </Card>
+      <div className="flex w-full max-w-sm flex-col items-center gap-8">
+        <WordmarkLarge />
+        <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Invalid invitation
+          </h2>
+          <p className="mt-3 text-sm font-light text-white/60">
+            This invitation link is invalid, expired, or has already been used.
+          </p>
+        </div>
       </div>
     );
   }
 
-  const inputClass =
-    "h-8 w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 text-xs text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent";
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-subtle px-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-6">
-        <img src="/saasmail-logo.png" alt="saasmail" className="h-10 w-auto" />
-        <Card className="w-full border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">
-              Join saasmail
-            </CardTitle>
-            <p className="text-xs text-text-secondary">
-              Create your account to get started.
+    <div className="flex w-full max-w-sm flex-col items-center gap-8">
+      <WordmarkLarge />
+      <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+        <div className="mb-6">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Join saasmail
+          </h2>
+          <p className="mt-1.5 text-sm font-light text-white/60">
+            Create your account to get started.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="invite-name"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Name
+            </label>
+            <input
+              id="invite-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              autoComplete="name"
+              className={INPUT_CLASS}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="invite-email"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Email
+            </label>
+            <input
+              id="invite-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              disabled={!!inviteEmail}
+              className={INPUT_CLASS + (inviteEmail ? " opacity-60" : "")}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="invite-password"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Password
+            </label>
+            <input
+              id="invite-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              autoComplete="new-password"
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs font-light text-white/40">
+              At least 8 characters.
             </p>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-3">
-              <div className="space-y-1">
-                <label
-                  htmlFor="invite-name"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Name
-                </label>
-                <input
-                  id="invite-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                  autoComplete="name"
-                  className={inputClass}
-                />
-              </div>
-              <div className="space-y-1">
-                <label
-                  htmlFor="invite-email"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Email
-                </label>
-                <input
-                  id="invite-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  disabled={!!inviteEmail}
-                  className={inputClass + (inviteEmail ? " opacity-50" : "")}
-                />
-              </div>
-              <div className="space-y-1">
-                <label
-                  htmlFor="invite-password"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Password
-                </label>
-                <input
-                  id="invite-password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className={inputClass}
-                />
-                <p className="text-[10px] text-text-tertiary">
-                  At least 8 characters.
-                </p>
-              </div>
-              {error && <p className="text-xs text-destructive">{error}</p>}
-              <button
-                type="submit"
-                className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-                disabled={loading}
-              >
-                {loading ? "Creating account..." : "Create account"}
-              </button>
-            </form>
-          </CardContent>
-        </Card>
+          </div>
+          {error && (
+            <p className="text-sm text-red-300" role="alert">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            className="w-full rounded-full bg-white py-2.5 text-sm font-medium text-[#0a0a0a] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? "Creating account…" : "Create account"}
+          </button>
+        </form>
       </div>
     </div>
   );
 }
+
+const INPUT_CLASS =
+  "h-10 w-full rounded-md border-0 bg-white/5 px-3 text-sm text-white ring-1 ring-white/15 placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-white/40 transition-all";

--- a/src/pages/InviteAcceptPage.tsx
+++ b/src/pages/InviteAcceptPage.tsx
@@ -62,7 +62,12 @@ export default function InviteAcceptPage() {
         setError("Account created but sign-in failed. Please go to login.");
         return;
       }
-      window.location.href = passkeyRequired ? "/setup-passkey" : "/";
+      // Redirect home regardless of passkey gating; the auth guard will
+      // bounce to /setup-passkey if needed once the session is loaded.
+      // This avoids a race where /api/config hasn't responded yet and we
+      // end up stuck on /invite/ while passkeyRequired flips.
+      void passkeyRequired;
+      window.location.href = "/";
     } catch (err: any) {
       setError(err?.message || "Failed to accept invitation");
     } finally {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -210,4 +210,4 @@ export default function LoginPage() {
 }
 
 const INPUT_CLASS =
-  "h-11 w-full rounded-md border-0 bg-white/5 px-3 text-sm text-white ring-1 ring-white/15 placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-white/40 transition-all";
+  "h-11 w-full rounded-md border-0 bg-white/5 px-3 text-sm text-white ring-1 ring-white/15 placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-white/40";

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -96,7 +96,7 @@ export default function LoginPage() {
         {error && (
           <p
             role="alert"
-            className="mb-4 rounded-md bg-red-500/15 px-3 py-2 text-center text-xs text-red-200 ring-1 ring-red-500/25"
+            className="text-destructive mb-4 rounded-md bg-red-500/15 px-3 py-2 text-center text-xs text-red-200 ring-1 ring-red-500/25"
           >
             {error}
           </p>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -123,7 +123,7 @@ export default function LoginPage() {
               className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md bg-[#24292f] px-4 text-sm font-semibold text-white ring-1 ring-white/15 transition-colors hover:bg-[#24292f]/80"
             >
               <Mail className="h-4 w-4" strokeWidth={2.25} />
-              Continue with email
+              Sign in with email instead
             </button>
           </div>
         ) : (
@@ -138,6 +138,7 @@ export default function LoginPage() {
               <input
                 id="login-email"
                 type="email"
+                placeholder="Email"
                 autoComplete="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -155,6 +156,7 @@ export default function LoginPage() {
               <input
                 id="login-password"
                 type="password"
+                placeholder="Password"
                 autoComplete="current-password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -171,8 +173,12 @@ export default function LoginPage() {
                 "Signing in…"
               ) : (
                 <>
-                  Sign in
-                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                  <span>Sign in</span>
+                  <ArrowRight
+                    className="h-4 w-4"
+                    strokeWidth={2.25}
+                    aria-hidden
+                  />
                 </>
               )}
             </button>
@@ -184,7 +190,7 @@ export default function LoginPage() {
               }}
               className="block w-full text-center text-xs font-light text-white/50 transition-colors hover:text-white/80"
             >
-              Use a passkey instead
+              Sign in with passkey instead
             </button>
           </form>
         )}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
+import { Mail, Fingerprint, ArrowRight } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function LoginPage() {
   const [error, setError] = useState("");
@@ -29,8 +29,8 @@ export default function LoginPage() {
 
   if (setupRequired === null) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-bg-subtle">
-        <p className="text-text-secondary">Loading...</p>
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <p className="animate-pulse text-sm text-white/40">Loading…</p>
       </div>
     );
   }
@@ -61,10 +61,7 @@ export default function LoginPage() {
     setLoading(true);
     setError("");
     try {
-      const result = await authClient.signIn.email({
-        email,
-        password,
-      });
+      const result = await authClient.signIn.email({ email, password });
       if (result?.error) {
         setError(result.error.message || "Sign-in failed");
       } else {
@@ -78,76 +75,133 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-subtle px-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-6">
-        <img src="/saasmail-logo.png" alt="saasmail" className="h-10 w-auto" />
-        <Card className="w-full border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">Sign in</CardTitle>
-            <p className="text-xs text-text-secondary">Welcome back.</p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {error && <p className="text-xs text-destructive">{error}</p>}
-            {mode === "passkey" ? (
-              <>
-                <button
-                  className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-                  onClick={handlePasskeyLogin}
-                  disabled={loading}
-                >
-                  {loading ? "Signing in..." : "Sign in with Passkey"}
-                </button>
-                <button
-                  className="w-full text-xs text-text-secondary hover:text-text-primary"
-                  onClick={() => {
-                    setError("");
-                    setMode("password");
-                  }}
-                  type="button"
-                >
-                  Sign in with email instead
-                </button>
-              </>
-            ) : (
-              <form onSubmit={handlePasswordLogin} className="space-y-3">
-                <input
-                  type="email"
-                  placeholder="Email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none"
-                  required
-                />
-                <input
-                  type="password"
-                  placeholder="Password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none"
-                  required
-                />
-                <button
-                  type="submit"
-                  className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-                  disabled={loading}
-                >
-                  {loading ? "Signing in..." : "Sign in"}
-                </button>
-                <button
-                  className="w-full text-xs text-text-secondary hover:text-text-primary"
-                  onClick={() => {
-                    setError("");
-                    setMode("passkey");
-                  }}
-                  type="button"
-                >
-                  Sign in with passkey instead
-                </button>
-              </form>
-            )}
-          </CardContent>
-        </Card>
+    <div className="relative z-10 mx-4 w-full max-w-sm">
+      <div className="rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+        {/* Brand block — matches givefeedback's auth layout exactly */}
+        <div className="mb-8 text-center">
+          <Mail
+            className="mx-auto mb-4 h-12 w-12"
+            strokeWidth={2}
+            style={{ color: "#BFFF00" }}
+            aria-hidden
+          />
+          <h1 className="text-2xl font-extrabold uppercase tracking-tight text-white">
+            saasmail
+          </h1>
+          <p className="mt-2 text-sm font-light text-white/50">
+            One unified timeline per customer
+          </p>
+        </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="mb-4 rounded-md bg-red-500/15 px-3 py-2 text-center text-xs text-red-200 ring-1 ring-red-500/25"
+          >
+            {error}
+          </p>
+        )}
+
+        {mode === "passkey" ? (
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={handlePasskeyLogin}
+              disabled={loading}
+              className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md bg-white px-4 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Fingerprint className="h-4 w-4" strokeWidth={2.25} />
+              {loading ? "Signing in…" : "Continue with passkey"}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setError("");
+                setMode("password");
+              }}
+              className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md bg-[#24292f] px-4 text-sm font-semibold text-white ring-1 ring-white/15 transition-colors hover:bg-[#24292f]/80"
+            >
+              <Mail className="h-4 w-4" strokeWidth={2.25} />
+              Continue with email
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handlePasswordLogin} className="space-y-3">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="login-email"
+                className="text-[11px] font-medium uppercase tracking-wider text-white/50"
+              >
+                Email
+              </label>
+              <input
+                id="login-email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className={INPUT_CLASS}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label
+                htmlFor="login-password"
+                className="text-[11px] font-medium uppercase tracking-wider text-white/50"
+              >
+                Password
+              </label>
+              <input
+                id="login-password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className={INPUT_CLASS}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md bg-white px-4 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {loading ? (
+                "Signing in…"
+              ) : (
+                <>
+                  Sign in
+                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setError("");
+                setMode("passkey");
+              }}
+              className="block w-full text-center text-xs font-light text-white/50 transition-colors hover:text-white/80"
+            >
+              Use a passkey instead
+            </button>
+          </form>
+        )}
+
+        <p className="mt-6 text-center text-xs font-light text-white/30">
+          By signing in, you agree to our{" "}
+          <a
+            href="/terms"
+            className="underline-offset-2 hover:text-white/60 hover:underline"
+          >
+            Terms of Service
+          </a>
+        </p>
       </div>
     </div>
   );
 }
+
+const INPUT_CLASS =
+  "h-11 w-full rounded-md border-0 bg-white/5 px-3 text-sm text-white ring-1 ring-white/15 placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-white/40 transition-all";

--- a/src/pages/NotificationsSettingsPage.tsx
+++ b/src/pages/NotificationsSettingsPage.tsx
@@ -5,6 +5,7 @@ import {
   enablePush,
   disablePush,
 } from "@/lib/push";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 interface Subscription {
   id: string;
@@ -39,21 +40,30 @@ export default function NotificationsSettingsPage() {
     void refresh();
   }, []);
 
+  function MessageState({ children }: { children: React.ReactNode }) {
+    return (
+      <PageContainer>
+        <PageHeader title="Settings" />
+        <p className="text-sm text-text-secondary">{children}</p>
+      </PageContainer>
+    );
+  }
+
   if (!supported) {
     return (
-      <div className="p-6 text-sm text-text-secondary">
+      <MessageState>
         Your browser does not support push notifications.
-      </div>
+      </MessageState>
     );
   }
   if (pushEnabled === null) {
-    return <div className="p-6 text-sm text-text-secondary">Loading…</div>;
+    return <MessageState>Loading…</MessageState>;
   }
   if (pushEnabled === false) {
     return (
-      <div className="p-6 text-sm text-text-secondary">
+      <MessageState>
         Push notifications are not configured on this saasmail deployment.
-      </div>
+      </MessageState>
     );
   }
 
@@ -94,71 +104,85 @@ export default function NotificationsSettingsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 p-6">
-      <h1 className="text-xl font-semibold text-text-primary">Notifications</h1>
+    <PageContainer>
+      <PageHeader
+        title="Settings"
+        subtitle="Manage push notifications and per-device subscriptions."
+      />
 
-      <section className="rounded-md border border-border bg-bg-subtle p-4">
-        <h2 className="text-sm font-medium text-text-primary">This browser</h2>
-        <p className="mt-1 text-xs text-text-tertiary">
-          {subscribedHere
-            ? "Push is on for this browser."
-            : "Push is off for this browser."}
-        </p>
-        {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
-        <div className="mt-3">
-          {subscribedHere ? (
-            <button
-              className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-              disabled={busy || !vapidPublicKey}
-              onClick={onDisable}
-            >
-              Disable
-            </button>
+      <div className="max-w-3xl space-y-5">
+        <section className="rounded-[8px] bg-card p-5 ring-1 ring-border">
+          <h2 className="text-sm font-semibold text-text-primary">
+            This browser
+          </h2>
+          <p className="mt-1 text-xs font-light text-text-secondary">
+            {subscribedHere
+              ? "Push is on for this browser."
+              : "Push is off for this browser."}
+          </p>
+          {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+          <div className="mt-3">
+            {subscribedHere ? (
+              <button
+                className="rounded-[6px] border border-border px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                disabled={busy || !vapidPublicKey}
+                onClick={onDisable}
+              >
+                Disable
+              </button>
+            ) : (
+              <button
+                className="rounded-[6px] bg-text-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-text-primary/90"
+                disabled={busy || !vapidPublicKey}
+                onClick={onEnable}
+              >
+                Enable
+              </button>
+            )}
+          </div>
+        </section>
+
+        <section className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="border-b border-border px-5 py-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+              All subscribed browsers
+            </h2>
+          </div>
+          {subs.length === 0 ? (
+            <p className="px-5 py-4 text-xs font-light text-text-tertiary">
+              None yet.
+            </p>
           ) : (
-            <button
-              className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
-              disabled={busy || !vapidPublicKey}
-              onClick={onEnable}
-            >
-              Enable
-            </button>
-          )}
-        </div>
-      </section>
-
-      <section className="rounded-md border border-border bg-bg-subtle p-4">
-        <h2 className="text-sm font-medium text-text-primary">
-          All subscribed browsers
-        </h2>
-        {subs.length === 0 ? (
-          <p className="mt-1 text-xs text-text-tertiary">None yet.</p>
-        ) : (
-          <ul className="mt-2 divide-y divide-border text-xs">
-            {subs.map((s) => (
-              <li key={s.id} className="flex items-center justify-between py-2">
-                <div>
-                  <div className="font-medium text-text-primary">
-                    {s.userAgent ?? "Unknown browser"}
-                  </div>
-                  <div className="text-text-tertiary">
-                    added {new Date(s.createdAt * 1000).toLocaleString()}
-                    {s.lastUsedAt
-                      ? ` · last used ${new Date(s.lastUsedAt * 1000).toLocaleString()}`
-                      : ""}
-                  </div>
-                </div>
-                <button
-                  className="rounded-md border border-border px-2 py-1 text-xs text-text-secondary hover:bg-bg-muted hover:text-text-primary"
-                  disabled={busy}
-                  onClick={() => onRevoke(s.id)}
+            <ul className="divide-y divide-border/60 text-xs">
+              {subs.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex items-center justify-between gap-4 px-5 py-3"
                 >
-                  Revoke
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </div>
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text-primary">
+                      {s.userAgent ?? "Unknown browser"}
+                    </div>
+                    <div className="text-xs font-light text-text-tertiary">
+                      added {new Date(s.createdAt * 1000).toLocaleString()}
+                      {s.lastUsedAt
+                        ? ` · last used ${new Date(s.lastUsedAt * 1000).toLocaleString()}`
+                        : ""}
+                    </div>
+                  </div>
+                  <button
+                    className="rounded-[6px] border border-border px-2 py-1 text-xs font-medium text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                    disabled={busy}
+                    onClick={() => onRevoke(s.id)}
+                  >
+                    Revoke
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </PageContainer>
   );
 }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { signIn } from "@/lib/auth-client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { WordmarkLarge } from "@/components/Wordmark";
 import { useBranding } from "@/lib/branding";
 
 type Status = "checking" | "available" | "unavailable";
@@ -63,120 +63,115 @@ export default function OnboardingPage() {
   }
 
   if (status === "checking") {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-bg-subtle">
-        <p className="text-text-secondary">Loading...</p>
-      </div>
-    );
+    return <p className="text-sm text-white/60">Loading…</p>;
   }
 
   if (status === "unavailable") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-bg-subtle">
-        <Card className="w-full max-w-sm border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">
-              Setup complete
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-xs text-text-secondary">
-              An administrator account already exists. Please sign in instead.
-            </p>
-            <button
-              className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover"
-              onClick={() => navigate("/login")}
-            >
-              Go to sign in
-            </button>
-          </CardContent>
-        </Card>
+      <div className="flex w-full max-w-sm flex-col items-center gap-8">
+        <WordmarkLarge />
+        <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Setup complete
+          </h2>
+          <p className="mt-3 text-sm font-light text-white/60">
+            An administrator account already exists. Please sign in instead.
+          </p>
+          <button
+            className="mt-6 w-full rounded-full bg-white py-2.5 text-sm font-medium text-[#0a0a0a] transition-colors hover:bg-white/90"
+            onClick={() => navigate("/login")}
+          >
+            Go to sign in
+          </button>
+        </div>
       </div>
     );
   }
 
-  const inputClass =
-    "h-8 w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 text-xs text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent";
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-subtle px-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-6">
-        <img src="/saasmail-logo.png" alt="saasmail" className="h-10 w-auto" />
-        <Card className="w-full border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">Welcome</CardTitle>
-            <p className="text-xs text-text-secondary">
-              Create the first administrator account to get started.
+    <div className="flex w-full max-w-sm flex-col items-center gap-8">
+      <WordmarkLarge />
+      <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+        <div className="mb-6">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Welcome
+          </h2>
+          <p className="mt-1.5 text-sm font-light text-white/60">
+            Create the first administrator account to get started.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="onboarding-name"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Name
+            </label>
+            <input
+              id="onboarding-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              autoComplete="name"
+              className={INPUT_CLASS}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="onboarding-email"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Email
+            </label>
+            <input
+              id="onboarding-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              className={INPUT_CLASS}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="onboarding-password"
+              className="text-xs font-medium uppercase tracking-wider text-white/50"
+            >
+              Password
+            </label>
+            <input
+              id="onboarding-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              autoComplete="new-password"
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs font-light text-white/40">
+              At least 8 characters.
             </p>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-3">
-              <div className="space-y-1">
-                <label
-                  htmlFor="onboarding-name"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Name
-                </label>
-                <input
-                  id="onboarding-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                  autoComplete="name"
-                  className={inputClass}
-                />
-              </div>
-              <div className="space-y-1">
-                <label
-                  htmlFor="onboarding-email"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Email
-                </label>
-                <input
-                  id="onboarding-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  autoComplete="email"
-                  className={inputClass}
-                />
-              </div>
-              <div className="space-y-1">
-                <label
-                  htmlFor="onboarding-password"
-                  className="text-xs font-medium text-text-secondary"
-                >
-                  Password
-                </label>
-                <input
-                  id="onboarding-password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className={inputClass}
-                />
-                <p className="text-[10px] text-text-tertiary">
-                  At least 8 characters.
-                </p>
-              </div>
-              {error && <p className="text-xs text-destructive">{error}</p>}
-              <button
-                type="submit"
-                className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-                disabled={loading}
-              >
-                {loading ? "Creating account..." : "Create administrator"}
-              </button>
-            </form>
-          </CardContent>
-        </Card>
+          </div>
+          {error && (
+            <p className="text-sm text-red-300" role="alert">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            className="w-full rounded-full bg-white py-2.5 text-sm font-medium text-[#0a0a0a] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? "Creating account…" : "Create administrator"}
+          </button>
+        </form>
       </div>
     </div>
   );
 }
+
+const INPUT_CLASS =
+  "h-10 w-full rounded-md border-0 bg-white/5 px-3 text-sm text-white ring-1 ring-white/15 placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-white/40 transition-all";

--- a/src/pages/PersonDetail.tsx
+++ b/src/pages/PersonDetail.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { CheckCheck } from "lucide-react";
 import {
   fetchPersonEmails,
   markEmailRead,
+  markPeopleRead,
   deleteEmail,
   fetchPersonEnrollment,
   fetchStats,
@@ -19,6 +20,7 @@ import ThreadInboxSection, {
   type ThreadInboxGroup,
 } from "@/components/ThreadInboxSection";
 import ChatInboxSection from "@/components/ChatInboxSection";
+import { cn } from "@/lib/utils";
 
 interface PersonDetailProps {
   person: GroupedPerson;
@@ -27,9 +29,6 @@ interface PersonDetailProps {
   refreshKey?: number;
 }
 
-// Each email is associated with an "inbox" address:
-//   - received: the recipient address (who the sender wrote to)
-//   - sent:     the fromAddress (which of our inboxes sent it)
 function inboxOf(email: Email): string {
   return (
     (email.type === "received" ? email.recipient : email.fromAddress) ??
@@ -47,13 +46,6 @@ function groupEmailsByInbox(emails: Email[]): ThreadInboxGroup[] {
   }
   const groups: ThreadInboxGroup[] = [];
   for (const [inbox, list] of byInbox) {
-    // Emails come newest-first from the API; keep that order within a group.
-    // Sort inbox groups by the most-recent RECEIVED email so that sending a
-    // reply does not re-order inboxes (which, combined with the auto-scroll,
-    // pushes other inbox sections — "old threads" — off-screen). A reply is a
-    // response to existing traffic, not fresh activity. Fall back to any
-    // email's timestamp for inboxes that have never received an email so
-    // outbound-only conversations still sort reasonably on initial load.
     const latestReceivedTs =
       list.find((e) => e.type === "received")?.timestamp ?? 0;
     const latestAnyTs = list[0]?.timestamp ?? 0;
@@ -63,9 +55,37 @@ function groupEmailsByInbox(emails: Email[]): ThreadInboxGroup[] {
       latestTimestamp: latestReceivedTs || latestAnyTs,
     });
   }
-  // Sort inbox groups by most recent received activity.
   groups.sort((a, b) => b.latestTimestamp - a.latestTimestamp);
   return groups;
+}
+
+function inboxColor(seed: string) {
+  // Stable but per-inbox accent so the active tab feels distinct.
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  const palette = [
+    "#7c5cfc",
+    "#0f766e",
+    "#0369a1",
+    "#a16207",
+    "#be185d",
+    "#7e22ce",
+  ];
+  return palette[h % palette.length];
+}
+
+function unreadIn(group: ThreadInboxGroup): number {
+  return group.emails.filter((e) => e.type === "received" && e.isRead === 0)
+    .length;
+}
+
+/** Strip the @domain — every inbox shares the same domain, so the tab
+ *  just shows the local-part (e.g., "support" instead of "support@example.com").
+ *  Falls back to the full string if there's no @. */
+function inboxLabel(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return email;
+  return email.slice(0, at);
 }
 
 export default function PersonDetail({
@@ -90,7 +110,7 @@ export default function PersonDetail({
   const [senderIdentities, setSenderIdentities] = useState<
     Array<{ email: string; displayName: string | null }>
   >([]);
-  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [activeInbox, setActiveInbox] = useState<string | null>(null);
 
   function refetchEmails() {
     fetchPersonEmails(person.id).then((res) => {
@@ -105,6 +125,7 @@ export default function PersonDetail({
     setLoading(true);
     setReplyToEmailId(null);
     setExpandedOlder({});
+    setActiveInbox(null);
     fetchPersonEmails(person.id)
       .then((res) => {
         setEmails(res.emails);
@@ -118,12 +139,6 @@ export default function PersonDetail({
   useEffect(() => {
     if (refreshKey) refetchEmails();
   }, [refreshKey]);
-
-  // Auto-scroll to latest (bottom) whenever the email list or expansion changes
-  useEffect(() => {
-    if (loading) return;
-    bottomRef.current?.scrollIntoView({ block: "end" });
-  }, [emails, expandedOlder, loading]);
 
   useEffect(() => {
     fetchPersonEnrollment(person.id).then(setEnrollmentInfo);
@@ -148,6 +163,23 @@ export default function PersonDetail({
     onEmailRead(person.id);
   }
 
+  async function handleMarkInboxRead(inboxAddress: string) {
+    // Optimistic local update on the active inbox's emails.
+    setEmails((prev) =>
+      prev.map((e) =>
+        e.recipient === inboxAddress && e.type === "received" && e.isRead === 0
+          ? { ...e, isRead: 1 }
+          : e,
+      ),
+    );
+    try {
+      await markPeopleRead([person.id], inboxAddress);
+      onEmailRead(person.id);
+    } catch {
+      refetchEmails();
+    }
+  }
+
   async function handleDelete(emailId: string) {
     if (
       !confirm(
@@ -167,6 +199,21 @@ export default function PersonDetail({
     () => inboxGroups.map((g) => g.inbox).filter((i) => i !== "(unknown)"),
     [inboxGroups],
   );
+
+  // Auto-pick the first (most-recent) inbox as active when person/emails load.
+  useEffect(() => {
+    if (inboxGroups.length === 0) {
+      setActiveInbox(null);
+      return;
+    }
+    if (!activeInbox || !inboxGroups.find((g) => g.inbox === activeInbox)) {
+      setActiveInbox(inboxGroups[0].inbox);
+    }
+  }, [inboxGroups, activeInbox]);
+
+  const activeGroup =
+    inboxGroups.find((g) => g.inbox === activeInbox) ?? inboxGroups[0] ?? null;
+
   const replyInboxForEmail = (email: Email) => {
     const ib = inboxOf(email);
     return ib === "(unknown)" ? distinctInboxes : [ib];
@@ -175,83 +222,156 @@ export default function PersonDetail({
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center text-text-tertiary">
-        Loading...
+        <span className="text-sm">Loading…</span>
       </div>
     );
   }
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="border-b border-border px-4 sm:px-6 py-3">
-        <div>
-          <h2 className="text-sm font-semibold text-text-primary">
-            {person.name || person.email}
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Person header */}
+      <div className="shrink-0 border-b border-border bg-card px-6 pb-4 pt-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-xl font-extrabold tracking-tight text-text-primary">
+              {person.name || person.email}
+            </h2>
             {person.name && (
-              <span className="ml-2 text-xs font-normal text-text-secondary">
+              <p className="mt-0.5 truncate text-sm font-light text-text-tertiary">
                 {person.email}
-              </span>
+              </p>
             )}
-          </h2>
-          <p className="text-[11px] text-text-tertiary">
-            {person.totalCount} email{person.totalCount !== 1 ? "s" : ""}
-            {inboxGroups.length > 1
-              ? ` across ${inboxGroups.length} inboxes`
-              : ""}
-          </p>
+            <p className="mt-2 text-xs text-text-secondary">
+              {person.totalCount} message
+              {person.totalCount !== 1 ? "s" : ""}
+              {inboxGroups.length > 1
+                ? ` across ${inboxGroups.length} inboxes`
+                : ""}
+            </p>
+          </div>
+
+          <div className="shrink-0">
+            {enrollmentInfo?.enrollment ? (
+              <SequenceStatus
+                personId={person.id}
+                onStatusChange={refreshEnrollment}
+              />
+            ) : (
+              <button
+                onClick={() => setEnrollModalOpen(true)}
+                className="inline-flex items-center gap-1.5 rounded-[8px] border border-border bg-card px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+              >
+                Add to sequence
+              </button>
+            )}
+          </div>
         </div>
       </div>
 
-      {/* Sequence status */}
-      <div className="border-b border-border px-4 sm:px-6 py-2">
-        {enrollmentInfo?.enrollment ? (
-          <SequenceStatus
-            personId={person.id}
-            onStatusChange={refreshEnrollment}
-          />
-        ) : (
-          <button
-            onClick={() => setEnrollModalOpen(true)}
-            className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-muted"
+      {/* Inbox tabs — short label (local-part only), counts + mode dot.
+          Tooltip on the tab shows the full address.
+          On mobile: horizontal scroll with snap (native-app feel).
+          On desktop: wraps onto multiple lines. */}
+      {inboxGroups.length > 0 && (
+        <div className="shrink-0 border-b border-border bg-card/60">
+          <div
+            className="smooth-scroll flex gap-1 overflow-x-auto px-3 py-2 sm:flex-wrap sm:overflow-visible"
+            style={{ scrollSnapType: "x proximity" }}
           >
-            Add to Sequence
-          </button>
-        )}
-      </div>
-
-      {/* Conversation — grouped by inbox */}
-      <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
-        <ScrollArea className="flex-1">
-          {inboxGroups.length === 0 ? (
-            <p className="py-4 text-center text-xs text-text-tertiary">
-              No emails found.
-            </p>
-          ) : (
-            inboxGroups.map((group) => {
-              const mode = inboxModeMap.get(group.inbox) ?? "thread";
-              if (mode === "chat") {
-                return (
-                  <ChatInboxSection
-                    key={group.inbox}
-                    group={group}
-                    personEmail={person.email}
-                    onOpenHtml={setHtmlPreviewEmail}
-                    onMarkRead={handleMarkRead}
-                    onDelete={handleDelete}
-                    onSent={refetchEmails}
-                  />
-                );
-              }
+            {inboxGroups.map((group) => {
+              const mode = inboxModeMap.get(group.inbox) ?? "chat";
+              const unread = unreadIn(group);
+              const isActive = activeGroup?.inbox === group.inbox;
+              const accent = inboxColor(group.inbox);
+              const label = inboxLabel(group.inbox);
               return (
-                <ThreadInboxSection
+                <button
                   key={group.inbox}
-                  group={group}
+                  data-testid="inbox-tab"
+                  onClick={() => setActiveInbox(group.inbox)}
+                  title={`${group.inbox} · ${mode} mode`}
+                  style={{ scrollSnapAlign: "start" }}
+                  className={cn(
+                    "inline-flex shrink-0 items-center gap-2 rounded-[8px] px-3 py-1.5 text-sm transition-all",
+                    isActive
+                      ? "bg-text-primary/[0.05] text-text-primary ring-1 ring-text-primary/10"
+                      : "text-text-secondary hover:bg-bg-muted/70 hover:text-text-primary",
+                  )}
+                >
+                  {/* Mode-aware accent dot — color stable per inbox */}
+                  <span
+                    className={cn(
+                      "h-2 w-2 shrink-0 rounded-full",
+                      mode === "chat" ? "" : "opacity-60",
+                    )}
+                    style={{ backgroundColor: accent }}
+                    aria-hidden
+                  />
+                  <span className="font-medium">{label}</span>
+                  <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-bg-muted px-1.5 text-[10px] font-semibold tabular-nums text-text-secondary">
+                    {group.emails.length}
+                  </span>
+                  {unread > 0 && (
+                    <span
+                      className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1.5 text-[10px] font-bold tabular-nums text-white"
+                      style={{ backgroundColor: "#7c5cfc" }}
+                      aria-label={`${unread} unread`}
+                    >
+                      {unread}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Per-inbox action row — visible when the active tab has unread emails */}
+      {activeGroup && unreadIn(activeGroup) > 0 && (
+        <div className="shrink-0 border-b border-border bg-bg-subtle/40 px-4 py-2">
+          <button
+            type="button"
+            onClick={() => handleMarkInboxRead(activeGroup.inbox)}
+            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+          >
+            <CheckCheck size={12} />
+            Mark all in {inboxLabel(activeGroup.inbox)} as read
+            <span className="ml-1 rounded-full bg-text-primary/[0.06] px-1.5 text-[10px] font-bold tabular-nums text-text-secondary">
+              {unreadIn(activeGroup)}
+            </span>
+          </button>
+        </div>
+      )}
+
+      {/* Active inbox section — fills remaining height */}
+      <div className="flex min-h-0 flex-1 flex-col">
+        {activeGroup ? (
+          (() => {
+            const mode = inboxModeMap.get(activeGroup.inbox) ?? "chat";
+            if (mode === "chat") {
+              return (
+                <ChatInboxSection
+                  key={activeGroup.inbox}
+                  group={activeGroup}
                   personEmail={person.email}
-                  isOlderExpanded={!!expandedOlder[group.inbox]}
+                  onOpenHtml={setHtmlPreviewEmail}
+                  onMarkRead={handleMarkRead}
+                  onDelete={handleDelete}
+                  onSent={refetchEmails}
+                />
+              );
+            }
+            return (
+              <ThreadPaneScroller key={activeGroup.inbox}>
+                <ThreadInboxSection
+                  group={activeGroup}
+                  personEmail={person.email}
+                  isOlderExpanded={!!expandedOlder[activeGroup.inbox]}
                   onToggleOlder={() =>
                     setExpandedOlder((prev) => ({
                       ...prev,
-                      [group.inbox]: !prev[group.inbox],
+                      [activeGroup.inbox]: !prev[activeGroup.inbox],
                     }))
                   }
                   onOpenHtml={setHtmlPreviewEmail}
@@ -259,13 +379,16 @@ export default function PersonDetail({
                   onReply={setReplyToEmailId}
                   onDelete={handleDelete}
                 />
-              );
-            })
-          )}
-          <div ref={bottomRef} />
-        </ScrollArea>
+              </ThreadPaneScroller>
+            );
+          })()
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-sm text-text-tertiary">
+            No emails found.
+          </div>
+        )}
 
-        {/* Reply Composer */}
+        {/* Reply composer (thread mode) */}
         {replyToEmailId && (
           <ReplyComposer
             emailId={replyToEmailId}
@@ -282,14 +405,12 @@ export default function PersonDetail({
         )}
       </div>
 
-      {/* HTML Preview Modal */}
       <EmailHtmlModal
         email={htmlPreviewEmail}
         open={htmlPreviewEmail !== null}
         onClose={() => setHtmlPreviewEmail(null)}
       />
 
-      {/* Sequence Enrollment Modal */}
       <EnrollSequenceModal
         personId={person.id}
         personName={person.name}
@@ -299,6 +420,19 @@ export default function PersonDetail({
         onClose={() => setEnrollModalOpen(false)}
         onEnrolled={refreshEnrollment}
       />
+    </div>
+  );
+}
+
+/** Scroll wrapper for thread-mode inbox content. */
+function ThreadPaneScroller({ children }: { children: React.ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      ref={scrollRef}
+      className="smooth-scroll min-h-0 flex-1 overflow-y-auto"
+    >
+      {children}
     </div>
   );
 }

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -1,77 +1,103 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   ChevronLeft,
   ChevronRight,
   Paperclip,
-  X,
   MoreHorizontal,
   Trash2,
+  CheckCheck,
 } from "lucide-react";
-import {
-  fetchGroupedPeople,
-  deletePerson,
-  type GroupedPerson,
-} from "@/lib/api";
-
-const PAGE_SIZE = 50;
+import { cn } from "@/lib/utils";
+import { deletePerson, type GroupedPerson } from "@/lib/api";
 
 interface PersonListProps {
   people: GroupedPerson[];
   setPeople: (people: GroupedPerson[]) => void;
+  loading: boolean;
+  total: number;
+  pageSize: number;
+  page: number;
+  onPageChange: (page: number) => void;
   selectedPersonId: string | null;
   onSelectPerson: (person: GroupedPerson) => void;
   onPersonDeleted?: (personId: string) => void;
-  refreshKey?: number;
   isAdmin?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelected?: (id: string) => void;
+  onMarkPersonRead?: (id: string) => void;
+}
+
+// Deterministic pastel-on-violet palette per person initial.
+const AVATAR_PALETTE = [
+  { bg: "rgba(124, 92, 252, 0.12)", fg: "#5b3ce6" },
+  { bg: "rgba(34, 197, 94, 0.12)", fg: "#15803d" },
+  { bg: "rgba(244, 114, 182, 0.14)", fg: "#be185d" },
+  { bg: "rgba(251, 146, 60, 0.14)", fg: "#c2410c" },
+  { bg: "rgba(56, 189, 248, 0.14)", fg: "#0369a1" },
+  { bg: "rgba(168, 85, 247, 0.14)", fg: "#7e22ce" },
+  { bg: "rgba(20, 184, 166, 0.14)", fg: "#0f766e" },
+  { bg: "rgba(234, 179, 8, 0.16)", fg: "#a16207" },
+];
+
+function avatarColor(seed: string) {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  return AVATAR_PALETTE[h % AVATAR_PALETTE.length];
+}
+
+function formatTime(ts: number) {
+  const date = new Date(ts * 1000);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffH = diffMs / 3_600_000;
+  if (diffH < 1) {
+    const m = Math.max(1, Math.floor(diffMs / 60_000));
+    return `${m}m`;
+  }
+  if (date.toDateString() === now.toDateString()) {
+    return date.toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  if (diffH < 24 * 7) {
+    return date.toLocaleDateString([], { weekday: "short" });
+  }
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+function initials(name: string | null, email: string) {
+  const source = name || email.split("@")[0];
+  const parts = source.split(/[\s.\-_]+/).filter(Boolean);
+  const letters = (parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "");
+  return letters.toUpperCase() || "?";
 }
 
 export default function PersonList({
   people,
   setPeople,
+  loading,
+  total,
+  pageSize,
+  page,
+  onPageChange,
   selectedPersonId,
   onSelectPerson,
   onPersonDeleted,
-  refreshKey,
   isAdmin,
+  selectedIds,
+  onToggleSelected,
+  onMarkPersonRead,
 }: PersonListProps) {
-  const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState("");
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(
     null,
   );
   const menuRef = useRef<HTMLDivElement | null>(null);
 
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
-  // Reset to page 1 when search changes
-  useEffect(() => {
-    setPage(1);
-  }, [search]);
-
-  // Fetch flat list of people (aggregated across all inboxes)
-  useEffect(() => {
-    setLoading(true);
-    const timeout = setTimeout(() => {
-      fetchGroupedPeople({
-        q: search || undefined,
-        page,
-        limit: PAGE_SIZE,
-      })
-        .then((result) => {
-          setPeople(result.data);
-          setTotal(result.total);
-        })
-        .finally(() => setLoading(false));
-    }, 200);
-    return () => clearTimeout(timeout);
-  }, [search, page, refreshKey]);
-
-  // Close menu when clicking outside or scrolling
   useEffect(() => {
     if (!menuOpenId) return;
     function handleClose(e: MouseEvent) {
@@ -97,150 +123,251 @@ export default function PersonList({
       return;
     await deletePerson(person.id);
     setPeople(people.filter((p) => p.id !== person.id));
-    setTotal((t) => t - 1);
     onPersonDeleted?.(person.id);
   }
 
-  function formatTime(ts: number) {
-    const date = new Date(ts * 1000);
-    const now = new Date();
-    if (date.toDateString() === now.toDateString()) {
-      return date.toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-    }
-    return date.toLocaleDateString([], { month: "short", day: "numeric" });
-  }
+  const showingRange = useMemo(() => {
+    if (total === 0) return "0";
+    const start = (page - 1) * pageSize + 1;
+    const end = Math.min(page * pageSize, total);
+    return `${start}-${end} of ${total}`;
+  }, [total, page, pageSize]);
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="space-y-2 p-3">
-        <div className="relative">
-          <input
-            data-testid="person-search-input"
-            type="text"
-            placeholder="Search..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-10 w-full rounded-md border border-border bg-white ring-1 ring-gray-200 px-3 pr-9 text-base text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent sm:h-8 sm:pr-7 sm:text-xs"
-          />
-          {search && (
-            <button
-              data-testid="person-search-clear"
-              onClick={() => setSearch("")}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-secondary"
-            >
-              <X className="h-4 w-4 sm:h-3 sm:w-3" />
-            </button>
-          )}
-        </div>
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header strip — count only; search lives in the page toolbar above */}
+      <div className="flex shrink-0 items-center justify-between border-b border-border bg-bg-subtle/70 px-4 py-2.5 backdrop-blur-sm">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-text-tertiary">
+          People
+        </span>
+        <span className="text-[11px] tabular-nums text-text-tertiary">
+          {showingRange}
+        </span>
       </div>
-      <ScrollArea className="flex-1">
+
+      {/* Scrollable list — independent of the right pane */}
+      <div className="smooth-scroll min-h-0 flex-1 overflow-y-auto">
         {loading ? (
-          <p className="p-4 text-center text-xs text-text-tertiary">
-            Loading...
-          </p>
+          <div className="flex flex-col items-center justify-center gap-2 px-4 py-16 text-center">
+            <p className="text-sm font-light text-text-tertiary">Loading…</p>
+          </div>
         ) : people.length === 0 ? (
-          <p className="p-4 text-center text-xs text-text-tertiary">
-            No people found
-          </p>
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+            <p className="text-sm font-medium text-text-primary">
+              No people found
+            </p>
+            <p className="text-xs font-light text-text-tertiary">
+              Try a different search, or wait for new mail.
+            </p>
+          </div>
         ) : (
-          people.map((person) => {
-            const isSelected = selectedPersonId === person.id;
-            const menuOpen = menuOpenId === person.id;
-            return (
-              <div
-                key={person.id}
-                className={`group relative border-b border-border transition-colors hover:bg-bg-muted ${
-                  isSelected ? "bg-bg-muted" : ""
-                }`}
-              >
-                <button
-                  data-testid="person-row"
-                  data-person-id={person.id}
-                  onClick={() => onSelectPerson(person)}
-                  className={`w-full px-4 py-2.5 text-left ${isAdmin ? "pr-8" : ""}`}
+          <ul className="divide-y divide-border/60">
+            {people.map((person) => {
+              const isSelected = selectedPersonId === person.id;
+              const isChecked = selectedIds?.has(person.id) ?? false;
+              const selectionMode = selectedIds !== undefined;
+              const anySelected = (selectedIds?.size ?? 0) > 0;
+              const menuOpen = menuOpenId === person.id;
+              const color = avatarColor(person.email);
+              const display = person.name || person.email;
+              return (
+                <li
+                  key={person.id}
+                  className={cn(
+                    "group relative transition-colors",
+                    isSelected
+                      ? "bg-text-primary/[0.04]"
+                      : isChecked
+                        ? "bg-violet/[0.04]"
+                        : "hover:bg-text-primary/[0.025]",
+                  )}
                 >
-                  <div className="flex items-center justify-between">
+                  {isSelected && (
                     <span
-                      className={`truncate text-xs ${
-                        person.unreadCount > 0
-                          ? "font-semibold text-text-primary"
-                          : "text-text-secondary"
-                      }`}
-                    >
-                      {person.name || person.email}
-                    </span>
-                    <span className="ml-2 shrink-0 text-[11px] text-text-tertiary">
-                      {formatTime(person.lastEmailAt)}
-                    </span>
-                  </div>
-                  <div className="mt-0.5 flex items-center justify-between">
-                    <span className="truncate text-[11px] text-text-tertiary">
-                      {person.totalCount} email
-                      {person.totalCount !== 1 ? "s" : ""}
-                      {person.recipientCount > 1
-                        ? ` · ${person.recipientCount} inboxes`
-                        : ""}
-                    </span>
-                    <div className="ml-2 flex shrink-0 items-center gap-1.5">
-                      {person.hasAttachment === 1 && (
-                        <Paperclip size={10} className="text-text-tertiary" />
-                      )}
-                      {person.unreadCount > 0 && (
-                        <span
-                          data-testid="person-unread-badge"
-                          className="flex h-4 min-w-4 items-center justify-center rounded-full bg-unread px-1 text-[10px] font-semibold text-white"
-                        >
-                          {person.unreadCount}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </button>
+                      className="absolute inset-y-2 left-0 w-0.5 rounded-full"
+                      style={{ backgroundColor: "#7c5cfc" }}
+                      aria-hidden
+                    />
+                  )}
 
-                {/* Kebab menu button — admin only, visible on hover or when menu is open */}
-                {isAdmin && (
                   <button
-                    data-testid="person-kebab-menu"
+                    data-testid="person-row"
                     data-person-id={person.id}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (menuOpen) {
-                        setMenuOpenId(null);
-                      } else {
-                        const rect = e.currentTarget.getBoundingClientRect();
-                        setMenuPos({
-                          top: rect.bottom + 4,
-                          right: window.innerWidth - rect.right,
-                        });
-                        setMenuOpenId(person.id);
-                      }
-                    }}
-                    className={`absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-text-tertiary transition-opacity hover:bg-bg-subtle hover:text-text-secondary ${
-                      menuOpen
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100"
-                    }`}
+                    onClick={() => onSelectPerson(person)}
+                    className="flex w-full items-start gap-3 px-4 py-3.5 text-left active:bg-text-primary/[0.04] sm:py-3"
                   >
-                    <MoreHorizontal size={14} />
-                  </button>
-                )}
-              </div>
-            );
-          })
-        )}
-      </ScrollArea>
+                    {/* Selection checkbox — appears on hover or when any selected.
+                        Clicking it toggles selection without opening the person. */}
+                    {selectionMode && (
+                      <span
+                        role="checkbox"
+                        aria-checked={isChecked}
+                        aria-label={`Select ${display}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onToggleSelected?.(person.id);
+                        }}
+                        className={cn(
+                          "mt-1.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border transition-all",
+                          isChecked
+                            ? "border-text-primary bg-text-primary text-white opacity-100"
+                            : anySelected
+                              ? "border-border bg-card opacity-100 hover:border-text-primary/40"
+                              : "border-border bg-card opacity-0 group-hover:opacity-100",
+                        )}
+                      >
+                        {isChecked && (
+                          <svg
+                            className="h-3 w-3"
+                            viewBox="0 0 12 12"
+                            fill="none"
+                          >
+                            <path
+                              d="M2.5 6.5L4.75 8.75L9.5 4"
+                              stroke="currentColor"
+                              strokeWidth="1.8"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </span>
+                    )}
 
-      {/* Dropdown rendered in a portal so it escapes ScrollArea's overflow clipping */}
+                    {/* Avatar — hidden behind checkbox when hovering in selection mode */}
+                    <span
+                      className={cn(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[13px] font-semibold tracking-tight",
+                        selectionMode &&
+                          (anySelected || isChecked) &&
+                          "hidden sm:flex",
+                      )}
+                      style={{ backgroundColor: color.bg, color: color.fg }}
+                    >
+                      {initials(person.name, person.email)}
+                    </span>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <span
+                          className={cn(
+                            "truncate text-sm",
+                            person.unreadCount > 0
+                              ? "font-semibold text-text-primary"
+                              : "font-medium text-text-primary",
+                          )}
+                        >
+                          {display}
+                        </span>
+                        <span className="shrink-0 text-[11px] font-light text-text-tertiary">
+                          {formatTime(person.lastEmailAt)}
+                        </span>
+                      </div>
+
+                      {person.name && (
+                        <p className="mt-0.5 truncate text-xs font-light text-text-tertiary">
+                          {person.email}
+                        </p>
+                      )}
+
+                      <div className="mt-1.5 flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 text-[11px] text-text-tertiary">
+                          <span>
+                            {person.totalCount} email
+                            {person.totalCount !== 1 ? "s" : ""}
+                          </span>
+                          {person.recipientCount > 1 && (
+                            <>
+                              <span className="text-text-tertiary/40">·</span>
+                              <span>{person.recipientCount} inboxes</span>
+                            </>
+                          )}
+                          {person.hasAttachment === 1 && (
+                            <Paperclip
+                              size={11}
+                              className="text-text-tertiary"
+                              aria-label="Has attachment"
+                            />
+                          )}
+                        </div>
+
+                        {/* Click unread badge to mark all read for this person.
+                            Larger tap target on mobile (h-6 vs h-5). */}
+                        {person.unreadCount > 0 && (
+                          <span
+                            role="button"
+                            tabIndex={0}
+                            data-testid="person-unread-badge"
+                            title="Tap to mark all as read"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onMarkPersonRead?.(person.id);
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onMarkPersonRead?.(person.id);
+                              }
+                            }}
+                            className="group/badge flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-full px-2 text-[11px] font-bold text-white transition-all active:scale-95 sm:h-5 sm:min-w-5 sm:px-1.5 sm:text-[10px] sm:hover:scale-110"
+                            style={{ backgroundColor: "#7c5cfc" }}
+                          >
+                            <span className="group-hover/badge:hidden">
+                              {person.unreadCount}
+                            </span>
+                            <CheckCheck
+                              size={11}
+                              className="hidden group-hover/badge:block"
+                            />
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+
+                  {isAdmin && (
+                    <button
+                      data-testid="person-kebab-menu"
+                      data-person-id={person.id}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (menuOpen) {
+                          setMenuOpenId(null);
+                        } else {
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          setMenuPos({
+                            top: rect.bottom + 4,
+                            right: window.innerWidth - rect.right,
+                          });
+                          setMenuOpenId(person.id);
+                        }
+                      }}
+                      className={cn(
+                        "absolute right-2 top-3 rounded p-1 text-text-tertiary transition-opacity hover:bg-bg-subtle hover:text-text-secondary",
+                        menuOpen
+                          ? "opacity-100"
+                          : "opacity-0 group-hover:opacity-100",
+                      )}
+                      aria-label="Person actions"
+                    >
+                      <MoreHorizontal size={14} />
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
       {menuOpenId &&
         menuPos &&
         createPortal(
           <div
             ref={menuRef}
             style={{ top: menuPos.top, right: menuPos.right }}
-            className="fixed z-50 w-40 rounded-md border border-border bg-white py-1 shadow-md"
+            className="fixed z-50 w-44 rounded-[8px] border border-border bg-card py-1 shadow-lg"
           >
             <button
               data-testid="person-delete-button"
@@ -249,7 +376,7 @@ export default function PersonList({
                 const person = people.find((p) => p.id === menuOpenId);
                 if (person) handleDeletePerson(person);
               }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-red-600 hover:bg-bg-muted"
+              className="flex w-full items-center gap-2 px-3 py-2 text-xs text-red-600 transition-colors hover:bg-red-50"
             >
               <Trash2 size={12} />
               Delete person
@@ -259,21 +386,23 @@ export default function PersonList({
         )}
 
       {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t border-border px-3 py-2">
+        <div className="flex shrink-0 items-center justify-between border-t border-border bg-bg-subtle/40 px-4 py-2.5">
           <button
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            onClick={() => onPageChange(Math.max(1, page - 1))}
             disabled={page <= 1}
-            className="rounded p-1 text-text-secondary hover:bg-bg-muted disabled:opacity-30 disabled:hover:bg-transparent"
+            className="flex h-7 w-7 items-center justify-center rounded-[8px] text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary disabled:opacity-30 disabled:hover:bg-transparent"
+            aria-label="Previous page"
           >
             <ChevronLeft size={14} />
           </button>
-          <span className="text-[11px] text-text-tertiary">
-            {page} / {totalPages}
+          <span className="text-[11px] font-medium text-text-tertiary">
+            Page {page} of {totalPages}
           </span>
           <button
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            onClick={() => onPageChange(Math.min(totalPages, page + 1))}
             disabled={page >= totalPages}
-            className="rounded p-1 text-text-secondary hover:bg-bg-muted disabled:opacity-30 disabled:hover:bg-transparent"
+            className="flex h-7 w-7 items-center justify-center rounded-[8px] text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary disabled:opacity-30 disabled:hover:bg-transparent"
+            aria-label="Next page"
           >
             <ChevronRight size={14} />
           </button>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,0 +1,219 @@
+import LegalLayout from "@/components/LegalLayout";
+
+export default function PrivacyPage() {
+  return (
+    <LegalLayout title="Privacy Policy" lastUpdated="May 7, 2026">
+      <p>
+        <strong>saasmail</strong> is open-source software that runs in your own
+        Cloudflare account. The saasmail project does <strong>not</strong>{" "}
+        operate a centralized service and does not collect, receive, or store
+        any data from saasmail deployments. This policy explains how data flows
+        through a typical deployment so you can evaluate it for your own use,
+        and what limited information the project's website and repository
+        collect.
+      </p>
+
+      <h2>1. Who is the data controller?</h2>
+      <p>
+        Because saasmail is self-hosted, <strong>the operator</strong> — the
+        person or organization that deploys saasmail to a Cloudflare account —
+        is the data controller for any personal data processed by that
+        deployment. The saasmail project is not a processor or sub-processor; it
+        provides source code only.
+      </p>
+      <p>
+        If you are using a saasmail instance that someone else operates (for
+        example, your employer), questions about your personal data should be
+        directed to that operator, not to the project.
+      </p>
+
+      <h2>2. What a saasmail deployment processes</h2>
+      <p>
+        When you deploy saasmail, the following categories of data flow through
+        Cloudflare bindings configured in your <code>wrangler.jsonc</code>:
+      </p>
+      <ul>
+        <li>
+          <strong>Inbound email content</strong> — subject, headers, body (plain
+          text and sanitized HTML), and attachments — received via Cloudflare
+          Email Routing and stored in your D1 database and R2 bucket.
+        </li>
+        <li>
+          <strong>Sender metadata</strong> — names and email addresses of people
+          who email your configured inboxes, plus aggregated counts (total
+          messages, unread count, last activity time).
+        </li>
+        <li>
+          <strong>Outbound email</strong> — messages composed and sent through
+          the UI or API, persisted in your D1 database. Delivery is performed by
+          Cloudflare Email Sending or Resend, depending on how you configure the
+          deployment.
+        </li>
+        <li>
+          <strong>Authentication state</strong> — user accounts (name, email,
+          hashed credentials), session tokens, and registered passkeys, all
+          managed by{" "}
+          <a
+            href="https://www.better-auth.com/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Better Auth
+          </a>{" "}
+          and stored in D1.
+        </li>
+        <li>
+          <strong>Push subscriptions</strong> — if you opt in to browser push
+          notifications, the VAPID-encrypted endpoint and keys for your device
+          are stored so the worker can deliver alerts.
+        </li>
+      </ul>
+      <p>
+        All of this data lives in your Cloudflare account. The saasmail
+        maintainers have no access to it.
+      </p>
+
+      <h2>3. Where data is stored</h2>
+      <p>
+        Data persistence in a saasmail deployment is handled entirely by
+        Cloudflare services that the operator provisions:
+      </p>
+      <ul>
+        <li>
+          <strong>Cloudflare D1</strong> (SQLite) — relational data: inboxes,
+          people, emails, sequences, templates, sessions.
+        </li>
+        <li>
+          <strong>Cloudflare R2</strong> — email attachments stored as opaque
+          objects.
+        </li>
+        <li>
+          <strong>Cloudflare Queues</strong> — scheduled outbound emails for
+          sequence campaigns.
+        </li>
+        <li>
+          <strong>Cloudflare Durable Objects</strong> — short-lived per-user
+          notification state for live updates.
+        </li>
+      </ul>
+      <p>
+        Cloudflare's own privacy practices apply to this storage; see{" "}
+        <a
+          href="https://www.cloudflare.com/privacypolicy/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          cloudflare.com/privacypolicy
+        </a>
+        .
+      </p>
+
+      <h2>4. Cookies and local storage</h2>
+      <p>
+        A deployed saasmail instance sets a single first-party session cookie
+        issued by Better Auth to keep signed-in members authenticated. The
+        cookie is HTTP-only, scoped to the deployment's domain, and contains no
+        third-party identifiers. Local browser storage is used to remember UI
+        preferences (e.g. sidebar collapsed state). No third-party analytics,
+        tracking pixels, or advertising cookies are loaded.
+      </p>
+
+      <h2>5. Outbound providers</h2>
+      <p>
+        If the operator enables outbound email, message bodies and recipients
+        are passed to one of the following on send:
+      </p>
+      <ul>
+        <li>
+          <strong>Cloudflare Email Sending</strong> — see Cloudflare's privacy
+          policy.
+        </li>
+        <li>
+          <strong>Resend</strong> — see{" "}
+          <a
+            href="https://resend.com/legal/privacy-policy"
+            target="_blank"
+            rel="noreferrer"
+          >
+            resend.com/legal/privacy-policy
+          </a>
+          . The operator's API key is stored as a Cloudflare Worker secret and
+          is never exposed to the browser.
+        </li>
+      </ul>
+
+      <h2>6. Data subject rights</h2>
+      <p>
+        Where applicable law gives you rights over your personal data — such as
+        access, correction, deletion, portability, or objection — those rights
+        are exercised against the operator of the saasmail instance you're
+        communicating with, not the project. The saasmail UI provides admins
+        with the tools to honor these requests (per-person view, per-email
+        delete, person-level delete).
+      </p>
+
+      <h2>7. Children</h2>
+      <p>
+        saasmail is professional infrastructure software and is not directed to
+        children under 16. The project does not knowingly collect data from
+        children. Operators should ensure their deployment's audience is
+        appropriate.
+      </p>
+
+      <h2>8. Project website and repository</h2>
+      <p>
+        The project's GitHub repository is hosted by GitHub, Inc. and is subject
+        to{" "}
+        <a
+          href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub's privacy statement
+        </a>
+        . The project itself does not run analytics, embed third-party tracking,
+        or sell any data.
+      </p>
+
+      <h2>9. Security</h2>
+      <p>
+        Source-code-level security disclosures should follow the process in{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/blob/main/SECURITY.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          SECURITY.md
+        </a>
+        . Operators are responsible for the security of their own deployment,
+        including credentials, secrets, and access controls.
+      </p>
+
+      <h2>10. Changes</h2>
+      <p>
+        Material updates to this policy will be noted in the{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/blob/main/CHANGELOG.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          project changelog
+        </a>
+        .
+      </p>
+
+      <h2>11. Contact</h2>
+      <p>
+        For questions about this policy, open an issue at{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/issues"
+          target="_blank"
+          rel="noreferrer"
+        >
+          github.com/choyiny/saasmail/issues
+        </a>
+        .
+      </p>
+    </LegalLayout>
+  );
+}

--- a/src/pages/SequencesPage.tsx
+++ b/src/pages/SequencesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Plus, ListOrdered, Pencil, Trash2 } from "lucide-react";
 import { fetchSequences, deleteSequence, type Sequence } from "@/lib/api";
 import PageHeader, { PageContainer } from "@/components/PageHeader";
@@ -74,8 +74,8 @@ export default function SequencesPage() {
                   data-sequence-id={seq.id}
                   className="group flex items-center justify-between gap-4 px-5 py-3.5 transition-colors hover:bg-text-primary/[0.02]"
                 >
-                  <button
-                    onClick={() => navigate(`/sequences/${seq.id}`)}
+                  <Link
+                    to={`/sequences/${seq.id}`}
                     className="flex min-w-0 flex-1 items-center gap-3 text-left"
                   >
                     <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[6px] bg-bg-muted">
@@ -90,7 +90,7 @@ export default function SequencesPage() {
                         {seq.steps.length !== 1 ? "s" : ""}
                       </p>
                     </div>
-                  </button>
+                  </Link>
                   <div className="flex shrink-0 items-center gap-1 opacity-60 transition-opacity group-hover:opacity-100">
                     <button
                       onClick={() => navigate(`/sequences/${seq.id}/edit`)}

--- a/src/pages/SequencesPage.tsx
+++ b/src/pages/SequencesPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Plus, ListOrdered, Pencil, Trash2 } from "lucide-react";
 import { fetchSequences, deleteSequence, type Sequence } from "@/lib/api";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 export default function SequencesPage() {
   const [sequences, setSequences] = useState<Sequence[]>([]);
@@ -24,57 +26,92 @@ export default function SequencesPage() {
   }
 
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-text-primary">Sequences</h1>
-        <button
-          onClick={() => navigate("/sequences/new")}
-          className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent/90"
-        >
-          New Sequence
-        </button>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Sequences"
+        subtitle="Multi-step drip campaigns. Enroll a contact and saasmail sends templated emails on a schedule."
+        action={
+          <button
+            onClick={() => navigate("/sequences/new")}
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
+          >
+            <Plus size={14} />
+            New sequence
+          </button>
+        }
+      />
 
-      {loading ? (
-        <p className="text-text-secondary">Loading...</p>
-      ) : sequences.length === 0 ? (
-        <p className="text-text-secondary">No sequences yet.</p>
-      ) : (
-        <div className="space-y-2">
-          {sequences.map((seq) => (
-            <div
-              key={seq.id}
-              data-testid="sequence-row"
-              data-sequence-id={seq.id}
-              className="flex items-center justify-between rounded-lg border border-border bg-white ring-1 ring-gray-200 px-4 py-3"
+      <div className="max-w-4xl">
+        {loading ? (
+          <p className="text-sm font-light text-text-tertiary">Loading…</p>
+        ) : sequences.length === 0 ? (
+          <div className="rounded-[8px] bg-card p-10 text-center ring-1 ring-border">
+            <span className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet/10">
+              <ListOrdered size={20} style={{ color: "#7c5cfc" }} />
+            </span>
+            <p className="mb-1 text-sm font-medium text-text-primary">
+              No sequences yet
+            </p>
+            <p className="mb-4 text-xs font-light text-text-tertiary">
+              Build your first multi-step campaign to nurture contacts
+              automatically.
+            </p>
+            <button
+              onClick={() => navigate("/sequences/new")}
+              className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
             >
-              <div
-                className="cursor-pointer"
-                onClick={() => navigate(`/sequences/${seq.id}`)}
-              >
-                <p className="font-medium text-text-primary">{seq.name}</p>
-                <p className="text-xs text-text-secondary">
-                  {seq.steps.length} step{seq.steps.length !== 1 ? "s" : ""}
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => navigate(`/sequences/${seq.id}/edit`)}
-                  className="rounded-md border border-border px-2 py-1 text-xs text-text-secondary hover:bg-bg-muted"
+              <Plus size={14} />
+              New sequence
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+            <ul className="divide-y divide-border/60">
+              {sequences.map((seq) => (
+                <li
+                  key={seq.id}
+                  data-testid="sequence-row"
+                  data-sequence-id={seq.id}
+                  className="group flex items-center justify-between gap-4 px-5 py-3.5 transition-colors hover:bg-text-primary/[0.02]"
                 >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(seq.id)}
-                  className="rounded-md border border-border px-2 py-1 text-xs text-red-400 hover:bg-bg-muted"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+                  <button
+                    onClick={() => navigate(`/sequences/${seq.id}`)}
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                  >
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[6px] bg-bg-muted">
+                      <ListOrdered size={14} className="text-text-tertiary" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-text-primary">
+                        {seq.name}
+                      </p>
+                      <p className="truncate text-xs font-light text-text-tertiary">
+                        {seq.steps.length} step
+                        {seq.steps.length !== 1 ? "s" : ""}
+                      </p>
+                    </div>
+                  </button>
+                  <div className="flex shrink-0 items-center gap-1 opacity-60 transition-opacity group-hover:opacity-100">
+                    <button
+                      onClick={() => navigate(`/sequences/${seq.id}/edit`)}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                    >
+                      <Pencil size={12} />
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(seq.id)}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </PageContainer>
   );
 }

--- a/src/pages/SequencesPage.tsx
+++ b/src/pages/SequencesPage.tsx
@@ -101,6 +101,7 @@ export default function SequencesPage() {
                     </button>
                     <button
                       onClick={() => handleDelete(seq.id)}
+                      aria-label="Delete"
                       className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
                     >
                       <Trash2 size={12} />

--- a/src/pages/SetupPasskeyPage.tsx
+++ b/src/pages/SetupPasskeyPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { WordmarkLarge } from "@/components/Wordmark";
 
 export default function SetupPasskeyPage() {
   const [error, setError] = useState("");
@@ -24,30 +24,29 @@ export default function SetupPasskeyPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-subtle px-4">
-      <div className="flex w-full max-w-sm flex-col items-center gap-6">
-        <img src="/saasmail-logo.png" alt="saasmail" className="h-10 w-auto" />
-        <Card className="w-full border-border bg-white ring-1 ring-gray-200 rounded-xl">
-          <CardHeader>
-            <CardTitle className="text-xl text-text-primary">
-              Register a Passkey
-            </CardTitle>
-            <p className="text-xs text-text-secondary">
-              For security, you must register a passkey before accessing
-              saasmail.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {error && <p className="text-xs text-destructive">{error}</p>}
-            <button
-              className="w-full rounded-md bg-accent py-2 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
-              onClick={handleRegister}
-              disabled={loading}
-            >
-              {loading ? "Registering..." : "Register Passkey"}
-            </button>
-          </CardContent>
-        </Card>
+    <div className="flex w-full max-w-sm flex-col items-center gap-8">
+      <WordmarkLarge />
+      <div className="w-full rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl">
+        <div className="mb-6">
+          <h2 className="text-xl font-extrabold tracking-tight text-white">
+            Register a passkey
+          </h2>
+          <p className="mt-1.5 text-sm font-light text-white/60">
+            For security, you must register a passkey before accessing saasmail.
+          </p>
+        </div>
+        {error && (
+          <p className="mb-4 text-sm text-red-300" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          className="w-full rounded-full bg-white py-2.5 text-sm font-medium text-[#0a0a0a] transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleRegister}
+          disabled={loading}
+        >
+          {loading ? "Registering…" : "Register passkey"}
+        </button>
       </div>
     </div>
   );

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -49,16 +49,9 @@ export default function TemplatesPage() {
             <p className="mb-1 text-sm font-medium text-text-primary">
               No templates yet
             </p>
-            <p className="mb-4 text-xs font-light text-text-tertiary">
-              Create your first template to send consistent emails at scale.
+            <p className="text-xs font-light text-text-tertiary">
+              Use the "New template" button above to create your first one.
             </p>
-            <button
-              onClick={() => navigate("/templates/new")}
-              className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
-            >
-              <Plus size={14} />
-              New template
-            </button>
           </div>
         ) : (
           <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Plus, FileText, Pencil, Trash2 } from "lucide-react";
 import { fetchTemplates, deleteTemplate } from "@/lib/api";
 import type { EmailTemplate } from "@/lib/api";
@@ -64,8 +64,8 @@ export default function TemplatesPage() {
                   data-template-slug={t.slug}
                   className="group flex items-center justify-between gap-4 px-5 py-3.5 transition-colors hover:bg-text-primary/[0.02]"
                 >
-                  <button
-                    onClick={() => navigate(`/templates/${t.slug}/edit`)}
+                  <Link
+                    to={`/templates/${t.slug}/edit`}
                     className="flex min-w-0 flex-1 items-center gap-3 text-left"
                   >
                     <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[6px] bg-bg-muted">
@@ -80,7 +80,7 @@ export default function TemplatesPage() {
                         {t.subject}
                       </p>
                     </div>
-                  </button>
+                  </Link>
                   <div className="flex shrink-0 items-center gap-1 opacity-60 transition-opacity group-hover:opacity-100">
                     <button
                       onClick={() => navigate(`/templates/${t.slug}/edit`)}

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Plus, FileText, Pencil, Trash2 } from "lucide-react";
 import { fetchTemplates, deleteTemplate } from "@/lib/api";
 import type { EmailTemplate } from "@/lib/api";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
 
 export default function TemplatesPage() {
   const [templates, setTemplates] = useState<EmailTemplate[]>([]);
@@ -21,61 +23,92 @@ export default function TemplatesPage() {
   }
 
   return (
-    <div className="flex-1 overflow-auto p-6">
-      <div className="mx-auto max-w-3xl">
-        <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-sm font-semibold text-text-primary">
-            Email Templates
-          </h1>
+    <PageContainer>
+      <PageHeader
+        title="Templates"
+        subtitle="Reusable HTML email templates with {{variable}} interpolation. Send via the UI or API."
+        action={
           <button
             onClick={() => navigate("/templates/new")}
-            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-hover"
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
           >
-            New Template
+            <Plus size={14} />
+            New template
           </button>
-        </div>
+        }
+      />
 
+      <div className="max-w-4xl">
         {loading ? (
-          <p className="text-xs text-text-tertiary">Loading...</p>
+          <p className="text-sm font-light text-text-tertiary">Loading…</p>
         ) : templates.length === 0 ? (
-          <p className="text-xs text-text-tertiary">No templates yet.</p>
+          <div className="rounded-[8px] bg-card p-10 text-center ring-1 ring-border">
+            <span className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet/10">
+              <FileText size={20} style={{ color: "#7c5cfc" }} />
+            </span>
+            <p className="mb-1 text-sm font-medium text-text-primary">
+              No templates yet
+            </p>
+            <p className="mb-4 text-xs font-light text-text-tertiary">
+              Create your first template to send consistent emails at scale.
+            </p>
+            <button
+              onClick={() => navigate("/templates/new")}
+              className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
+            >
+              <Plus size={14} />
+              New template
+            </button>
+          </div>
         ) : (
-          <div className="space-y-1">
-            {templates.map((t) => (
-              <div
-                key={t.id}
-                data-testid="template-row"
-                data-template-name={t.name}
-                data-template-slug={t.slug}
-                className="flex items-center justify-between rounded-lg border border-border bg-white ring-1 ring-gray-200 px-4 py-3"
-              >
-                <div>
-                  <p className="text-xs font-medium text-text-primary">
-                    {t.name}
-                  </p>
-                  <p className="text-[11px] text-text-tertiary">
-                    {t.slug} &middot; {t.subject}
-                  </p>
-                </div>
-                <div className="flex gap-1">
+          <div className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+            <ul className="divide-y divide-border/60">
+              {templates.map((t) => (
+                <li
+                  key={t.id}
+                  data-testid="template-row"
+                  data-template-name={t.name}
+                  data-template-slug={t.slug}
+                  className="group flex items-center justify-between gap-4 px-5 py-3.5 transition-colors hover:bg-text-primary/[0.02]"
+                >
                   <button
                     onClick={() => navigate(`/templates/${t.slug}/edit`)}
-                    className="rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:bg-bg-muted hover:text-text-primary"
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
                   >
-                    Edit
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[6px] bg-bg-muted">
+                      <FileText size={14} className="text-text-tertiary" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-text-primary">
+                        {t.name}
+                      </p>
+                      <p className="truncate text-xs font-light text-text-tertiary">
+                        <span className="font-mono">{t.slug}</span> ·{" "}
+                        {t.subject}
+                      </p>
+                    </div>
                   </button>
-                  <button
-                    onClick={() => handleDelete(t.slug)}
-                    className="rounded-md px-2.5 py-1 text-[11px] text-destructive hover:bg-bg-muted"
-                  >
-                    Delete
-                  </button>
-                </div>
-              </div>
-            ))}
+                  <div className="flex shrink-0 items-center gap-1 opacity-60 transition-opacity group-hover:opacity-100">
+                    <button
+                      onClick={() => navigate(`/templates/${t.slug}/edit`)}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                    >
+                      <Pencil size={12} />
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(t.slug)}
+                      className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
           </div>
         )}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -25,7 +25,7 @@ export default function TemplatesPage() {
   return (
     <PageContainer>
       <PageHeader
-        title="Templates"
+        title="Email Templates"
         subtitle="Reusable HTML email templates with {{variable}} interpolation. Send via the UI or API."
         action={
           <button
@@ -98,6 +98,7 @@ export default function TemplatesPage() {
                     </button>
                     <button
                       onClick={() => handleDelete(t.slug)}
+                      aria-label="Delete"
                       className="inline-flex h-8 items-center gap-1.5 rounded-[6px] px-2.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
                     >
                       <Trash2 size={12} />

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,163 @@
+import LegalLayout from "@/components/LegalLayout";
+
+export default function TermsPage() {
+  return (
+    <LegalLayout title="Terms of Service" lastUpdated="May 7, 2026">
+      <p>
+        <strong>saasmail</strong> is open-source self-hosted email
+        infrastructure. These terms apply to your use of the saasmail source
+        code, the website at{" "}
+        <a
+          href="https://github.com/choyiny/saasmail"
+          target="_blank"
+          rel="noreferrer"
+        >
+          github.com/choyiny/saasmail
+        </a>
+        , and any saasmail instance that you choose to deploy. They do
+        <strong> not</strong> create an ongoing service relationship between you
+        and the saasmail project — there is no centralized saasmail SaaS.
+      </p>
+
+      <h2>1. The Software</h2>
+      <p>
+        saasmail is licensed under the{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/blob/main/LICENSE"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Apache License 2.0
+        </a>
+        . You may use, copy, modify, distribute, and self-host the software for
+        any purpose — commercial or otherwise — provided you comply with the
+        license. The full license text governs your rights and obligations and
+        prevails over any conflicting language in this document.
+      </p>
+
+      <h2>2. Self-hosted, no central service</h2>
+      <p>
+        Every saasmail deployment runs entirely inside <strong>your</strong>{" "}
+        Cloudflare account, using your own bindings (D1, R2, Queues, Durable
+        Objects, Email Routing) and any optional outbound provider you
+        configure. The saasmail project does not operate any backend that
+        receives, stores, or processes email on your behalf.
+      </p>
+      <p>This means the project maintainers cannot:</p>
+      <ul>
+        <li>Read, restore, or delete email data on a deployed instance.</li>
+        <li>Provision accounts, reset passwords, or unlock lost passkeys.</li>
+        <li>Provide uptime or availability guarantees for your deployment.</li>
+      </ul>
+
+      <h2>3. Your responsibilities as an operator</h2>
+      <p>
+        If you deploy saasmail and grant access to other users (teammates,
+        customers, etc.), you act as the operator and are solely responsible
+        for:
+      </p>
+      <ul>
+        <li>
+          Complying with all laws applicable to your processing of email and
+          personal data — including, where relevant, GDPR, CCPA/CPRA, CASL,
+          CAN-SPAM, and any sector-specific rules.
+        </li>
+        <li>
+          Honoring data-subject rights of people who email your inboxes (access,
+          deletion, portability) — the saasmail UI gives you the tools to do
+          this; using them is up to you.
+        </li>
+        <li>
+          Configuring authentication (DKIM, SPF, DMARC) and enforcing the terms
+          of your underlying providers (Cloudflare, Resend, etc.).
+        </li>
+        <li>
+          Not using saasmail to send unsolicited bulk email or to harass,
+          impersonate, or harm others.
+        </li>
+      </ul>
+
+      <h2>4. Acceptable use</h2>
+      <p>
+        You agree not to use saasmail or its source code to send spam, malware,
+        or content that is unlawful, harassing, defamatory, or infringing.
+        Violation of any third-party provider's terms of service (Cloudflare,
+        Resend) is your responsibility, not the project's.
+      </p>
+
+      <h2>5. Trademarks</h2>
+      <p>
+        The name <strong>"saasmail"</strong> and the saasmail logo identify the
+        original project. The Apache 2.0 license grants you broad rights to the
+        source, but it does <strong>not</strong> grant trademark rights. If you
+        fork and run saasmail as your own branded product, please rename it and
+        replace the logo so users aren't confused about which project they're
+        installing.
+      </p>
+
+      <h2>6. Contributions</h2>
+      <p>
+        Pull requests are welcome. By opening a pull request against the
+        upstream repository, you agree that your contribution is licensed to the
+        project under the same Apache License 2.0 and that you have the right to
+        license it. There is no separate Contributor License Agreement (CLA).
+      </p>
+
+      <h2>7. Disclaimer of warranties</h2>
+      <p>
+        The software is provided <strong>"as is"</strong>, without warranty of
+        any kind, express or implied — including warranties of merchantability,
+        fitness for a particular purpose, and non-infringement. The project does
+        not guarantee that saasmail will be error-free, secure against every
+        threat, or fit for your specific use case. You are responsible for
+        evaluating and testing it before relying on it.
+      </p>
+
+      <h2>8. Limitation of liability</h2>
+      <p>
+        To the maximum extent permitted by law, the saasmail authors and
+        contributors are not liable for any direct, indirect, incidental,
+        special, consequential, or punitive damages arising out of your use of
+        the software — including lost profits, lost data, business interruption,
+        or any other commercial damages — even if advised of the possibility of
+        such damages.
+      </p>
+
+      <h2>9. Changes to these terms</h2>
+      <p>
+        These terms may be updated to reflect changes in the project, the
+        license, or applicable law. Material changes will be noted in the{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/blob/main/CHANGELOG.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          project changelog
+        </a>
+        . Continued use of the software after a change means you accept the
+        revised terms.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        For questions about these terms, open an issue at{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/issues"
+          target="_blank"
+          rel="noreferrer"
+        >
+          github.com/choyiny/saasmail/issues
+        </a>
+        . For security disclosures, see{" "}
+        <a
+          href="https://github.com/choyiny/saasmail/blob/main/SECURITY.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          SECURITY.md
+        </a>
+        .
+      </p>
+    </LegalLayout>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    // Force a single React instance — prevents the "Invalid hook call" error
+    // when lazy-loading @paper-design/shaders-react which can otherwise be
+    // bundled with its own React copy.
+    dedupe: ["react", "react-dom"],
+  },
+  optimizeDeps: {
+    include: ["@paper-design/shaders-react"],
   },
   build: {},
 });

--- a/worker/src/__tests__/admin-inboxes-router.test.ts
+++ b/worker/src/__tests__/admin-inboxes-router.test.ts
@@ -73,10 +73,12 @@ describe("admin inboxes router", () => {
   it("PATCH clears display name when null is provided", async () => {
     const { apiKey } = await createTestUser({ role: "admin" });
     const now = Math.floor(Date.now() / 1000);
+    // Inserts row at the new default (chat) so PATCH-to-null displayName
+    // collapses to defaults and the row is removed.
     await getDb().insert(senderIdentities).values({
       email: "a@x.com",
       displayName: "Alpha",
-      displayMode: "thread", // ← add this line
+      displayMode: "chat",
       createdAt: now,
       updatedAt: now,
     });
@@ -96,7 +98,7 @@ describe("admin inboxes router", () => {
     expect(rows).toHaveLength(0);
   });
 
-  it("GET returns displayMode (defaulting to 'thread' when no row)", async () => {
+  it("GET returns displayMode (defaulting to 'chat' when no row)", async () => {
     const { apiKey } = await createTestUser({ role: "admin" });
     await createTestPerson();
     await createTestEmail({ recipient: "a@x.com" });
@@ -104,7 +106,7 @@ describe("admin inboxes router", () => {
     await getDb().insert(senderIdentities).values({
       email: "b@x.com",
       displayName: "Bee",
-      displayMode: "chat",
+      displayMode: "thread",
       createdAt: now,
       updatedAt: now,
     });
@@ -116,8 +118,10 @@ describe("admin inboxes router", () => {
       displayMode: "thread" | "chat";
     }>;
     const byEmail = Object.fromEntries(body.map((b) => [b.email, b]));
-    expect(byEmail["a@x.com"].displayMode).toBe("thread");
-    expect(byEmail["b@x.com"].displayMode).toBe("chat");
+    // a@x.com has no sender_identities row → falls back to default (chat).
+    expect(byEmail["a@x.com"].displayMode).toBe("chat");
+    // b@x.com has an explicit thread row → preserved.
+    expect(byEmail["b@x.com"].displayMode).toBe("thread");
   });
 
   it("PATCH persists displayMode independently of displayName", async () => {
@@ -129,7 +133,7 @@ describe("admin inboxes router", () => {
       {
         apiKey,
         method: "PATCH",
-        body: JSON.stringify({ displayMode: "chat" }),
+        body: JSON.stringify({ displayMode: "thread" }),
       },
     );
     expect(res.status).toBe(200);
@@ -138,23 +142,23 @@ describe("admin inboxes router", () => {
       displayName: string | null;
       displayMode: "thread" | "chat";
     };
-    expect(body.displayMode).toBe("chat");
+    expect(body.displayMode).toBe("thread");
     expect(body.displayName).toBeNull();
     const rows = await getDb()
       .select()
       .from(senderIdentities)
       .where(eq(senderIdentities.email, "a@x.com"));
-    expect(rows[0]?.displayMode).toBe("chat");
+    expect(rows[0]?.displayMode).toBe("thread");
     expect(rows[0]?.displayName).toBeNull();
   });
 
-  it("PATCH keeps the row when displayName=null but displayMode=chat", async () => {
+  it("PATCH keeps the row when displayName=null but displayMode=thread", async () => {
     const { apiKey } = await createTestUser({ role: "admin" });
     const now = Math.floor(Date.now() / 1000);
     await getDb().insert(senderIdentities).values({
       email: "a@x.com",
       displayName: "Alpha",
-      displayMode: "chat",
+      displayMode: "thread",
       createdAt: now,
       updatedAt: now,
     });
@@ -173,7 +177,7 @@ describe("admin inboxes router", () => {
       .where(eq(senderIdentities.email, "a@x.com"));
     expect(rows).toHaveLength(1);
     expect(rows[0].displayName).toBeNull();
-    expect(rows[0].displayMode).toBe("chat");
+    expect(rows[0].displayMode).toBe("thread");
   });
 
   it("PATCH deletes the row when both fields are at defaults", async () => {
@@ -182,16 +186,18 @@ describe("admin inboxes router", () => {
     await getDb().insert(senderIdentities).values({
       email: "a@x.com",
       displayName: "Alpha",
-      displayMode: "chat",
+      displayMode: "thread",
       createdAt: now,
       updatedAt: now,
     });
+    // Defaults are now displayName=null + displayMode=chat — patching back
+    // to those values should sparse-delete the row.
     const res = await authFetch(
       `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
       {
         apiKey,
         method: "PATCH",
-        body: JSON.stringify({ displayName: null, displayMode: "thread" }),
+        body: JSON.stringify({ displayName: null, displayMode: "chat" }),
       },
     );
     expect(res.status).toBe(200);

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -174,11 +174,12 @@ describe("emails router", () => {
         createdAt: now + 10,
       });
 
-      // Set support@ to chat mode; sales@ has no row → defaults to thread.
+      // Set support@ to thread mode (override the new default); sales@ has
+      // no row so it falls back to the default ("chat").
       await db.insert(senderIdentities).values({
         email: "support@saasmail.test",
         displayName: null,
-        displayMode: "chat",
+        displayMode: "thread",
         createdAt: now,
         updatedAt: now,
       });
@@ -194,8 +195,8 @@ describe("emails router", () => {
         }>;
       };
       const byEmail = Object.fromEntries(body.inboxes.map((i) => [i.email, i]));
-      expect(byEmail["support@saasmail.test"]?.displayMode).toBe("chat");
-      expect(byEmail["sales@saasmail.test"]?.displayMode).toBe("thread");
+      expect(byEmail["support@saasmail.test"]?.displayMode).toBe("thread");
+      expect(byEmail["sales@saasmail.test"]?.displayMode).toBe("chat");
     });
   });
 

--- a/worker/src/routers/admin-inboxes-router.ts
+++ b/worker/src/routers/admin-inboxes-router.ts
@@ -64,7 +64,7 @@ adminInboxesRouter.openapi(listInboxesRoute, async (c) => {
     rows.map((r) => ({
       email: r.email,
       displayName: r.displayName,
-      displayMode: r.displayMode ?? "thread",
+      displayMode: r.displayMode ?? "chat",
       assignedUserIds: r.assignedUserIds ? JSON.parse(r.assignedUserIds) : [],
     })),
     200,
@@ -116,7 +116,7 @@ adminInboxesRouter.openapi(createInboxRoute, async (c) => {
   const body = c.req.valid("json");
   const email = body.email.trim().toLowerCase();
   const displayName = body.displayName ?? null;
-  const displayMode = body.displayMode ?? "thread";
+  const displayMode = body.displayMode ?? "chat";
   const now = Math.floor(Date.now() / 1000);
 
   const existing = await db
@@ -154,7 +154,7 @@ const patchInboxRoute = createRoute({
   path: "/{email}",
   tags: ["Admin Inboxes"],
   description:
-    "Update display name and/or display mode for an inbox. Row is deleted only when both fields are at defaults (null + 'thread').",
+    "Update display name and/or display mode for an inbox. Row is deleted only when both fields are at defaults (null + 'chat').",
   request: {
     params: z.object({ email: z.string() }),
     body: {
@@ -201,12 +201,12 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
   const nextDisplayMode =
     body.displayMode !== undefined
       ? body.displayMode
-      : (currentRow?.displayMode ?? "thread");
+      : (currentRow?.displayMode ?? "chat");
 
   // Both fields at defaults → delete the row to keep the table sparse.
-  if (nextDisplayName === null && nextDisplayMode === "thread") {
+  if (nextDisplayName === null && nextDisplayMode === "chat") {
     await db.delete(senderIdentities).where(eq(senderIdentities.email, email));
-    return c.json({ email, displayName: null, displayMode: "thread" }, 200);
+    return c.json({ email, displayName: null, displayMode: "chat" }, 200);
   }
 
   await db

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -237,7 +237,7 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
     return {
       email,
       displayName: id?.displayName ?? null,
-      displayMode: (id?.displayMode ?? "thread") as "thread" | "chat",
+      displayMode: (id?.displayMode ?? "chat") as "thread" | "chat",
     };
   });
 

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -46,6 +46,7 @@ const GroupedPersonSchema = z.object({
   unreadCount: z.number(),
   totalCount: z.number(),
   recipientCount: z.number(),
+  recipients: z.array(z.string()),
   hasAttachment: z.number(),
 });
 
@@ -61,6 +62,17 @@ const listGroupedPeopleRoute = createRoute({
         .string()
         .optional()
         .openapi({ description: "Search person name/email" }),
+      recipient: z.string().optional().openapi({
+        description: "Filter to people who have emailed this inbox address",
+      }),
+      unread: z
+        .enum(["1", "true"])
+        .optional()
+        .openapi({ description: "Only people with unread emails" }),
+      hasAttachment: z
+        .enum(["1", "true"])
+        .optional()
+        .openapi({ description: "Only people with downloadable attachments" }),
       page: z.coerce.number().optional().default(1),
       limit: z.coerce.number().optional().default(50),
     }),
@@ -80,11 +92,27 @@ const listGroupedPeopleRoute = createRoute({
 
 peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
   const db = c.get("db");
-  const { q, page, limit } = c.req.valid("query");
+  const { q, recipient, unread, hasAttachment, page, limit } =
+    c.req.valid("query");
   const offset = (page - 1) * limit;
 
   const allowed = c.get("allowedInboxes")!;
   const conditions: any[] = [];
+  if (recipient) {
+    conditions.push(
+      sql`s.id IN (SELECT person_id FROM emails WHERE recipient = ${recipient})`,
+    );
+  }
+  if (unread) {
+    conditions.push(
+      sql`s.id IN (SELECT person_id FROM emails WHERE is_read = 0)`,
+    );
+  }
+  if (hasAttachment) {
+    conditions.push(
+      sql`s.id IN (SELECT e2.person_id FROM emails e2 JOIN ${attachments} a ON a.email_id = e2.id WHERE a.content_id IS NULL)`,
+    );
+  }
   if (q) {
     const pattern = `%${escapeLike(q)}%`;
     const ftsQuery = escapeFts(q);
@@ -131,6 +159,7 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
     unreadCount: number;
     totalCount: number;
     recipientCount: number;
+    recipientsCsv: string | null;
     hasAttachment: number;
   }>(sql`
     SELECT
@@ -141,6 +170,7 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
       SUM(CASE WHEN e.is_read = 0 THEN 1 ELSE 0 END) AS unreadCount,
       COUNT(*) AS totalCount,
       COUNT(DISTINCT e.inbox) AS recipientCount,
+      GROUP_CONCAT(DISTINCT e.inbox) AS recipientsCsv,
       EXISTS(
         SELECT 1 FROM ${attachments} a
         JOIN ${emails} e2 ON e2.id = a.email_id
@@ -154,6 +184,17 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
     ORDER BY lastEmailAt DESC
     LIMIT ${limit} OFFSET ${offset}
   `);
+  const data = rows.map((r) => ({
+    id: r.id,
+    email: r.email,
+    name: r.name,
+    lastEmailAt: r.lastEmailAt,
+    unreadCount: r.unreadCount,
+    totalCount: r.totalCount,
+    recipientCount: r.recipientCount,
+    recipients: r.recipientsCsv ? r.recipientsCsv.split(",") : [],
+    hasAttachment: r.hasAttachment,
+  }));
 
   const countResult = await db.all<{ count: number }>(sql`
     SELECT COUNT(*) AS count FROM (
@@ -165,7 +206,7 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
   `);
   const total = countResult[0]?.count ?? 0;
 
-  return c.json({ data: rows, total, page, limit }, 200);
+  return c.json({ data, total, page, limit }, 200);
 });
 
 const listPeopleRoute = createRoute({
@@ -392,4 +433,103 @@ peopleRouter.openapi(deletePersonRoute, async (c) => {
   await db.delete(people).where(eq(people.id, id));
 
   return c.json({ success: true }, 200);
+});
+
+// Bulk mark all unread emails as read for one or more people. Optionally
+// scope to a specific inbox (e.g. mark only `support@` traffic as read).
+const bulkMarkReadRoute = createRoute({
+  method: "post",
+  path: "/mark-read",
+  tags: ["People"],
+  description: "Mark every unread email for the given people as read.",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            personIds: z.array(z.string()).min(1),
+            recipient: z.string().optional().openapi({
+              description:
+                "Optional: scope the mark-read to one inbox address.",
+            }),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json200Response(
+      z.object({
+        success: z.boolean(),
+        affected: z.number(),
+      }),
+      "Marked unread emails as read",
+    ),
+  },
+});
+
+peopleRouter.openapi(bulkMarkReadRoute, async (c) => {
+  const db = c.get("db");
+  const { personIds, recipient } = c.req.valid("json");
+  const allowed = c.get("allowedInboxes")!;
+
+  if (personIds.length === 0) {
+    return c.json({ success: true, affected: 0 }, 200);
+  }
+
+  // Build the recipient scope (admin sees all; member is gated by permitted
+  // inboxes; explicit `recipient` narrows further).
+  const recipientScope = (() => {
+    if (recipient) {
+      if (!allowed.isAdmin && !allowed.inboxes.includes(recipient)) {
+        return null; // not permitted
+      }
+      return [recipient];
+    }
+    if (allowed.isAdmin) return null; // no scope needed
+    if (allowed.inboxes.length === 0) return [];
+    return allowed.inboxes;
+  })();
+
+  if (recipientScope && recipientScope.length === 0) {
+    return c.json({ success: true, affected: 0 }, 200);
+  }
+
+  // Update emails. We compute the affected count via a SELECT first so we
+  // can return a useful number to the UI.
+  const conditions = [
+    inArray(emails.personId, personIds),
+    eq(emails.isRead, 0),
+  ];
+  if (recipientScope) {
+    conditions.push(inArray(emails.recipient, recipientScope));
+  }
+  const where = and(...conditions)!;
+
+  const affectedRows = await db
+    .select({ id: emails.id, personId: emails.personId })
+    .from(emails)
+    .where(where);
+  const affected = affectedRows.length;
+
+  if (affected > 0) {
+    await db.update(emails).set({ isRead: 1 }).where(where);
+
+    // Recompute unread_count for each touched person from source-of-truth.
+    const touchedPersonIds = Array.from(
+      new Set(affectedRows.map((r) => r.personId).filter(Boolean) as string[]),
+    );
+    for (const pid of touchedPersonIds) {
+      const [row] = await db.all<{ count: number }>(sql`
+        SELECT COUNT(*) AS count FROM ${emails}
+        WHERE person_id = ${pid} AND is_read = 0
+      `);
+      await db
+        .update(people)
+        .set({ unreadCount: row?.count ?? 0 })
+        .where(eq(people.id, pid));
+    }
+  }
+
+  return c.json({ success: true, affected }, 200);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,18 @@
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
+"@paper-design/shaders-react@^0.0.76":
+  version "0.0.76"
+  resolved "https://registry.yarnpkg.com/@paper-design/shaders-react/-/shaders-react-0.0.76.tgz#c574c2e75b8e7b40a1c50d2e919cd10f16be469a"
+  integrity sha512-uPJWrYRf6cJdO2H+fuXlahaqz0QjYglNAyUTaRfIInpzCa/d6guxBIK003soAZQFuQ035yg9FhtfFzKNWm+a5A==
+  dependencies:
+    "@paper-design/shaders" "0.0.76"
+
+"@paper-design/shaders@0.0.76":
+  version "0.0.76"
+  resolved "https://registry.yarnpkg.com/@paper-design/shaders/-/shaders-0.0.76.tgz#85788f66ac94067af284d3ba4ccb33f8df6b531c"
+  integrity sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==
+
 "@peculiar/asn1-android@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz"


### PR DESCRIPTION
## Summary

Large UX + visual overhaul plus a new bulk-actions API. Frontend, brand, and admin tooling all changed; the data model is unchanged. Cofounder-aligned, so the brand swap and "sponsored by givefeedback.dev" footer link are intentional.

Bumps to **0.4.0**. Rebased onto current `main`, all 251 tests pass, `yarn tsc --noEmit` is clean.

## Highlights

- **Top nav layout** replaces the persistent left sidebar — floating dark pill nav, breadcrumbs, footer, page-header chrome on every dashboard page. Capped at `max-w-[1600px]`.
- **Inbox table view + filter toolbar** is the new default view. Per-row stats + inbox-name chips. Unified toolbar combines search, inbox dropdown, unread/attachments chips, List ↔ Table view toggle.
- **Bulk actions**: per-row checkboxes, floating SelectionBar, click any unread badge to mark just that person's emails read, per-inbox "Mark all" button in PersonDetail. New `POST /api/people/mark-read` endpoint with optional recipient scope.
- **Per-person tabbed inbox view** — when a contact has emailed multiple inboxes, each is its own tab.
- **Drawers** for "View original" and "Reply" — right-side animated slide-in. Reply drawer shows the email being replied to + surrounding thread alongside the editor.
- **Chat redesign** — sticky reply input, day separators, scroll affordances, "Jump to latest" pill, larger bubbles.
- **Mobile-first** — Compose FAB, full-screen drawers under `sm`, edge-to-edge inbox card, scroll-snap inbox tabs, ≥44px touch targets, `text-base` toolbar inputs.
- **Capability-aware animations** — new `useReducedAnimations()` gates the WebGL shader on `prefers-reduced-motion` / Save-Data / slow connection / low memory / low cores. Static gradient fallback when any of these fire.
- **Admin Inboxes redesign** — real `<table>` with bulk select, bulk Thread/Chat/Delete, inline display-name editing, member-popover cell.
- **Public legal pages** — new `/terms` and `/privacy` with content appropriate for self-hosted Apache 2.0 software (operator-as-data-controller framing).
- **Brand refresh** — lime + violet palette via Tailwind v4 `@theme` tokens, Inter/Caveat fonts, mail-glyph favicon, OpenGraph image, comprehensive SEO meta + JSON-LD `SoftwareApplication`.

## API surface

- **Added**: `POST /api/people/mark-read` (bulk mark-as-read, optional `recipient` scope; recomputes `people.unread_count` from source of truth; permission-scoped).
- **Added**: `GET /api/people/grouped` accepts new query params `recipient` / `unread` / `hasAttachment`, and returns a new `recipients: string[]` field (the distinct inbox addresses each person has emailed, via `GROUP_CONCAT(DISTINCT)`).
- **Changed**: default `displayMode` for inboxes is now `chat` (was `thread`). Existing rows with explicit values are unchanged; only fallback for missing rows flipped. Tests updated.

## Commits (in reverse chronological order)

1. `chore(release): 0.4.0` — version bump, CHANGELOG, gitignore for `.claude/launch.json`, `@paper-design/shaders-react` dep added.
2. `feat(ui): v0.4.0 frontend redesign` — the big one: top nav, page chrome, inbox table view, bulk actions, drawers, mobile, chat, legal pages, reduced-motion. Vite config gets `dedupe: ['react','react-dom']` + `optimizeDeps.include` for the lazy-loaded shader.
3. `feat(api): bulk mark-read, filter params, recipients[], default chat` — server-side additions only; tests updated for the default flip.
4. `chore(brand): mail-glyph favicon, OG image, fonts, SEO meta, manifest` — pure assets + meta.

## Test plan

- [ ] `yarn test` passes (251/252, 1 pre-existing skip)
- [ ] `yarn tsc --noEmit` clean
- [ ] Local dev: `yarn db:seed:dev && yarn dev` — login flow works, inbox renders in table view by default, click person → tabbed view → reply drawer with thread context
- [ ] Mobile (375×812): Compose FAB visible, person tap opens full-screen, drawers full-screen, no iOS zoom on inputs
- [ ] Reduced motion (`prefers-reduced-motion: reduce`): shader replaced with static gradient on auth pages, dashboard backdrop static
- [ ] Bulk actions: select 3+ people via checkboxes, "Mark as read" optimistically clears badges
- [ ] Click an unread badge directly → that person's badge clears
- [ ] Inboxes admin: create / inline-edit display name / toggle mode / select 2+ → bulk Thread/Chat/Delete
- [ ] `/terms` and `/privacy` render through LegalLayout with no auth

## Notes for review

- The `seeds/demo.sql` is **unchanged** from upstream. A new `seeds/generate-demo.ts` ships alongside that produces a 100-person / ~700-email dataset for stress-testing — run `npx tsx seeds/generate-demo.ts && yarn db:seed:dev` locally if you want volume.
- Rebased on top of `424c81e fix: surface compose recipients in the people list`. The conflict was in `worker/src/routers/people-router.ts` — resolved by keeping upstream's `activity` UNION subquery and adapting the new filter conditions + `recipients[]` aggregate to use the `e.inbox` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)