### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-12
+
+### Security
+
+- Closed stored-XSS surface on per-inbox signatures: a new HTMLRewriter-based sanitizer (`worker/src/lib/sanitize-signature.ts`) strips dangerous tags (`script`, `style`, `iframe`, etc.), every `on*` event handler, `style` attributes, and unsafe URL schemes (`javascript:`, `vbscript:`, non-image `data:`). Signatures are sanitized at write time in the PATCH inbox endpoint (with a 20 000-character schema cap) and on the client in `ComposeModal` and `ReplyComposer` as defense-in-depth.
+- `inbox-permissions.ts` lowercases addresses at resolution time, closing a latent permission-check bypass for mixed-case `inbox_permissions.email` rows.
+
+### Fixed
+
+- `EmailHtmlModal`: converted a `useMemo` side-effect to `useEffect`, eliminating a "Cannot update a component while rendering" warning under React StrictMode.
+- Send and reply routes now cap CC arrays at 50 entries and normalize `fromAddress`, `to`, and every CC email to lowercase at the route boundary, ensuring consistent `computeConversationId` results.
+- Inbound CC entries are now lowercased, trimmed, name-truncated, and filtered through a regex email-shape gate before storage; capped at 50 entries per inbound message.
+- Non-admin member can no longer fetch a sent email authored from an inbox they do not own via `GET /api/emails/:id` (previously returned 200; now returns 404).
+- Removed dead `inboxMode` toggle, unreachable `ThreadInboxSection` branch, and related state from `ConversationDetail` (~130 lines).
+
+### Changed
+
+- Drizzle meta snapshots reconciled for migrations 0021–0024, fixing a `parent snapshot collision` that prevented `drizzle-kit generate` from running; missing `app_settings` table export added to `worker/src/db/index.ts`.
+
 ## [0.4.1] - 2026-05-08
 
 ### Changed
@@ -235,7 +254,8 @@ and admin tooling all changed; the data model is unchanged.
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/choyiny/saasmail/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/choyiny/saasmail/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/choyiny/saasmail/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/choyiny/saasmail/compare/v0.3.2...v0.3.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version from `0.4.1` → `0.4.2` in `package.json`
- Adds `[0.4.2]` entry to `CHANGELOG.md` covering yesterday's commits (2026-05-11)

## What's in 0.4.2

**Security**
- Stored-XSS surface closed on per-inbox signatures via a new HTMLRewriter-based sanitizer; 20 000-character schema cap added; client-side defense-in-depth in `ComposeModal` and `ReplyComposer`
- Permission-check bypass closed in `inbox-permissions.ts` for mixed-case email rows

**Fixed**
- `EmailHtmlModal`: `useMemo` side-effect converted to `useEffect` (StrictMode warning)
- CC arrays capped at 50 entries; `fromAddress`/`to`/CC emails normalized to lowercase at route boundary
- Inbound CC entries lowercased, trimmed, and regex-filtered; capped at 50 per message
- Non-admin member can no longer fetch a sent email from an inbox they don't own (`GET /api/emails/:id` now returns 404)
- Dead `inboxMode` toggle and unreachable `ThreadInboxSection` branch removed from `ConversationDetail`

**Changed**
- Drizzle meta snapshots reconciled for migrations 0021–0024; missing `app_settings` export added to `worker/src/db/index.ts`

## Test plan

- [ ] CI passes (unit tests: 279 passing, 1 skipped; tsc clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKuBn7adMZmHBfqs5y8oeF)_