### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-13
+
+### Fixed
+
+- HTML preview in chat inbox no longer shows a blurred overlay; content is readable at a glance with a persistent "View original" action, and the redundant "HTML email" tag has been removed (`ChatInboxSection`).
+- Removed the fade-out gradient overlay that partially obscured HTML preview content in the chat view.
+
+### Dependencies
+
+- Bumped `kysely` from 0.28.16 to 0.28.17.
+- Bumped `better-auth` group with 2 updates.
+- Bumped `@codemirror/view` in the codemirror group.
+- Bumped the tiptap group with 4 updates.
+- Bumped the cloudflare dev-dependency group across 1 directory with 4 updates.
+
 ## [0.4.2] - 2026-05-12
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to `0.4.3` in `package.json`
- Adds `[0.4.3]` entry to `CHANGELOG.md` capturing commits from 2026-05-12 that were missed by the v0.4.2 release

### Changes documented

**Fixed**
- HTML preview in chat inbox no longer shows a blurred overlay; content is readable at a glance with a persistent "View original" action, and the redundant "HTML email" tag has been removed (`ChatInboxSection`)
- Removed the fade-out gradient overlay that partially obscured HTML preview content in the chat view

**Dependencies**
- `kysely` 0.28.16 → 0.28.17
- `better-auth` group (2 updates)
- `@codemirror/view` (codemirror group)
- tiptap group (4 updates)
- cloudflare dev-dependency group (4 updates)

## Test plan

- [ ] Verify `package.json` version is `0.4.3`
- [ ] Verify `CHANGELOG.md` has a `[0.4.3] - 2026-05-13` section with the correct entries
- [ ] CI passes

https://claude.ai/code/session_01BAPiPvAYarPkpmqXZscNTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAPiPvAYarPkpmqXZscNTP)_