### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-05-06
+
+### Fixed
+
+- Compose recipients are now surfaced in the people list: sending via compose upserts a people row for the recipient and the `/api/people/grouped` aggregation now unions sent emails so sent activity contributes to `totalCount`, `lastEmailAt`, and `recipientCount`.
+
 ## [0.3.3] - 2026-05-05
 
 ### Fixed
@@ -174,7 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/choyiny/saasmail/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/choyiny/saasmail/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/choyiny/saasmail/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/choyiny/saasmail/compare/v0.3.0...v0.3.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version from `0.3.3` → `0.3.4` in `package.json`
- Adds `[0.3.4] - 2026-05-06` entry to `CHANGELOG.md` documenting the fix for surfacing compose recipients in the people list

## Changes included

- **fix**: Compose recipients are now surfaced in the people list — sending via compose upserts a people row for the recipient and `/api/people/grouped` unions sent emails so sent activity contributes to `totalCount`, `lastEmailAt`, and `recipientCount`.

https://claude.ai/code/session_01Dk6xATZhde3SN6MhQ2xVvU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk6xATZhde3SN6MhQ2xVvU)_