### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-11
+
+### Changed
+
+- Bump hono from 4.12.14 to 4.12.18.
+- Add `.mailmap` to canonicalize historical author attribution.
+
 ## [0.4.1] - 2026-05-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump version to 0.4.2 in `package.json`
- Update `CHANGELOG.md` with entries for commits from 2026-05-10:
  - hono dependency bump from 4.12.14 to 4.12.18
  - `.mailmap` addition for canonical author attribution

## Test plan

- [ ] CHANGELOG.md has a new `[0.4.2]` section
- [ ] `package.json` version is `0.4.2`

https://claude.ai/code/session_01ArM2siJMycbDDVQnw3LGgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArM2siJMycbDDVQnw3LGgD)_