### PR TITLE
fix: preserve image aspect ratio in chat-bubble HTML previews

### DIFF
--- a/src/components/ChatInboxSection.tsx
+++ b/src/components/ChatInboxSection.tsx
@@ -213,9 +213,12 @@ function Bubble({
             isUnread ? "outline outline-2 outline-violet/40" : ""
           }`}
         >
-          {/* Capped, sanitized inline preview */}
+          {/* Sanitized inline preview. Images render at their natural
+              size, constrained only by the bubble width so aspect ratio
+              is preserved — capping height made hero/inline images
+              unreadably small. */}
           <div
-            className="prose prose-sm relative max-h-[200px] max-w-none overflow-hidden px-4 py-3 text-xs text-text-secondary [&_*]:max-w-full [&_a]:pointer-events-none [&_img]:max-h-24 [&_img]:max-w-full [&_table]:!w-full [&_table]:!table-fixed"
+            className="prose prose-sm relative max-w-none px-4 py-3 text-xs text-text-secondary [&_*]:max-w-full [&_a]:pointer-events-none [&_img]:h-auto [&_img]:max-w-full [&_table]:!w-full [&_table]:!table-fixed"
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
           />
         </div>


### PR DESCRIPTION
## Summary
- In chat-bubble mode, the HTML preview card capped every `<img>` at `max-h-24` (96px) and the whole block at `max-h-[200px] overflow-hidden`, which compressed inline images and clipped tall ones.
- Drop the height caps so images render at their natural aspect ratio, constrained only by the bubble width via `max-w-full`.

## Test plan
- [ ] Open a chat-mode inbox containing an email with inline images (e.g., a marketing email with a hero image) and confirm images now render at full width with correct aspect ratio.
- [ ] Sanity-check that short plain-text bubbles still look unchanged (this path only affects the HTML-preview card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)