### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-17
+
+### Added
+
+- Rich text editor now supports drag-and-drop, paste, and file-picker image insertion; images are base64-embedded inline (2 MB cap) so they travel with the email body without requiring an R2 upload.
+
 ## [0.4.2] - 2026-05-12
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version from `0.4.2` → `0.4.3` in `package.json`
- Adds `[0.4.3] - 2026-05-17` entry to `CHANGELOG.md` covering the image insertion feature shipped on 2026-05-16

## Changes included

- **feat(editor):** drag, paste, or pick images into rich text editor — images are base64-embedded inline (2 MB cap) so they travel with the email body without an R2 upload.

## Test plan

- [ ] Verify `package.json` version reads `0.4.3`
- [ ] Verify CHANGELOG entry appears under `[0.4.3]` with the correct date

https://claude.ai/code/session_018EuAnwUDAoyeryKdv8bugE

---
_Generated by [Claude Code](https://claude.ai/code/session_018EuAnwUDAoyeryKdv8bugE)_