### PR TITLE
chore: add .mailmap to canonicalize author attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+# Canonical author mapping. Tools that respect .mailmap (git log,
+# git shortlog, git blame, GitHub's per-file blame view in some
+# contexts) display the canonical identity instead of whatever
+# email a contributor's local git happened to be configured with
+# at commit time.
+#
+# Format: <Canonical Name> <canonical@email> <commit-time-email>
+#
+# References:
+# - https://git-scm.com/docs/gitmailmap
+# - https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address
+
+Mahmoud Halat <17732306+MahmoudHalat@users.noreply.github.com> <mahmoudhalat@MacBook-Pro.local>


### PR DESCRIPTION
## Summary

Adds a `.mailmap` at the repo root that maps a stray
hostname-derived author email (`mahmoudhalat@MacBook-Pro.local`)
to my canonical GitHub no-reply address. My local git author
config wasn't set when the v0.4.x work landed, so 15 commits
from PRs #61 and #64 ended up authored under the bogus email.

This PR doesn't rewrite history — it's purely additive. With
the file in place, tooling that respects `.mailmap` displays
the canonical identity instead.

```
$ git shortlog -sne | head -3
   384  Cho Yin Yong <choyiny@users.noreply.github.com>
    20  dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
    15  Mahmoud Halat <17732306+MahmoudHalat@users.noreply.github.com>
```

## What this changes

`git log`, `git shortlog`, `git blame`, and GitHub's per-file
blame view (in places it consults `.mailmap`) all attribute
the affected commits to my canonical identity going forward.

## What this does NOT change

GitHub's contribution graph and the repo's "Contributors" widget
on the home page read raw commit-author emails — they don't
consult `.mailmap`. Fully retroactive credit on those would
require rewriting `dev` history (force-push), which I'm not
asking for here. Cosmetic git-tooling fix only.

## Going forward

My git author config (local + global) has been corrected, so
every new commit — starting with #66 — already lands with the
right attribution and doesn't need `.mailmap`'s help.

## Test plan

- [ ] `git shortlog -sne` shows my 15 commits under the
  canonical no-reply address (no entries left under the
  hostname email).
- [ ] No diff in production code; only the new `.mailmap` file.

## References

- [git-scm.com/docs/gitmailmap](https://git-scm.com/docs/gitmailmap)
- [GitHub: setting your commit email address](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)

🤖 Generated with [Claude Code](https://claude.com/claude-code)