### PR TITLE
fix: default chat-bubble quick reply to reply-all

### DIFF
--- a/src/components/ChatInboxSection.tsx
+++ b/src/components/ChatInboxSection.tsx
@@ -411,6 +411,16 @@ export default function ChatInboxSection({
     [group.emails],
   );
 
+  // CC carried into the inline reply so chat-bubble sends default to
+  // "reply-all" — matches the full ReplyComposer's behavior. Strip our
+  // own inbox so we don't CC ourselves.
+  const replyCc = useMemo(() => {
+    const ownInbox = group.inbox.toLowerCase();
+    return (replyTarget?.cc ?? []).filter(
+      (c) => c.email.toLowerCase() !== ownInbox,
+    );
+  }, [replyTarget, group.inbox]);
+
   // Build the seed values for the full compose drawer. We pull the most
   // recent received email's recipient list so switching to compose
   // carries the original CC roster + subject through (minus our own
@@ -422,10 +432,7 @@ export default function ChatInboxSection({
           : null;
         const to =
           sender?.email ?? replyTarget?.fromAddress ?? _personEmail ?? "";
-        const ownInbox = group.inbox.toLowerCase();
-        const cc = (replyTarget?.cc ?? []).filter(
-          (c) => c.email.toLowerCase() !== ownInbox,
-        );
+        const cc = replyCc;
         const baseSubject = replyTarget?.subject ?? "";
         const subject =
           baseSubject && !/^re:\s/i.test(baseSubject)
@@ -567,6 +574,7 @@ export default function ChatInboxSection({
           inboxAddress={group.inbox}
           latestReceivedEmailId={replyTarget?.id ?? null}
           personEmail={_personEmail}
+          replyCc={replyCc}
           onSent={onSent}
           onOpenCompose={handleOpenInCompose}
         />

--- a/src/components/ChatQuickReply.tsx
+++ b/src/components/ChatQuickReply.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Maximize2 } from "lucide-react";
-import { replyToEmail, sendEmail } from "@/lib/api";
+import { replyToEmail, sendEmail, type CcEntry } from "@/lib/api";
 import { dispatchEmailSent } from "@/lib/email-events";
 import AttachmentPicker from "@/components/AttachmentPicker";
 import AttachmentChips from "@/components/AttachmentChips";
@@ -11,6 +11,13 @@ interface ChatQuickReplyProps {
   inboxAddress: string; // From address, fixed to this section's inbox
   latestReceivedEmailId: string | null; // What we reply to; if null, send as new email
   personEmail: string; // Recipient address when no reply target exists
+  /**
+   * CC list to carry over from the original message — chat bubbles
+   * default to "reply-all" semantics so group conversations stay
+   * group conversations. Should already be filtered to exclude this
+   * section's own inbox address. Ignored when there's no reply target.
+   */
+  replyCc?: CcEntry[];
   onSent: () => void; // Refetch + scroll
   /**
    * Optional handoff to the global compose drawer. When provided, the
@@ -45,6 +52,7 @@ export default function ChatQuickReply({
   inboxAddress,
   latestReceivedEmailId,
   personEmail,
+  replyCc,
   onSent,
   onOpenCompose,
 }: ChatQuickReplyProps) {
@@ -75,10 +83,15 @@ export default function ChatQuickReply({
     setError(null);
     try {
       if (latestReceivedEmailId) {
+        // Default to reply-all semantics for the chat bubble: carry the
+        // original CC roster (already filtered by the parent to exclude
+        // our own inbox) so group conversations don't silently collapse
+        // to a 1:1. Users who want plain "reply" open the full composer.
         await replyToEmail(latestReceivedEmailId, {
           bodyHtml: plainTextToHtml(text),
           bodyText: text,
           fromAddress: inboxAddress,
+          ...(replyCc && replyCc.length > 0 ? { cc: replyCc } : {}),
           ...(files.length > 0
             ? { files: files.map((file) => ({ file })) }
             : {}),


### PR DESCRIPTION
## Summary

- **Bug:** Replying from a group chat bubble silently collapsed the conversation to a 1:1. `ChatQuickReply.handleSend()` called `replyToEmail()` without a `cc` field, and the server (`worker/src/routers/send-router.ts:289`) only forwards CC when the client supplies it — so the original CC roster was dropped.
- **Fix:** Mirror the pattern already used by `ReplyComposer` (`src/components/ReplyComposer.tsx:138-143`) and the existing `handleOpenInCompose` handoff: thread the original message's CC list down into `ChatQuickReply`, with our own inbox address filtered out.
- **Scope:** Chat-bubble inline reply only. Thread mode is unchanged — users still pick reply vs reply-all via the full composer's CC chips.

## Test plan

- [ ] Reply to a group email from a chat bubble → outgoing message includes original CCs (minus your own inbox).
- [ ] Reply to a 1:1 email from a chat bubble → no CC added (unchanged).
- [ ] "Open in compose" from the same chat bubble → CC chips populated identically (regression check on shared filter).
- [ ] Thread-mode `ReplyComposer` still behaves as before — CC chips editable, reply-all still the default there.
- [ ] `yarn test` passes (couldn't run locally — fresh worktree).
- [ ] `e2e/specs/chat-display.spec.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)