### PR TITLE
feat: resizable images in tiptap editor

### DIFF
--- a/src/components/ResizableImage.tsx
+++ b/src/components/ResizableImage.tsx
@@ -1,0 +1,177 @@
+import Image from "@tiptap/extension-image";
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Tiptap Image extension that lets users drag a corner handle to resize.
+ * The width is stored as an inline attribute (in pixels) on the rendered
+ * <img>, so it round-trips through HTML serialization and DOMPurify
+ * untouched. Height is kept fluid via `height: auto` in CSS to preserve
+ * aspect ratio.
+ */
+const MIN_WIDTH = 50;
+
+function ResizableImageView({
+  node,
+  selected,
+  updateAttributes,
+  editor,
+}: NodeViewProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  // Tracks a width override while the user is dragging so we don't commit
+  // an updateAttributes call on every mousemove (which would flood undo
+  // history and re-render the editor at 60Hz).
+  const [draftWidth, setDraftWidth] = useState<number | null>(null);
+
+  const src = node.attrs.src as string;
+  const alt = (node.attrs.alt as string | undefined) ?? "";
+  const title = (node.attrs.title as string | undefined) ?? "";
+  const widthAttr = node.attrs.width as number | string | null | undefined;
+
+  const isEditable = editor.isEditable;
+
+  function handlePointerDown(event: React.PointerEvent<HTMLSpanElement>) {
+    if (!isEditable) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const img = imgRef.current;
+    if (!img) return;
+
+    const startX = event.clientX;
+    const startWidth = img.getBoundingClientRect().width;
+    // Cap dragging at the editor's content width so the handle can't be
+    // dragged off into space — the image visually maxes out at 100% anyway.
+    const containerWidth =
+      img.parentElement?.parentElement?.getBoundingClientRect().width ??
+      Infinity;
+
+    function onMove(e: PointerEvent) {
+      const delta = e.clientX - startX;
+      let next = startWidth + delta;
+      if (next < MIN_WIDTH) next = MIN_WIDTH;
+      if (next > containerWidth) next = containerWidth;
+      setDraftWidth(next);
+    }
+    function onUp(e: PointerEvent) {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      const delta = e.clientX - startX;
+      let next = startWidth + delta;
+      if (next < MIN_WIDTH) next = MIN_WIDTH;
+      if (next > containerWidth) next = containerWidth;
+      setDraftWidth(null);
+      updateAttributes({ width: Math.round(next) });
+    }
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }
+
+  // If the node's width changes from elsewhere (e.g. paste), drop any
+  // stale local draft so the img reflects the canonical attribute.
+  useEffect(() => {
+    setDraftWidth(null);
+  }, [widthAttr]);
+
+  const displayedWidth =
+    draftWidth !== null
+      ? `${Math.round(draftWidth)}px`
+      : widthAttr
+        ? typeof widthAttr === "number"
+          ? `${widthAttr}px`
+          : String(widthAttr)
+        : undefined;
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="notion-image-wrapper"
+      data-selected={selected ? "true" : undefined}
+      // Inline-block so the wrapper hugs the image and the handle sits
+      // flush with its bottom-right corner.
+      style={{
+        display: "inline-block",
+        position: "relative",
+        maxWidth: "100%",
+      }}
+    >
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        title={title || undefined}
+        className="notion-image"
+        width={
+          typeof widthAttr === "number"
+            ? widthAttr
+            : draftWidth !== null
+              ? Math.round(draftWidth)
+              : undefined
+        }
+        style={displayedWidth ? { width: displayedWidth } : undefined}
+        draggable={false}
+      />
+      {isEditable && (
+        <span
+          role="slider"
+          aria-label="Resize image"
+          aria-valuemin={MIN_WIDTH}
+          aria-valuenow={
+            draftWidth !== null
+              ? Math.round(draftWidth)
+              : typeof widthAttr === "number"
+                ? widthAttr
+                : Math.round(imgRef.current?.getBoundingClientRect().width ?? 0)
+          }
+          className="notion-image-resize-handle"
+          onPointerDown={handlePointerDown}
+          contentEditable={false}
+          data-visible={selected || draftWidth !== null ? "true" : undefined}
+        />
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+export const ResizableImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        // Parse from either the HTML width attribute or an inline
+        // `width: NNNpx` style so pasted/loaded content keeps its size.
+        parseHTML: (element) => {
+          const attr = element.getAttribute("width");
+          if (attr) {
+            const n = parseInt(attr, 10);
+            if (!Number.isNaN(n)) return n;
+            return attr;
+          }
+          const style = element.getAttribute("style") ?? "";
+          const m = style.match(/width:\s*(\d+(?:\.\d+)?)px/i);
+          if (m) return Math.round(parseFloat(m[1] ?? "0"));
+          return null;
+        },
+        renderHTML: (attrs) => {
+          if (attrs.width == null || attrs.width === "") return {};
+          // Render BOTH the width attribute and an inline style so the
+          // size survives strict email HTML sanitizers that strip one or
+          // the other.
+          return {
+            width: String(attrs.width),
+            style: `width: ${typeof attrs.width === "number" ? attrs.width + "px" : attrs.width}; height: auto;`,
+          };
+        },
+      },
+    };
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(ResizableImageView);
+  },
+});
+
+export default ResizableImage;

--- a/src/components/TiptapEditor.tsx
+++ b/src/components/TiptapEditor.tsx
@@ -1,7 +1,7 @@
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
-import Image from "@tiptap/extension-image";
+import { ResizableImage } from "./ResizableImage";
 import { useEffect, useRef, useState } from "react";
 
 interface TiptapEditorProps {
@@ -92,7 +92,7 @@ export default function TiptapEditor({
         placeholder: placeholderText || "Start writing",
         emptyEditorClass: "is-editor-empty",
       }),
-      Image.configure({
+      ResizableImage.configure({
         inline: false,
         allowBase64: true,
         HTMLAttributes: { class: "notion-image" },

--- a/src/index.css
+++ b/src/index.css
@@ -479,7 +479,37 @@ body {
   border-radius: 6px;
 }
 
-.notion-editor img.ProseMirror-selectednode {
+.notion-editor img.ProseMirror-selectednode,
+.notion-editor .notion-image-wrapper[data-selected="true"] .notion-image {
   outline: 2px solid var(--color-accent, #7c5cfc);
   outline-offset: 2px;
+}
+
+.notion-editor .notion-image-wrapper {
+  /* Margin moves up to the wrapper so the handle visually attaches to
+     the image rather than the surrounding block flow. */
+  margin: 0.75em 0;
+}
+.notion-editor .notion-image-wrapper .notion-image {
+  margin: 0;
+}
+
+.notion-editor .notion-image-resize-handle {
+  position: absolute;
+  right: -6px;
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  background: var(--color-accent, #7c5cfc);
+  border: 2px solid var(--color-bg, #fff);
+  border-radius: 2px;
+  cursor: nwse-resize;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  touch-action: none;
+  z-index: 1;
+}
+.notion-editor .notion-image-wrapper:hover .notion-image-resize-handle,
+.notion-editor .notion-image-resize-handle[data-visible="true"] {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Adds a `ResizableImage` extension that wraps `@tiptap/extension-image` with a React NodeView and a bottom-right drag handle
- Width is rendered as both a `width` attribute and an inline `width/height` style so it survives strict email HTML sanitizers; height stays `auto` to preserve aspect ratio
- Width is committed once on pointer-up (not on every move) to keep undo history clean

## Test plan
- [ ] Open compose modal, drop/paste an image, click it, drag the bottom-right handle — image resizes smoothly with cursor
- [ ] Send the email and verify the received HTML keeps the chosen width
- [ ] Confirm `setImage`, paste, drop, and file picker all still work
- [ ] Reload a draft containing a resized image and confirm the size is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)