### PR TITLE
feat: suppression list + one-click unsubscribe (closes #94 part 1)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -15,3 +15,8 @@ DISABLE_PASSKEY_GATE=true
 # synthetic demo_... id). Required by `yarn test:e2e`; safe to leave
 # off for normal `yarn dev`. Never set in production.
 DEMO_MODE=1
+
+# Secret used to sign one-click unsubscribe tokens (HMAC). Generate
+# with: openssl rand -hex 32. Set in prod via:
+#   wrangler secret put UNSUBSCRIBE_SECRET
+UNSUBSCRIBE_SECRET=replace-with-output-of-openssl-rand-hex-32

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,7 @@ jobs:
           DEMO_MODE=1
           DISABLE_PASSKEY_GATE=true
           BETTER_AUTH_SECRET=ci-only-secret-not-used-for-real-auth
+          UNSUBSCRIBE_SECRET=ci-only-unsubscribe-secret-not-used-for-real-tokens
           EOF
 
       - name: Cache Playwright browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Suppression list with admin UI at `/admin/suppressions` and CRUD API at `/api/suppressions` (admin-only).
+- Public unsubscribe page at `/unsubscribe?token=…` with one-click POST handling and a re-subscribe button.
+- `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` (RFC 8058) headers on marketing sends.
+- Template variable `{{unsubscribe_url}}` available in marketing email templates. If the rendered body doesn't include the URL, an unsubscribe footer is auto-appended (HTML and plaintext).
+- `transactional: boolean` flag on `POST /api/send` (default `false`) to bypass suppression checks and unsubscribe injection for account-critical mail (password resets, OTPs, system notifications).
+- `suppressed: string[]` field on the `POST /api/send` response, listing recipients that were dropped because they're on the suppression list.
+- Sequence dispatcher and template preview/test send now respect the suppression list — unsubscribed recipients no longer receive scheduled or test sends.
+
+### Changed
+
+- **Behavior shift for API integrators:** sends through `POST /api/send` now have `List-Unsubscribe` headers added and (if the body lacks the URL) an unsubscribe footer auto-appended UNLESS the caller passes `transactional: true`. To preserve previous behavior for transactional mail (password resets, OTPs, etc.), set the flag explicitly on every transactional send.
+- `POST /api/send` response: `id` is now nullable. When every recipient is suppressed, the response is `{ id: null, status: "suppressed", delivered: [], suppressed: [...] }` with no message dispatched.
+- The `sequence_emails.status` enum now includes `suppressed` for steps dropped due to suppression.
+
+### Configuration
+
+- New required env var: `UNSUBSCRIBE_SECRET` — Worker secret used to sign one-click unsubscribe tokens (HMAC). Set in prod via `wrangler secret put UNSUBSCRIBE_SECRET`. Generate with `openssl rand -hex 32`.
+- The existing `BASE_URL` var is reused to build absolute unsubscribe URLs — no new `APP_URL` introduced.
+
 ## [0.6.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ Create reusable HTML email templates with `{{variable}}` interpolation. Edit tem
 
 Build multi-step drip campaigns. Enroll a contact into a sequence and saasmail sends templated emails on a schedule. Supports step skipping, delay overrides, custom variables, and automatic cancellation when the contact replies. Enrollment is enforced against the member's allowed inboxes.
 
+### Suppressions and Unsubscribe
+
+saasmail tracks unsubscribed and manually-suppressed recipients in a `suppressions` table. Suppression checks run on every outbound dispatch path: `POST /api/send`, scheduled sequence steps, and admin template test-sends. Admins manage the list at `/admin/suppressions` (CRUD also exposed at `/api/suppressions`).
+
+- **List-Unsubscribe headers**: marketing sends automatically include `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` (RFC 8058) headers so Gmail/Yahoo bulk-sender rules and major mail clients render native unsubscribe affordances.
+- **Unsubscribe footer**: templates can use `{{unsubscribe_url}}` in HTML or plaintext bodies. If the rendered output doesn't include the URL, saasmail auto-appends a minimal unsubscribe footer.
+- **Unsubscribe page**: recipients land on `/unsubscribe?token=…`. The page POSTs to `/api/unsubscribe` on JavaScript mount (so URL-preview crawlers don't trigger it) and offers a "Re-subscribe" button. One-click unsubscribe (RFC 8058) also works via `POST /api/unsubscribe?token=…` directly — no session, no UI; the token signs the recipient's email.
+- **Transactional sends**: account-critical mail (password resets, OTPs, system notifications) should pass `transactional: true` in the `POST /api/send` body. This bypasses the suppression check, skips the unsubscribe headers, and skips the footer auto-append. Anyone you genuinely _need_ to email will still get the message.
+
+> **Behavior shift for API integrators**: `POST /api/send` now adds `List-Unsubscribe` headers and (if the body lacks the URL) appends an unsubscribe footer to every send UNLESS the caller passes `transactional: true`. If your integration sends password resets, OTPs, or other account-critical mail through `/api/send`, set the flag explicitly on those calls to preserve the previous behavior.
+
+The Worker signs unsubscribe tokens with `UNSUBSCRIBE_SECRET` (see [Configuration](#devvars)) and builds absolute URLs from the existing `BASE_URL` setting.
+
 ### User Management
 
 Admin-controlled onboarding via one-time invite links. New members sign up with email + password, and can register a passkey for passwordless login on subsequent sessions. Roles: `admin` (full access + user management) and `member` (scoped by inbox assignment).
@@ -214,11 +227,13 @@ Edit `.dev.vars`:
 - `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` — your Bavimail bearer token and alias UUID (only if using Bavimail; both must be set)
 - `RESEND_API_KEY` — your Resend API key (omit if using Cloudflare Email Sending or Bavimail)
 - `BETTER_AUTH_SECRET` — generate a random string (`openssl rand -hex 32`)
+- `UNSUBSCRIBE_SECRET` — generate a random string (`openssl rand -hex 32`); used to sign one-click unsubscribe tokens
 
 For production, set these as Cloudflare secrets:
 
 ```bash
 wrangler secret put BETTER_AUTH_SECRET
+wrangler secret put UNSUBSCRIBE_SECRET
 wrangler secret put RESEND_API_KEY      # only if using Resend
 wrangler secret put BAVIMAIL_API_KEY    # only if using Bavimail
 wrangler secret put BAVIMAIL_ALIAS_ID   # only if using Bavimail
@@ -344,6 +359,7 @@ Local development secrets. Created from `.dev.vars.example`. This file is gitign
 - `BAVIMAIL_ALIAS_ID` — Bavimail alias UUID identifying the sending alias (required for Bavimail)
 - `RESEND_API_KEY` — Resend API key (if using Resend)
 - `BETTER_AUTH_SECRET` — Secret for session signing
+- `UNSUBSCRIBE_SECRET` — Secret used to HMAC-sign one-click unsubscribe tokens. Generate with `openssl rand -hex 32`. Set in prod via `wrangler secret put UNSUBSCRIBE_SECRET`. Required for the suppressions/unsubscribe feature.
 - `DISABLE_PASSKEY_GATE` — Local-only: set to `"true"` to skip the server-side passkey requirement so you can sign in with email+password during development. **Never set this in production.**
 
 ## Roadmap

--- a/migrations/0026_kind_miracleman.sql
+++ b/migrations/0026_kind_miracleman.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `suppressions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`email` text NOT NULL,
+	`reason` text NOT NULL,
+	`source` text,
+	`note` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `suppressions_email_unique` ON `suppressions` (`email`);

--- a/migrations/meta/0026_snapshot.json
+++ b/migrations/meta/0026_snapshot.json
@@ -1,0 +1,2398 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "67ff9b3b-8aa6-42a4-982d-f28dee607b95",
+  "prevId": "7e3cbff4-753f-493e-9493-368b27a23c2f",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwkss": {
+      "name": "jwkss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_userId_idx": {
+          "name": "passkeys_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkeys_credentialID_idx": {
+          "name": "passkeys_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_email_at": {
+          "name": "last_email_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "people_last_email_at_idx": {
+          "name": "people_last_email_at_idx",
+          "columns": [
+            "last_email_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emails": {
+      "name": "emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spf": {
+          "name": "spf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dkim": {
+          "name": "dkim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dmarc": {
+          "name": "dmarc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "emails_message_id_unique": {
+          "name": "emails_message_id_unique",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "emails_person_received_idx": {
+          "name": "emails_person_received_idx",
+          "columns": [
+            "person_id",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_recipient_received_idx": {
+          "name": "emails_recipient_received_idx",
+          "columns": [
+            "recipient",
+            "received_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sent_emails": {
+      "name": "sent_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sent'"
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sent_emails_person_sent_idx": {
+          "name": "sent_emails_person_sent_idx",
+          "columns": [
+            "person_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inbound'"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachments_email_id_idx": {
+          "name": "attachments_email_id_idx",
+          "columns": [
+            "email_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_templates_slug_unique": {
+          "name": "email_templates_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invitations_used_by_users_id_fk": {
+          "name": "invitations_used_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_unique": {
+          "name": "api_keys_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequences": {
+      "name": "sequences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_enrollments": {
+      "name": "sequence_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrollments_person_status_idx": {
+          "name": "enrollments_person_status_idx",
+          "columns": [
+            "person_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "enrollments_sequence_status_idx": {
+          "name": "enrollments_sequence_status_idx",
+          "columns": [
+            "sequence_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_emails": {
+      "name": "sequence_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seq_emails_status_scheduled_idx": {
+          "name": "seq_emails_status_scheduled_idx",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "seq_emails_enrollment_id_idx": {
+          "name": "seq_emails_enrollment_id_idx",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sender_identities": {
+      "name": "sender_identities",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'thread'"
+        },
+        "signature_html": {
+          "name": "signature_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_permissions": {
+      "name": "inbox_permissions",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inbox_permissions_email_idx": {
+          "name": "inbox_permissions_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_permissions_user_id_users_id_fk": {
+          "name": "inbox_permissions_user_id_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_permissions_created_by_users_id_fk": {
+          "name": "inbox_permissions_created_by_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "inbox_permissions_user_id_email_pk": {
+          "columns": [
+            "user_id",
+            "email"
+          ],
+          "name": "inbox_permissions_user_id_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suppressions": {
+      "name": "suppressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "suppressions_email_unique": {
+          "name": "suppressions_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1779085083856,
       "tag": "0025_jazzy_hellcat",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1779563699138,
+      "tag": "0026_kind_miracleman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import TemplateEditorPage from "@/pages/TemplateEditorPage";
 import SetupPasskeyPage from "@/pages/SetupPasskeyPage";
 import InviteAcceptPage from "@/pages/InviteAcceptPage";
 import AdminUsersPage from "@/pages/AdminUsersPage";
+import SuppressionsPage from "@/pages/SuppressionsPage";
 import ApiKeysPage from "@/pages/ApiKeysPage";
 import DashboardLayout from "@/components/DashboardLayout";
 import PublicLayout from "@/components/PublicLayout";
@@ -138,6 +139,10 @@ function App() {
             <Route element={<AuthGuard />}>
               <Route element={<DashboardLayout />}>
                 <Route path="/admin/users" element={<AdminUsersPage />} />
+                <Route
+                  path="/admin/suppressions"
+                  element={<SuppressionsPage />}
+                />
                 <Route path="/templates" element={<TemplatesPage />} />
                 <Route path="/templates/new" element={<TemplateEditorPage />} />
                 <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import SequenceEditorPage from "@/pages/SequenceEditorPage";
 import InboxesPage from "./pages/InboxesPage";
 import SettingsPage from "@/pages/SettingsPage";
 import MessageLinkPage from "@/pages/MessageLinkPage";
+import UnsubscribePage from "@/pages/UnsubscribePage";
 
 const queryClient = new QueryClient();
 
@@ -126,6 +127,12 @@ function App() {
             {/* Public legal pages — light readable layout, no auth */}
             <Route path="/terms" element={<TermsPage />} />
             <Route path="/privacy" element={<PrivacyPage />} />
+
+            {/* Public unsubscribe landing — token-authenticated, no session.
+                Lives outside AuthGuard so recipients (who are never logged in)
+                can land here from email links. See worker/src/routers/
+                unsubscribe-router.ts for the API. */}
+            <Route path="/unsubscribe" element={<UnsubscribePage />} />
 
             {/* Authenticated routes with shared layout */}
             <Route element={<AuthGuard />}>

--- a/src/components/SequenceStatus.tsx
+++ b/src/components/SequenceStatus.tsx
@@ -26,7 +26,12 @@ export default function SequenceStatus({
 
   if (loading || !info || !info.enrollment) return null;
 
-  const sent = info.scheduledEmails.filter((e) => e.status === "sent").length;
+  // 'suppressed' is a completed-but-not-delivered terminal state — count it
+  // toward the progress display so completed-via-suppression enrollments
+  // don't look stuck.
+  const sent = info.scheduledEmails.filter(
+    (e) => e.status === "sent" || e.status === "suppressed",
+  ).length;
   const total = info.scheduledEmails.length;
   const nextPending = info.scheduledEmails.find(
     (e) => e.status === "pending" || e.status === "queued",

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -9,6 +9,7 @@ import {
   Settings as SettingsIcon,
   Shield,
   Users,
+  Ban,
   Menu,
   User,
   LogOut,
@@ -163,6 +164,13 @@ export default function TopNav() {
                       <Users className="h-4 w-4" />
                       Users
                     </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => navigate("/admin/suppressions")}
+                      className="cursor-pointer"
+                    >
+                      <Ban className="h-4 w-4" />
+                      Suppressions
+                    </DropdownMenuItem>
                   </>
                 )}
                 <DropdownMenuSeparator />
@@ -264,6 +272,13 @@ export default function TopNav() {
                   >
                     <Users className="h-4 w-4" />
                     Users
+                  </button>
+                  <button
+                    onClick={() => navigate("/admin/suppressions")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+                  >
+                    <Ban className="h-4 w-4" />
+                    Suppressions
                   </button>
                 </>
               )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -721,3 +721,40 @@ export interface AdminUser {
 export async function fetchAdminUsers(): Promise<AdminUser[]> {
   return apiFetch("/api/admin/users");
 }
+
+// --- Suppressions ---
+
+export interface Suppression {
+  id: string;
+  email: string;
+  reason: "unsubscribe" | "manual";
+  source: string | null;
+  note: string | null;
+  createdAt: number;
+}
+
+export interface SuppressionsPage {
+  items: Suppression[];
+  nextCursor: string | null;
+}
+
+export async function fetchSuppressions(
+  cursor?: string | null,
+): Promise<SuppressionsPage> {
+  const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}` : "";
+  return apiFetch(`/api/suppressions${qs}`);
+}
+
+export async function createSuppression(email: string): Promise<Suppression> {
+  return apiFetch("/api/suppressions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+}
+
+export async function deleteSuppression(
+  id: string,
+): Promise<{ deleted: true }> {
+  return apiFetch(`/api/suppressions/${id}`, { method: "DELETE" });
+}

--- a/src/pages/SuppressionsPage.tsx
+++ b/src/pages/SuppressionsPage.tsx
@@ -1,0 +1,413 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { Ban, Plus, Trash2 } from "lucide-react";
+import { useSession } from "@/lib/auth-client";
+import {
+  fetchSuppressions,
+  createSuppression,
+  deleteSuppression,
+} from "@/lib/api";
+import type { Suppression } from "@/lib/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
+import { SectionHeader } from "@/components/PageForm";
+import { cn } from "@/lib/utils";
+
+function formatDate(ts: number): string {
+  return new Date(ts * 1000).toLocaleDateString();
+}
+
+function relativeTime(ts: number): string {
+  const diff = ts - Date.now() / 1000;
+  const abs = Math.abs(diff);
+  if (abs < 3600) return diff < 0 ? "just now" : "in <1h";
+  if (abs < 86400)
+    return diff < 0
+      ? `${Math.floor(abs / 3600)}h ago`
+      : `in ${Math.floor(abs / 3600)}h`;
+  const days = Math.floor(abs / 86400);
+  return diff < 0 ? `${days}d ago` : `in ${days}d`;
+}
+
+const REASON_META: Record<
+  Suppression["reason"],
+  { label: string; chipClass: string; color: string }
+> = {
+  unsubscribe: {
+    label: "Unsubscribed",
+    chipClass: "bg-violet/10 ring-violet/20",
+    color: "#7c5cfc",
+  },
+  manual: {
+    label: "Manual",
+    chipClass: "bg-bg-muted ring-border",
+    color: "#6b7280",
+  },
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function SuppressionsPage() {
+  const { data: session } = useSession();
+  const [items, setItems] = useState<Suppression[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [addEmail, setAddEmail] = useState("");
+  const [addSubmitting, setAddSubmitting] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [confirmDelete, setConfirmDelete] = useState<Suppression | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function loadInitial() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchSuppressions();
+      setItems(res.items);
+      setNextCursor(res.nextCursor);
+    } catch {
+      setError("Failed to load suppressions.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadMore() {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const res = await fetchSuppressions(nextCursor);
+      setItems((prev) => [...prev, ...res.items]);
+      setNextCursor(res.nextCursor);
+    } catch {
+      setError("Failed to load more.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  useEffect(() => {
+    if (session?.user?.role === "admin") loadInitial();
+  }, [session]);
+
+  if (session?.user?.role !== "admin") {
+    return <Navigate to="/" replace />;
+  }
+
+  function resetAddDialog() {
+    setAddEmail("");
+    setAddError(null);
+    setAddSubmitting(false);
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    const email = addEmail.trim().toLowerCase();
+    if (!email) {
+      setAddError("Email is required.");
+      return;
+    }
+    if (!EMAIL_RE.test(email)) {
+      setAddError("Enter a valid email address.");
+      return;
+    }
+    setAddSubmitting(true);
+    setAddError(null);
+    try {
+      const created = await createSuppression(email);
+      setItems((prev) => {
+        // Idempotent on the server — if it's already in the list, refresh it
+        // in place; otherwise prepend.
+        const idx = prev.findIndex((s) => s.id === created.id);
+        if (idx >= 0) {
+          const copy = prev.slice();
+          copy[idx] = created;
+          return copy;
+        }
+        return [created, ...prev];
+      });
+      setAddOpen(false);
+      resetAddDialog();
+    } catch {
+      setAddError("Failed to add suppression. Please try again.");
+    } finally {
+      setAddSubmitting(false);
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!confirmDelete) return;
+    setDeleteSubmitting(true);
+    setDeleteError(null);
+    try {
+      await deleteSuppression(confirmDelete.id);
+      setItems((prev) => prev.filter((s) => s.id !== confirmDelete.id));
+      setConfirmDelete(null);
+    } catch {
+      setDeleteError("Failed to remove. Please try again.");
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Suppressions"
+        subtitle="Email addresses that won't receive marketing or sequence sends."
+        action={
+          <button
+            onClick={() => {
+              resetAddDialog();
+              setAddOpen(true);
+            }}
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
+          >
+            <Plus size={14} />
+            Add suppression
+          </button>
+        }
+      />
+
+      <div className="max-w-4xl space-y-6">
+        <section className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="border-b border-border px-5 py-4">
+            <SectionHeader
+              icon={Ban}
+              title={`Suppressed addresses (${items.length}${
+                nextCursor ? "+" : ""
+              })`}
+              subtitle="Outbound /api/send and sequence emails skip these recipients."
+            />
+          </div>
+
+          {error && (
+            <div className="border-b border-border bg-rose-50/60 px-5 py-2 text-xs font-medium text-rose-700">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <p className="px-5 py-6 text-xs font-light text-text-tertiary">
+              Loading…
+            </p>
+          ) : items.length === 0 ? (
+            <EmptyState
+              icon={Ban}
+              title="No suppressions yet"
+              hint="Recipients who unsubscribe land here automatically. You can also add one manually above."
+            />
+          ) : (
+            <>
+              <ul className="divide-y divide-border/60">
+                {items.map((item) => {
+                  const meta = REASON_META[item.reason];
+                  return (
+                    <li
+                      key={item.id}
+                      className="flex items-center gap-3 px-5 py-3"
+                    >
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-bg-muted">
+                        <Ban size={14} className="text-text-tertiary" />
+                      </span>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="truncate text-sm font-medium text-text-primary">
+                            {item.email}
+                          </p>
+                          <span
+                            className={cn(
+                              "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ring-1",
+                              meta.chipClass,
+                            )}
+                            style={{ color: meta.color }}
+                          >
+                            {meta.label}
+                          </span>
+                        </div>
+                        <p className="truncate text-xs font-light text-text-tertiary">
+                          {item.source ?? "—"} · added{" "}
+                          {relativeTime(item.createdAt)} (
+                          {formatDate(item.createdAt)})
+                        </p>
+                      </div>
+
+                      <button
+                        onClick={() => {
+                          setDeleteError(null);
+                          setConfirmDelete(item);
+                        }}
+                        aria-label={`Remove suppression for ${item.email}`}
+                        className="inline-flex h-8 shrink-0 items-center gap-1 rounded-[6px] px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-rose-50 hover:text-rose-600"
+                      >
+                        <Trash2 size={12} />
+                        Remove
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {nextCursor && (
+                <div className="border-t border-border px-5 py-3">
+                  <button
+                    onClick={loadMore}
+                    disabled={loadingMore}
+                    className="w-full rounded-[6px] border border-border bg-card py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {loadingMore ? "Loading…" : "Load more"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      </div>
+
+      {/* --- Add suppression dialog --- */}
+      <Dialog
+        open={addOpen}
+        onOpenChange={(open) => {
+          setAddOpen(open);
+          if (!open) resetAddDialog();
+        }}
+      >
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">
+              Add suppression
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleAdd} className="space-y-4">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="suppression-email"
+                className="block text-[11px] font-medium uppercase tracking-wider text-text-tertiary"
+              >
+                Email
+              </label>
+              <input
+                id="suppression-email"
+                type="email"
+                autoFocus
+                required
+                value={addEmail}
+                onChange={(e) => setAddEmail(e.target.value)}
+                placeholder="user@example.com"
+                className="h-10 w-full rounded-[6px] border border-border bg-bg-subtle px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/20"
+              />
+              <p className="text-[11px] font-light text-text-tertiary">
+                Future marketing and sequence sends to this address will be
+                skipped.
+              </p>
+            </div>
+
+            {addError && (
+              <p className="text-xs font-medium text-rose-600">{addError}</p>
+            )}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setAddOpen(false)}
+                className="rounded-[8px] border border-border bg-card px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={addSubmitting}
+                className="rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {addSubmitting ? "Adding…" : "Add suppression"}
+              </button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* --- Confirm remove dialog --- */}
+      <Dialog
+        open={confirmDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmDelete(null);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">
+              Remove suppression?
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-light text-text-secondary">
+            <span className="font-medium text-text-primary">
+              {confirmDelete?.email}
+            </span>{" "}
+            will receive marketing and sequence sends again. You can re-add the
+            suppression later.
+          </p>
+
+          {deleteError && (
+            <p className="text-xs font-medium text-rose-600">{deleteError}</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              className="rounded-[8px] border border-border bg-card px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              disabled={deleteSubmitting}
+              className="rounded-[8px] bg-rose-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {deleteSubmitting ? "Removing…" : "Remove"}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </PageContainer>
+  );
+}
+
+/* --------------------------------- helpers --------------------------------- */
+
+function EmptyState({
+  icon: Icon,
+  title,
+  hint,
+}: {
+  icon: React.ElementType;
+  title: string;
+  hint: string;
+}) {
+  return (
+    <div className="px-5 py-10 text-center">
+      <span className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-violet/10">
+        <Icon size={16} style={{ color: "#7c5cfc" }} />
+      </span>
+      <p className="text-sm font-medium text-text-primary">{title}</p>
+      <p className="mt-1 text-xs font-light text-text-tertiary">{hint}</p>
+    </div>
+  );
+}

--- a/src/pages/UnsubscribePage.tsx
+++ b/src/pages/UnsubscribePage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { Mail } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Footer from "@/components/Footer";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "suppressed"; email: string }
+  | { kind: "subscribed"; email: string }
+  | { kind: "error" };
+
+/**
+ * Public, unauthenticated unsubscribe landing page.
+ *
+ * Mounted at `/unsubscribe?token=…`. On mount, POSTs to the public
+ * `/api/unsubscribe` endpoint (see worker/src/routers/unsubscribe-router.ts).
+ *
+ * Bot-preview-defense pattern: the initial GET serves inert HTML — the
+ * actual suppression write only happens once JS mounts and fires the POST.
+ * Slack/iMessage/AV link scanners don't execute JS, so they hit the inert
+ * landing without recording a suppression.
+ */
+export default function UnsubscribePage() {
+  const [params] = useSearchParams();
+  const token = params.get("token") ?? "";
+  const [state, setState] = useState<State>({ kind: "loading" });
+  const [undoLoading, setUndoLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setState({ kind: "error" });
+      return;
+    }
+    let cancelled = false;
+    const url = `/api/unsubscribe?token=${encodeURIComponent(token)}&source=user-link`;
+    fetch(url, { method: "POST" })
+      .then(async (r) => {
+        if (!r.ok) throw new Error("invalid");
+        const body = (await r.json()) as { email: string; status: string };
+        if (cancelled) return;
+        setState({ kind: "suppressed", email: body.email });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ kind: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  async function handleResubscribe() {
+    if (!token) return;
+    setUndoLoading(true);
+    try {
+      const url = `/api/unsubscribe/undo?token=${encodeURIComponent(token)}`;
+      const r = await fetch(url, { method: "POST" });
+      if (!r.ok) return;
+      const body = (await r.json()) as { email: string; status: string };
+      setState({ kind: "subscribed", email: body.email });
+    } catch {
+      // v1: leave the page in `suppressed` so the user can retry.
+    } finally {
+      setUndoLoading(false);
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-screen flex-col bg-background">
+      <div className="dashboard-backdrop" aria-hidden />
+      <div className="dashboard-backdrop-mask" aria-hidden />
+
+      {/* Brand strip — mirrors LegalLayout so the page sits next to /terms
+          and /privacy stylistically. */}
+      <header className="relative z-10">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-6 md:px-6">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-text-primary transition-opacity hover:opacity-80"
+          >
+            <Mail
+              className="h-5 w-5"
+              strokeWidth={2.5}
+              style={{ color: "#7c5cfc" }}
+              aria-hidden
+            />
+            <span className="text-lg font-extrabold uppercase tracking-tight">
+              saasmail
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="relative z-10 flex flex-1 items-center justify-center px-4 pb-16">
+        <div className="w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center shadow-sm">
+          {state.kind === "loading" && (
+            <>
+              <h1 className="text-xl font-semibold tracking-tight text-text-primary">
+                Processing your request…
+              </h1>
+              <p className="mt-2 text-sm text-text-secondary">
+                One moment while we update your preferences.
+              </p>
+            </>
+          )}
+
+          {state.kind === "suppressed" && (
+            <>
+              <h1 className="text-2xl font-extrabold tracking-tight text-text-primary">
+                You've been unsubscribed
+              </h1>
+              <p className="mt-3 break-all text-sm text-text-secondary">
+                <span className="font-medium text-text-primary">
+                  {state.email}
+                </span>{" "}
+                won't receive any more emails from us.
+              </p>
+              <div className="mt-6">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleResubscribe}
+                  disabled={undoLoading}
+                >
+                  {undoLoading ? "Updating…" : "Re-subscribe"}
+                </Button>
+              </div>
+              <p className="mt-4 text-xs text-text-tertiary">
+                Changed your mind? Re-subscribing only restores delivery — it
+                doesn't sign you up for anything new.
+              </p>
+            </>
+          )}
+
+          {state.kind === "subscribed" && (
+            <>
+              <h1 className="text-2xl font-extrabold tracking-tight text-text-primary">
+                You're subscribed again
+              </h1>
+              <p className="mt-3 break-all text-sm text-text-secondary">
+                <span className="font-medium text-text-primary">
+                  {state.email}
+                </span>{" "}
+                will continue to receive emails.
+              </p>
+            </>
+          )}
+
+          {state.kind === "error" && (
+            <>
+              <h1 className="text-xl font-semibold tracking-tight text-text-primary">
+                This unsubscribe link is invalid or expired
+              </h1>
+              <p className="mt-3 text-sm text-text-secondary">
+                If you keep receiving unwanted emails, reply to one of them and
+                let the sender know directly.
+              </p>
+            </>
+          )}
+        </div>
+      </main>
+
+      <div className="relative z-10">
+        <Footer variant="light" />
+      </div>
+    </div>
+  );
+}

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -29,6 +29,7 @@ export default defineConfig({
           VAPID_PRIVATE_KEY: "test-vapid-private",
           VAPID_PUBLIC_KEY: "test-vapid-public",
           VAPID_SUBJECT: "mailto:test@example.com",
+          UNSUBSCRIBE_SECRET: "test-secret-do-not-use-in-prod",
         },
       },
     }),

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -18,6 +18,8 @@ declare namespace Cloudflare {
 		VAPID_SUBJECT: "mailto:admin@<your-domain>";
 		/** Secret: set via `wrangler secret put VAPID_PRIVATE_KEY`. Not emitted by `wrangler types`; added manually. */
 		VAPID_PRIVATE_KEY?: string;
+		/** Secret: set via `wrangler secret put UNSUBSCRIBE_SECRET`. Used to sign one-click unsubscribe tokens. Not emitted by `wrangler types`; added manually. */
+		UNSUBSCRIBE_SECRET: string;
 		NOTIFICATIONS_HUB: DurableObjectNamespace<import("./worker/src/index").NotificationsHub>;
 	}
 }

--- a/worker/src/__tests__/email-templates-router.test.ts
+++ b/worker/src/__tests__/email-templates-router.test.ts
@@ -5,7 +5,10 @@ import {
   createTestUser,
   createTestTemplate,
   authFetch,
+  getDb,
 } from "./helpers";
+import { suppressions } from "../db/suppressions.schema";
+import { sentEmails } from "../db/sent-emails.schema";
 
 describe("email templates router", () => {
   let apiKey: string;
@@ -136,6 +139,49 @@ describe("email templates router", () => {
         method: "DELETE",
       });
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/email-templates/:slug/send", () => {
+    it("returns status=suppressed and does not write sent_emails when recipient is suppressed", async () => {
+      const db = getDb();
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hi",
+        bodyHtml: "<p>Hi {{name}}</p>",
+      });
+
+      const now = Math.floor(Date.now() / 1000);
+      await db.insert(suppressions).values({
+        id: "sup-1",
+        email: "blocked@test.com",
+        reason: "unsubscribe",
+        source: "test",
+        note: null,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/email-templates/welcome/send", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          to: "blocked@test.com",
+          fromAddress: "support@example.com",
+          variables: { name: "Blocked" },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.status).toBe("suppressed");
+      expect(data.id).toBeNull();
+      expect(data.resendId).toBeNull();
+      expect(data.delivered).toEqual([]);
+      expect(data.suppressed).toEqual(["blocked@test.com"]);
+
+      // No sent_emails row should have been written for the suppressed send
+      const sentRows = await db.select().from(sentEmails);
+      expect(sentRows).toHaveLength(0);
     });
   });
 });

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -72,6 +72,8 @@ export async function applyMigrations() {
     `CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_endpoint_idx ON push_subscriptions(endpoint)`,
     `CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT, updated_at INTEGER NOT NULL, updated_by TEXT)`,
     `CREATE INDEX IF NOT EXISTS push_subscriptions_user_idx ON push_subscriptions(user_id)`,
+    `CREATE TABLE IF NOT EXISTS suppressions (id TEXT PRIMARY KEY, email TEXT NOT NULL, reason TEXT NOT NULL, source TEXT, note TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS suppressions_email_unique ON suppressions(email)`,
   ];
 
   for (const sql of statements) {
@@ -259,6 +261,7 @@ export function buildSendForm(
 export async function cleanDb() {
   const db = env.DB;
   await db.exec(`
+    DELETE FROM suppressions;
     DELETE FROM push_subscriptions;
     DELETE FROM inbox_permissions;
     DELETE FROM sender_identities;

--- a/worker/src/__tests__/send-helper.test.ts
+++ b/worker/src/__tests__/send-helper.test.ts
@@ -89,7 +89,7 @@ describe("sendWithSuppressionCheck", () => {
     expect(sent[1].cc).toBeUndefined();
   });
 
-  it("promotes first surviving cc when primary `to` is suppressed", async () => {
+  it("cancels the entire send when primary `to` is suppressed, even with unsuppressed cc", async () => {
     await suppress("alice@example.com");
     const result = await sendWithSuppressionCheck({
       db: getDb(),
@@ -101,48 +101,9 @@ describe("sendWithSuppressionCheck", () => {
       subject: "Hi",
       html: "<p>hi {{unsubscribe_url}}</p>",
     });
-    expect(result.delivered).toEqual(["bob@example.com", "carol@example.com"]);
-    expect(result.suppressed).toEqual(["alice@example.com"]);
-    expect(fakeSender.send).toHaveBeenCalledTimes(2);
-    expect(sent[0].to).toBe("bob@example.com");
-    expect(sent[1].to).toBe("carol@example.com");
-    expect(sent[0].cc).toBeUndefined();
-    expect(sent[1].cc).toBeUndefined();
-  });
-
-  it("unsubscribe token in headers and body matches the transport's `to`", async () => {
-    // Regression: when the primary `to` is suppressed and a cc gets promoted,
-    // the token must encode the promoted recipient, NOT the original `to`.
-    await suppress("alice@example.com");
-    await sendWithSuppressionCheck({
-      db: getDb(),
-      env: fakeEnv,
-      sender: fakeSender,
-      from: "test@host",
-      to: "alice@example.com",
-      cc: [{ email: "bob@example.com" }, { email: "carol@example.com" }],
-      subject: "Hi",
-      html: "<p>Click {{unsubscribe_url}}</p>",
-    });
-    const call = sent[0];
-    expect(call.to).toBe("bob@example.com");
-
-    const headerToken = extractUnsubToken(call.headers?.["List-Unsubscribe"]);
-    const decodedHeader = await verifyToken(
-      headerToken,
-      fakeEnv.UNSUBSCRIBE_SECRET,
-    );
-    expect(decodedHeader?.email).toBe("bob@example.com");
-
-    // And the body URL token should match too.
-    const bodyMatch = call.html.match(/token=([^"&<>\s]+)/);
-    expect(bodyMatch).not.toBeNull();
-    const bodyToken = decodeURIComponent(bodyMatch![1]);
-    const decodedBody = await verifyToken(
-      bodyToken,
-      fakeEnv.UNSUBSCRIBE_SECRET,
-    );
-    expect(decodedBody?.email).toBe("bob@example.com");
+    expect(result.delivered).toEqual([]);
+    expect(result.suppressed).toContain("alice@example.com");
+    expect(fakeSender.send).not.toHaveBeenCalled();
   });
 
   it("CC with display name still triggers suppression check", async () => {

--- a/worker/src/__tests__/send-helper.test.ts
+++ b/worker/src/__tests__/send-helper.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { suppressions } from "../db/suppressions.schema";
+import { applyMigrations, cleanDb, getDb } from "./helpers";
+import { sendWithSuppressionCheck } from "../lib/send";
+import type { SendEmailParams } from "../lib/email-sender";
+
+const sent: SendEmailParams[] = [];
+const fakeSender = {
+  provider: "none" as const,
+  maxAttachmentBytes: () => 25_000_000,
+  send: vi.fn(async (params: SendEmailParams) => {
+    sent.push(params);
+    return { id: "fake-msg-id", error: null };
+  }),
+};
+
+const fakeEnv = {
+  UNSUBSCRIBE_SECRET: "test-secret-do-not-use-in-prod",
+  BASE_URL: "https://mail.example.com",
+};
+
+beforeAll(applyMigrations);
+beforeEach(async () => {
+  await cleanDb();
+  sent.length = 0;
+  fakeSender.send.mockClear();
+});
+
+async function suppress(email: string) {
+  const db = getDb();
+  await db.insert(suppressions).values({
+    id: "test-" + email,
+    email: email.toLowerCase(),
+    reason: "unsubscribe",
+    source: "test",
+    note: null,
+    createdAt: Math.floor(Date.now() / 1000),
+  });
+}
+
+describe("sendWithSuppressionCheck", () => {
+  it("blocks send when sole recipient is suppressed", async () => {
+    await suppress("alice@example.com");
+    const result = await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Hi",
+      html: "<p>hi {{unsubscribe_url}}</p>",
+    });
+    expect(result.delivered).toEqual([]);
+    expect(result.suppressed).toEqual(["alice@example.com"]);
+    expect(fakeSender.send).not.toHaveBeenCalled();
+  });
+
+  it("partitions a mixed recipient list across to and cc", async () => {
+    await suppress("bob@example.com");
+    const result = await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com", "bob@example.com"],
+      cc: ["carol@example.com", "bob@example.com"],
+      subject: "Hi",
+      html: "<p>hi {{unsubscribe_url}}</p>",
+    });
+    // Only one delivered `to` (alice) — transport called once.
+    expect(result.delivered.sort()).toEqual([
+      "alice@example.com",
+      "carol@example.com",
+    ]);
+    // bob appears in both `to` and `cc` → reported twice in `suppressed`.
+    expect(result.suppressed.sort()).toEqual([
+      "bob@example.com",
+      "bob@example.com",
+    ]);
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    expect(sent[0].to).toBe("alice@example.com");
+    expect(sent[0].cc).toEqual(["carol@example.com"]);
+  });
+
+  it("with transactional=true, bypasses suppression entirely", async () => {
+    await suppress("alice@example.com");
+    const result = await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Reset",
+      html: "<p>token</p>",
+      transactional: true,
+    });
+    expect(result.delivered).toEqual(["alice@example.com"]);
+    expect(result.suppressed).toEqual([]);
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("marketing send: adds List-Unsubscribe headers and interpolates {{unsubscribe_url}}", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Hi",
+      html: "<p>Click {{unsubscribe_url}}</p>",
+    });
+    const call = sent[0];
+    expect(call.headers?.["List-Unsubscribe"]).toMatch(
+      /^<https:\/\/mail\.example\.com\/unsubscribe\?token=[^>]+>$/,
+    );
+    expect(call.headers?.["List-Unsubscribe-Post"]).toBe(
+      "List-Unsubscribe=One-Click",
+    );
+    expect(call.html).toMatch(
+      /Click https:\/\/mail\.example\.com\/unsubscribe\?token=/,
+    );
+    expect(call.html).not.toContain("{{unsubscribe_url}}");
+    expect(call.headers?.["List-Unsubscribe"]).not.toContain("mailto:");
+  });
+
+  it("transactional send: no unsubscribe headers, no footer, no variable", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Reset",
+      html: "<p>Click here</p>",
+      text: "Click here",
+      transactional: true,
+    });
+    const call = sent[0];
+    expect(call.headers?.["List-Unsubscribe"]).toBeUndefined();
+    expect(call.headers?.["List-Unsubscribe-Post"]).toBeUndefined();
+    expect(call.html).toBe("<p>Click here</p>");
+    expect(call.text).toBe("Click here");
+  });
+
+  it("auto-appends HTML footer when body lacks the URL", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Hi",
+      html: "<p>No link here</p>",
+    });
+    const call = sent[0];
+    expect(call.html).toContain("No link here");
+    expect(call.html).toMatch(
+      /<a href="https:\/\/mail\.example\.com\/unsubscribe\?token=[^"]+">Unsubscribe<\/a>/,
+    );
+  });
+
+  it("does NOT auto-append HTML footer when body already includes the URL", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Hi",
+      html: "<p>Link: {{unsubscribe_url}}</p>",
+    });
+    const call = sent[0];
+    expect(call.html.match(/\/unsubscribe\?token=/g)?.length).toBe(1);
+  });
+
+  it("auto-appends plaintext footer when text body lacks URL", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: ["alice@example.com"],
+      subject: "Hi",
+      html: "<p>hi</p>",
+      text: "Hello no link",
+    });
+    const call = sent[0];
+    expect(call.text).toContain("Hello no link");
+    expect(call.text).toMatch(
+      /Unsubscribe: https:\/\/mail\.example\.com\/unsubscribe\?token=/,
+    );
+  });
+});

--- a/worker/src/__tests__/send-helper.test.ts
+++ b/worker/src/__tests__/send-helper.test.ts
@@ -165,7 +165,9 @@ describe("sendWithSuppressionCheck", () => {
     expect(fakeSender.send).toHaveBeenCalledTimes(1);
     expect(sent[0].to).toBe("alice@example.com");
     const allRecipients = sent.flatMap((s) => [s.to, ...(s.cc ?? [])]);
-    expect(allRecipients.some((r) => r.includes("bob@example.com"))).toBe(false);
+    expect(allRecipients.some((r) => r.includes("bob@example.com"))).toBe(
+      false,
+    );
   });
 
   it("multi-recipient marketing send: each recipient gets a per-recipient token", async () => {
@@ -195,9 +197,7 @@ describe("sendWithSuppressionCheck", () => {
 
     // Each call's List-Unsubscribe header token decodes back to that call's `to`.
     for (const call of sent) {
-      const headerToken = extractUnsubToken(
-        call.headers?.["List-Unsubscribe"],
-      );
+      const headerToken = extractUnsubToken(call.headers?.["List-Unsubscribe"]);
       const decoded = await verifyToken(
         headerToken,
         fakeEnv.UNSUBSCRIBE_SECRET,
@@ -213,7 +213,10 @@ describe("sendWithSuppressionCheck", () => {
       sender: fakeSender,
       from: "test@host",
       to: "alice@example.com",
-      cc: [{ email: "bob@example.com" }, { email: "carol@example.com", name: "Carol" }],
+      cc: [
+        { email: "bob@example.com" },
+        { email: "carol@example.com", name: "Carol" },
+      ],
       subject: "Reset",
       html: "<p>token</p>",
       transactional: true,
@@ -221,7 +224,10 @@ describe("sendWithSuppressionCheck", () => {
     expect(fakeSender.send).toHaveBeenCalledTimes(1);
     expect(sent[0].to).toBe("alice@example.com");
     // cc preserved as formatted strings; display name on carol becomes "Carol <…>".
-    expect(sent[0].cc).toEqual(["bob@example.com", "Carol <carol@example.com>"]);
+    expect(sent[0].cc).toEqual([
+      "bob@example.com",
+      "Carol <carol@example.com>",
+    ]);
     expect(sent[0].headers?.["List-Unsubscribe"]).toBeUndefined();
   });
 

--- a/worker/src/__tests__/send-helper.test.ts
+++ b/worker/src/__tests__/send-helper.test.ts
@@ -71,15 +71,22 @@ describe("sendWithSuppressionCheck", () => {
       sender: fakeSender,
       from: "test@host",
       to: "alice@example.com",
-      cc: ["bob@example.com", "carol@example.com"],
+      cc: [{ email: "bob@example.com" }, { email: "carol@example.com" }],
       subject: "Hi",
       html: "<p>hi {{unsubscribe_url}}</p>",
     });
-    expect(result.delivered).toEqual(["alice@example.com", "carol@example.com"]);
+    expect(result.delivered).toEqual([
+      "alice@example.com",
+      "carol@example.com",
+    ]);
     expect(result.suppressed).toEqual(["bob@example.com"]);
-    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    // Marketing path now does one call per delivered recipient.
+    expect(fakeSender.send).toHaveBeenCalledTimes(2);
     expect(sent[0].to).toBe("alice@example.com");
-    expect(sent[0].cc).toEqual(["carol@example.com"]);
+    expect(sent[1].to).toBe("carol@example.com");
+    // No cc on per-recipient marketing calls.
+    expect(sent[0].cc).toBeUndefined();
+    expect(sent[1].cc).toBeUndefined();
   });
 
   it("promotes first surviving cc when primary `to` is suppressed", async () => {
@@ -90,15 +97,17 @@ describe("sendWithSuppressionCheck", () => {
       sender: fakeSender,
       from: "test@host",
       to: "alice@example.com",
-      cc: ["bob@example.com", "carol@example.com"],
+      cc: [{ email: "bob@example.com" }, { email: "carol@example.com" }],
       subject: "Hi",
       html: "<p>hi {{unsubscribe_url}}</p>",
     });
     expect(result.delivered).toEqual(["bob@example.com", "carol@example.com"]);
     expect(result.suppressed).toEqual(["alice@example.com"]);
-    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    expect(fakeSender.send).toHaveBeenCalledTimes(2);
     expect(sent[0].to).toBe("bob@example.com");
-    expect(sent[0].cc).toEqual(["carol@example.com"]);
+    expect(sent[1].to).toBe("carol@example.com");
+    expect(sent[0].cc).toBeUndefined();
+    expect(sent[1].cc).toBeUndefined();
   });
 
   it("unsubscribe token in headers and body matches the transport's `to`", async () => {
@@ -111,7 +120,7 @@ describe("sendWithSuppressionCheck", () => {
       sender: fakeSender,
       from: "test@host",
       to: "alice@example.com",
-      cc: ["bob@example.com", "carol@example.com"],
+      cc: [{ email: "bob@example.com" }, { email: "carol@example.com" }],
       subject: "Hi",
       html: "<p>Click {{unsubscribe_url}}</p>",
     });
@@ -134,6 +143,86 @@ describe("sendWithSuppressionCheck", () => {
       fakeEnv.UNSUBSCRIBE_SECRET,
     );
     expect(decodedBody?.email).toBe("bob@example.com");
+  });
+
+  it("CC with display name still triggers suppression check", async () => {
+    // Regression: pre-formatting CC as "Name <addr>" before the suppression
+    // check meant isSuppressed never matched the bare-email column.
+    await suppress("bob@example.com");
+    const result = await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: "alice@example.com",
+      cc: [{ email: "bob@example.com", name: "Bob" }],
+      subject: "Hi",
+      html: "<p>hi</p>",
+    });
+    expect(result.suppressed).toContain("bob@example.com");
+    expect(result.delivered).toEqual(["alice@example.com"]);
+    // Only one transport call, to alice — bob must NOT have been sent.
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    expect(sent[0].to).toBe("alice@example.com");
+    const allRecipients = sent.flatMap((s) => [s.to, ...(s.cc ?? [])]);
+    expect(allRecipients.some((r) => r.includes("bob@example.com"))).toBe(false);
+  });
+
+  it("multi-recipient marketing send: each recipient gets a per-recipient token", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: "alice@example.com",
+      cc: [{ email: "bob@example.com" }, { email: "carol@example.com" }],
+      subject: "Hi",
+      html: "<p>Click {{unsubscribe_url}}</p>",
+    });
+
+    expect(fakeSender.send).toHaveBeenCalledTimes(3);
+    const recipients = sent.map((s) => s.to);
+    expect(recipients).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com",
+    ]);
+
+    // Each call has no cc — every recipient sees themselves as the sole to.
+    for (const call of sent) {
+      expect(call.cc).toBeUndefined();
+    }
+
+    // Each call's List-Unsubscribe header token decodes back to that call's `to`.
+    for (const call of sent) {
+      const headerToken = extractUnsubToken(
+        call.headers?.["List-Unsubscribe"],
+      );
+      const decoded = await verifyToken(
+        headerToken,
+        fakeEnv.UNSUBSCRIBE_SECRET,
+      );
+      expect(decoded?.email).toBe(call.to);
+    }
+  });
+
+  it("multi-recipient transactional send: single call with cc preserved", async () => {
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: "alice@example.com",
+      cc: [{ email: "bob@example.com" }, { email: "carol@example.com", name: "Carol" }],
+      subject: "Reset",
+      html: "<p>token</p>",
+      transactional: true,
+    });
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    expect(sent[0].to).toBe("alice@example.com");
+    // cc preserved as formatted strings; display name on carol becomes "Carol <…>".
+    expect(sent[0].cc).toEqual(["bob@example.com", "Carol <carol@example.com>"]);
+    expect(sent[0].headers?.["List-Unsubscribe"]).toBeUndefined();
   });
 
   it("with transactional=true, bypasses suppression entirely", async () => {

--- a/worker/src/__tests__/send-helper.test.ts
+++ b/worker/src/__tests__/send-helper.test.ts
@@ -3,6 +3,7 @@ import { suppressions } from "../db/suppressions.schema";
 import { applyMigrations, cleanDb, getDb } from "./helpers";
 import { sendWithSuppressionCheck } from "../lib/send";
 import type { SendEmailParams } from "../lib/email-sender";
+import { verifyToken } from "../lib/unsubscribe-token";
 
 const sent: SendEmailParams[] = [];
 const fakeSender = {
@@ -38,6 +39,13 @@ async function suppress(email: string) {
   });
 }
 
+function extractUnsubToken(headerValue: string | undefined): string {
+  expect(headerValue).toBeDefined();
+  const match = headerValue!.match(/token=([^>&]+)/);
+  expect(match).not.toBeNull();
+  return decodeURIComponent(match![1]);
+}
+
 describe("sendWithSuppressionCheck", () => {
   it("blocks send when sole recipient is suppressed", async () => {
     await suppress("alice@example.com");
@@ -46,7 +54,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Hi",
       html: "<p>hi {{unsubscribe_url}}</p>",
     });
@@ -55,31 +63,77 @@ describe("sendWithSuppressionCheck", () => {
     expect(fakeSender.send).not.toHaveBeenCalled();
   });
 
-  it("partitions a mixed recipient list across to and cc", async () => {
+  it("drops suppressed cc but keeps unsuppressed primary `to`", async () => {
     await suppress("bob@example.com");
     const result = await sendWithSuppressionCheck({
       db: getDb(),
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com", "bob@example.com"],
-      cc: ["carol@example.com", "bob@example.com"],
+      to: "alice@example.com",
+      cc: ["bob@example.com", "carol@example.com"],
       subject: "Hi",
       html: "<p>hi {{unsubscribe_url}}</p>",
     });
-    // Only one delivered `to` (alice) — transport called once.
-    expect(result.delivered.sort()).toEqual([
-      "alice@example.com",
-      "carol@example.com",
-    ]);
-    // bob appears in both `to` and `cc` → reported twice in `suppressed`.
-    expect(result.suppressed.sort()).toEqual([
-      "bob@example.com",
-      "bob@example.com",
-    ]);
+    expect(result.delivered).toEqual(["alice@example.com", "carol@example.com"]);
+    expect(result.suppressed).toEqual(["bob@example.com"]);
     expect(fakeSender.send).toHaveBeenCalledTimes(1);
     expect(sent[0].to).toBe("alice@example.com");
     expect(sent[0].cc).toEqual(["carol@example.com"]);
+  });
+
+  it("promotes first surviving cc when primary `to` is suppressed", async () => {
+    await suppress("alice@example.com");
+    const result = await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: "alice@example.com",
+      cc: ["bob@example.com", "carol@example.com"],
+      subject: "Hi",
+      html: "<p>hi {{unsubscribe_url}}</p>",
+    });
+    expect(result.delivered).toEqual(["bob@example.com", "carol@example.com"]);
+    expect(result.suppressed).toEqual(["alice@example.com"]);
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+    expect(sent[0].to).toBe("bob@example.com");
+    expect(sent[0].cc).toEqual(["carol@example.com"]);
+  });
+
+  it("unsubscribe token in headers and body matches the transport's `to`", async () => {
+    // Regression: when the primary `to` is suppressed and a cc gets promoted,
+    // the token must encode the promoted recipient, NOT the original `to`.
+    await suppress("alice@example.com");
+    await sendWithSuppressionCheck({
+      db: getDb(),
+      env: fakeEnv,
+      sender: fakeSender,
+      from: "test@host",
+      to: "alice@example.com",
+      cc: ["bob@example.com", "carol@example.com"],
+      subject: "Hi",
+      html: "<p>Click {{unsubscribe_url}}</p>",
+    });
+    const call = sent[0];
+    expect(call.to).toBe("bob@example.com");
+
+    const headerToken = extractUnsubToken(call.headers?.["List-Unsubscribe"]);
+    const decodedHeader = await verifyToken(
+      headerToken,
+      fakeEnv.UNSUBSCRIBE_SECRET,
+    );
+    expect(decodedHeader?.email).toBe("bob@example.com");
+
+    // And the body URL token should match too.
+    const bodyMatch = call.html.match(/token=([^"&<>\s]+)/);
+    expect(bodyMatch).not.toBeNull();
+    const bodyToken = decodeURIComponent(bodyMatch![1]);
+    const decodedBody = await verifyToken(
+      bodyToken,
+      fakeEnv.UNSUBSCRIBE_SECRET,
+    );
+    expect(decodedBody?.email).toBe("bob@example.com");
   });
 
   it("with transactional=true, bypasses suppression entirely", async () => {
@@ -89,7 +143,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Reset",
       html: "<p>token</p>",
       transactional: true,
@@ -105,7 +159,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Hi",
       html: "<p>Click {{unsubscribe_url}}</p>",
     });
@@ -129,7 +183,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Reset",
       html: "<p>Click here</p>",
       text: "Click here",
@@ -148,7 +202,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Hi",
       html: "<p>No link here</p>",
     });
@@ -165,7 +219,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Hi",
       html: "<p>Link: {{unsubscribe_url}}</p>",
     });
@@ -179,7 +233,7 @@ describe("sendWithSuppressionCheck", () => {
       env: fakeEnv,
       sender: fakeSender,
       from: "test@host",
-      to: ["alice@example.com"],
+      to: "alice@example.com",
       subject: "Hi",
       html: "<p>hi</p>",
       text: "Hello no link",

--- a/worker/src/__tests__/send-router.test.ts
+++ b/worker/src/__tests__/send-router.test.ts
@@ -14,6 +14,7 @@ import {
 import { people } from "../db/people.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { attachments } from "../db/attachments.schema";
+import { suppressions } from "../db/suppressions.schema";
 
 describe("send router", () => {
   let apiKey: string;
@@ -314,6 +315,101 @@ describe("send router", () => {
       expect(body.data).toHaveLength(1);
       expect(body.data[0].email).toBe("newperson@example.com");
       expect(body.data[0].totalCount).toBe(1);
+    });
+  });
+
+  describe("POST /api/send with suppressions", () => {
+    async function insertSuppression(email: string) {
+      await getDb()
+        .insert(suppressions)
+        .values({
+          id: `sup-${email}`,
+          email,
+          reason: "unsubscribe",
+          source: "test",
+          note: null,
+          createdAt: Math.floor(Date.now() / 1000),
+        });
+    }
+
+    it("returns suppressed list and skips delivery when the only recipient is on the suppression list", async () => {
+      await insertSuppression("alice@example.com");
+
+      const res = await authFetch("/api/send", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          to: "alice@example.com",
+          fromAddress: "me@saasmail.test",
+          subject: "Hi",
+          bodyHtml: "<p>hi</p>",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        id: string | null;
+        delivered: string[];
+        suppressed: string[];
+        status: string;
+      };
+      expect(body.suppressed).toContain("alice@example.com");
+      expect(body.delivered).toEqual([]);
+      expect(body.status).toBe("suppressed");
+      expect(body.id).toBeNull();
+
+      // No sent_emails row was written.
+      const sent = await getDb()
+        .select()
+        .from(sentEmails)
+        .where(eq(sentEmails.toAddress, "alice@example.com"));
+      expect(sent).toHaveLength(0);
+    });
+
+    it("transactional=true bypasses suppression", async () => {
+      await insertSuppression("alice@example.com");
+
+      const res = await authFetch("/api/send", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          to: "alice@example.com",
+          fromAddress: "me@saasmail.test",
+          subject: "Reset",
+          bodyHtml: "<p>token</p>",
+          transactional: true,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        delivered: string[];
+        suppressed: string[];
+        status: string;
+      };
+      expect(body.suppressed).toEqual([]);
+      expect(body.delivered).toContain("alice@example.com");
+      expect(body.status).toBe("sent");
+    });
+
+    it("marketing send to a non-suppressed recipient still delivers", async () => {
+      const res = await authFetch("/api/send", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          to: "fresh@example.com",
+          fromAddress: "me@saasmail.test",
+          subject: "Hi",
+          bodyHtml: "<p>hi</p>",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        delivered: string[];
+        suppressed: string[];
+        status: string;
+      };
+      expect(body.delivered).toContain("fresh@example.com");
+      expect(body.suppressed).toEqual([]);
+      expect(body.status).toBe("sent");
     });
   });
 });

--- a/worker/src/__tests__/sequence-processor.test.ts
+++ b/worker/src/__tests__/sequence-processor.test.ts
@@ -209,14 +209,15 @@ describe("sequence processor - processSequenceEmail suppression", () => {
       // Transport must NOT have been called
       expect(fakeSender.send).not.toHaveBeenCalled();
 
-      // sequence_emails row should be in `suppressed` state with sentAt set
+      // sequence_emails row should be in `suppressed` state. sentAt is
+      // intentionally NOT written — the transport was never called.
       const row = await db
         .select()
         .from(sequenceEmails)
         .where(eq(sequenceEmails.id, "se-1"))
         .limit(1);
       expect(row[0].status).toBe("suppressed");
-      expect(row[0].sentAt).not.toBeNull();
+      expect(row[0].sentAt).toBeNull();
 
       // No sent_emails row should have been written
       const sentRows = await db.select().from(sentEmails);

--- a/worker/src/__tests__/sequence-processor.test.ts
+++ b/worker/src/__tests__/sequence-processor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { env } from "cloudflare:workers";
 import {
   applyMigrations,
@@ -12,8 +12,13 @@ import { sequences } from "../db/sequences.schema";
 import { sequenceEnrollments } from "../db/sequence-enrollments.schema";
 import { sequenceEmails } from "../db/sequence-emails.schema";
 import { sentEmails } from "../db/sent-emails.schema";
+import { suppressions } from "../db/suppressions.schema";
 import { eq } from "drizzle-orm";
-import { handleScheduled } from "../lib/sequence-processor";
+import {
+  handleScheduled,
+  processSequenceEmail,
+} from "../lib/sequence-processor";
+import type { EmailSender, SendEmailParams } from "../lib/email-sender";
 
 describe("sequence processor - handleScheduled", () => {
   beforeAll(async () => {
@@ -123,5 +128,174 @@ describe("sequence processor - handleScheduled", () => {
   it("does nothing when no pending emails", async () => {
     // Should not throw
     await handleScheduled(env as unknown as CloudflareBindings);
+  });
+});
+
+describe("sequence processor - processSequenceEmail suppression", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    await createTestUser();
+  });
+
+  it(
+    "marks the row as suppressed without calling the transport when " +
+      "the recipient is on the suppression list",
+    async () => {
+      const db = getDb();
+      const now = Math.floor(Date.now() / 1000);
+
+      await createTestPerson({ id: "p1", email: "suppressed@test.com" });
+      await createTestTemplate({ slug: "welcome" });
+
+      // Suppress the recipient
+      await db.insert(suppressions).values({
+        id: "sup-1",
+        email: "suppressed@test.com",
+        reason: "unsubscribe",
+        source: "test",
+        note: null,
+        createdAt: now,
+      });
+
+      await db.insert(sequences).values({
+        id: "seq-1",
+        name: "Test",
+        steps: JSON.stringify([
+          { order: 1, templateSlug: "welcome", delayHours: 0 },
+        ]),
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await db.insert(sequenceEnrollments).values({
+        id: "enr-1",
+        sequenceId: "seq-1",
+        personId: "p1",
+        status: "active",
+        variables: "{}",
+        fromAddress: "test@test.com",
+        enrolledAt: now,
+      });
+
+      await db.insert(sequenceEmails).values({
+        id: "se-1",
+        enrollmentId: "enr-1",
+        stepOrder: 1,
+        templateSlug: "welcome",
+        scheduledAt: now - 100,
+        status: "queued",
+      });
+
+      const fakeSender: EmailSender = {
+        provider: "none",
+        maxAttachmentBytes: () => 25_000_000,
+        send: vi.fn(async (_params: SendEmailParams) => ({
+          id: "should-not-be-called",
+          error: null,
+        })),
+      };
+
+      await processSequenceEmail(
+        db,
+        fakeSender,
+        env as unknown as CloudflareBindings,
+        "se-1",
+      );
+
+      // Transport must NOT have been called
+      expect(fakeSender.send).not.toHaveBeenCalled();
+
+      // sequence_emails row should be in `suppressed` state with sentAt set
+      const row = await db
+        .select()
+        .from(sequenceEmails)
+        .where(eq(sequenceEmails.id, "se-1"))
+        .limit(1);
+      expect(row[0].status).toBe("suppressed");
+      expect(row[0].sentAt).not.toBeNull();
+
+      // No sent_emails row should have been written
+      const sentRows = await db.select().from(sentEmails);
+      expect(sentRows).toHaveLength(0);
+
+      // Enrollment should be completed (no remaining steps)
+      const enrollmentRow = await db
+        .select()
+        .from(sequenceEnrollments)
+        .where(eq(sequenceEnrollments.id, "enr-1"))
+        .limit(1);
+      expect(enrollmentRow[0].status).toBe("completed");
+    },
+  );
+
+  it("still sends to non-suppressed recipients via the helper", async () => {
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+
+    await createTestPerson({ id: "p1", email: "ok@test.com" });
+    await createTestTemplate({ slug: "welcome" });
+
+    await db.insert(sequences).values({
+      id: "seq-1",
+      name: "Test",
+      steps: JSON.stringify([
+        { order: 1, templateSlug: "welcome", delayHours: 0 },
+      ]),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(sequenceEnrollments).values({
+      id: "enr-1",
+      sequenceId: "seq-1",
+      personId: "p1",
+      status: "active",
+      variables: "{}",
+      fromAddress: "test@test.com",
+      enrolledAt: now,
+    });
+
+    await db.insert(sequenceEmails).values({
+      id: "se-1",
+      enrollmentId: "enr-1",
+      stepOrder: 1,
+      templateSlug: "welcome",
+      scheduledAt: now - 100,
+      status: "queued",
+    });
+
+    const fakeSender: EmailSender = {
+      provider: "none",
+      maxAttachmentBytes: () => 25_000_000,
+      send: vi.fn(async (_params: SendEmailParams) => ({
+        id: "fake-resend-id",
+        error: null,
+      })),
+    };
+
+    await processSequenceEmail(
+      db,
+      fakeSender,
+      env as unknown as CloudflareBindings,
+      "se-1",
+    );
+
+    expect(fakeSender.send).toHaveBeenCalledTimes(1);
+
+    const row = await db
+      .select()
+      .from(sequenceEmails)
+      .where(eq(sequenceEmails.id, "se-1"))
+      .limit(1);
+    expect(row[0].status).toBe("sent");
+    expect(row[0].sentEmailId).not.toBeNull();
+
+    const sentRows = await db.select().from(sentEmails);
+    expect(sentRows).toHaveLength(1);
+    expect(sentRows[0].toAddress).toBe("ok@test.com");
   });
 });

--- a/worker/src/__tests__/sequences-router.test.ts
+++ b/worker/src/__tests__/sequences-router.test.ts
@@ -473,5 +473,41 @@ describe("sequences router", () => {
       expect(data[0].totalSteps).toBe(2);
       expect(data[0].sentSteps).toBe(0);
     });
+
+    it("counts 'suppressed' rows toward sentSteps (terminal state)", async () => {
+      const seq = await createSequenceWithTemplates();
+      await createTestPerson({ id: "s1", email: "a@test.com", name: "Alice" });
+
+      const enrollRes = await authFetch(`/api/sequences/${seq.id}/enroll`, {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          personId: "s1",
+          fromAddress: "me@saasmail.test",
+        }),
+      });
+      const enrollData = await enrollRes.json();
+
+      // Manually mark one of the scheduled emails as suppressed (simulating
+      // what processSequenceEmail would do when the recipient is on the list).
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(sequenceEmails)
+        .where(eq(sequenceEmails.enrollmentId, enrollData.enrollment.id));
+      // Pick the first step deterministically by stepOrder.
+      const first = rows.sort((a, b) => a.stepOrder - b.stepOrder)[0];
+      await db
+        .update(sequenceEmails)
+        .set({ status: "suppressed" })
+        .where(eq(sequenceEmails.id, first.id));
+
+      const res = await authFetch(`/api/sequences/${seq.id}/enrollments`, {
+        apiKey,
+      });
+      const data = await res.json();
+      expect(data[0].totalSteps).toBe(2);
+      expect(data[0].sentSteps).toBe(1);
+    });
   });
 });

--- a/worker/src/__tests__/suppressions-lib.test.ts
+++ b/worker/src/__tests__/suppressions-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { applyMigrations, cleanDb, getDb } from "./helpers";
+import { suppressions } from "../db/suppressions.schema";
+import { isSuppressed } from "../lib/suppressions";
+
+async function insertSuppression(email: string) {
+  const db = getDb();
+  await db.insert(suppressions).values({
+    id: `sup-${email}`,
+    email: email.toLowerCase(),
+    reason: "unsubscribe",
+    createdAt: Math.floor(Date.now() / 1000),
+  });
+}
+
+describe("isSuppressed", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+  });
+
+  it("returns false when the email is not on the list", async () => {
+    const db = getDb();
+    expect(await isSuppressed(db, "alice@example.com")).toBe(false);
+  });
+
+  it("returns true for an exact-match email", async () => {
+    await insertSuppression("alice@example.com");
+    const db = getDb();
+    expect(await isSuppressed(db, "alice@example.com")).toBe(true);
+  });
+
+  it("matches case-insensitively", async () => {
+    await insertSuppression("alice@example.com");
+    const db = getDb();
+    expect(await isSuppressed(db, "Alice@Example.COM")).toBe(true);
+  });
+
+  it("does NOT strip Gmail plus-tags (exact normalized match only)", async () => {
+    await insertSuppression("user+a@gmail.com");
+    const db = getDb();
+    expect(await isSuppressed(db, "user@gmail.com")).toBe(false);
+    expect(await isSuppressed(db, "user+a@gmail.com")).toBe(true);
+  });
+});

--- a/worker/src/__tests__/suppressions-router.test.ts
+++ b/worker/src/__tests__/suppressions-router.test.ts
@@ -25,7 +25,10 @@ describe("suppressions router", () => {
       reason: string;
       source: string;
     };
-    expect(body).toMatchObject({ email: "alice@example.com", reason: "manual" });
+    expect(body).toMatchObject({
+      email: "alice@example.com",
+      reason: "manual",
+    });
     expect(body.source).toMatch(/^admin:/);
   });
 
@@ -43,9 +46,9 @@ describe("suppressions router", () => {
     });
     expect([200, 201]).toContain(r.status);
     const rows = await getDb().query.suppressions.findMany();
-    expect(rows.filter((row) => row.email === "alice@example.com")).toHaveLength(
-      1,
-    );
+    expect(
+      rows.filter((row) => row.email === "alice@example.com"),
+    ).toHaveLength(1);
   });
 
   it("POST /api/suppressions lowercases the input email", async () => {
@@ -88,14 +91,16 @@ describe("suppressions router", () => {
 
   it("DELETE /api/suppressions/:id removes the row", async () => {
     const { apiKey } = await createTestUser({ role: "admin" });
-    await getDb().insert(suppressions).values({
-      id: "s1",
-      email: "alice@example.com",
-      reason: "manual",
-      source: "test",
-      note: null,
-      createdAt: Math.floor(Date.now() / 1000),
-    });
+    await getDb()
+      .insert(suppressions)
+      .values({
+        id: "s1",
+        email: "alice@example.com",
+        reason: "manual",
+        source: "test",
+        note: null,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
     const r = await authFetch("/api/suppressions/s1", {
       apiKey,
       method: "DELETE",

--- a/worker/src/__tests__/suppressions-router.test.ts
+++ b/worker/src/__tests__/suppressions-router.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  authFetch,
+  createTestUser,
+  getDb,
+  applyMigrations,
+  cleanDb,
+} from "./helpers";
+import { suppressions } from "../db/suppressions.schema";
+
+beforeAll(applyMigrations);
+beforeEach(cleanDb);
+
+describe("suppressions router", () => {
+  it("POST /api/suppressions creates a manual entry", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const r = await authFetch("/api/suppressions", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ email: "alice@example.com" }),
+    });
+    expect(r.status).toBe(201);
+    const body = (await r.json()) as {
+      email: string;
+      reason: string;
+      source: string;
+    };
+    expect(body).toMatchObject({ email: "alice@example.com", reason: "manual" });
+    expect(body.source).toMatch(/^admin:/);
+  });
+
+  it("POST /api/suppressions is idempotent for duplicate email", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    await authFetch("/api/suppressions", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ email: "alice@example.com" }),
+    });
+    const r = await authFetch("/api/suppressions", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ email: "alice@example.com" }),
+    });
+    expect([200, 201]).toContain(r.status);
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows.filter((row) => row.email === "alice@example.com")).toHaveLength(
+      1,
+    );
+  });
+
+  it("POST /api/suppressions lowercases the input email", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const r = await authFetch("/api/suppressions", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ email: "ALICE@EXAMPLE.COM" }),
+    });
+    const body = (await r.json()) as { email: string };
+    expect(body.email).toBe("alice@example.com");
+  });
+
+  it("GET /api/suppressions returns paginated list newest-first", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+    // Insert 3 rows with distinct timestamps — newest (i=0) first.
+    for (let i = 0; i < 3; i++) {
+      await db.insert(suppressions).values({
+        id: "s" + i,
+        email: "u" + i + "@example.com",
+        reason: "manual",
+        source: "test",
+        note: null,
+        createdAt: now - i * 60,
+      });
+    }
+    const r = await authFetch("/api/suppressions", { apiKey });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as {
+      items: Array<{ email: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.items).toHaveLength(3);
+    expect(body.items[0].email).toBe("u0@example.com");
+    expect(body.items[2].email).toBe("u2@example.com");
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("DELETE /api/suppressions/:id removes the row", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    await getDb().insert(suppressions).values({
+      id: "s1",
+      email: "alice@example.com",
+      reason: "manual",
+      source: "test",
+      note: null,
+      createdAt: Math.floor(Date.now() / 1000),
+    });
+    const r = await authFetch("/api/suppressions/s1", {
+      apiKey,
+      method: "DELETE",
+    });
+    expect(r.status).toBe(200);
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("DELETE is idempotent (no 404 on missing id)", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const r = await authFetch("/api/suppressions/does-not-exist", {
+      apiKey,
+      method: "DELETE",
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const r = await authFetch("/api/suppressions");
+    expect([401, 403]).toContain(r.status);
+  });
+
+  it("rejects non-admin authenticated requests", async () => {
+    const { apiKey } = await createTestUser({
+      role: "member",
+      email: "regular@example.com",
+    });
+    const r = await authFetch("/api/suppressions", { apiKey });
+    expect([401, 403]).toContain(r.status);
+  });
+});

--- a/worker/src/__tests__/unsubscribe-router.test.ts
+++ b/worker/src/__tests__/unsubscribe-router.test.ts
@@ -109,4 +109,45 @@ describe("public unsubscribe endpoints", () => {
     );
     expect(r.status).toBe(200); // not 401 — the allowlist must let this through
   });
+
+  // RFC 8058 one-click clients (Gmail, Fastmail, Apple Mail) POST directly to
+  // the URL in the `List-Unsubscribe` header, which is the same URL we use for
+  // the SPA body link (`/unsubscribe?token=...`). Without a Worker handler at
+  // that path, those POSTs fell through to the SPA route and returned 405,
+  // which the clients render as "We were unable to unsubscribe you."
+  it("POST /unsubscribe (bare, no /api prefix) writes a suppression row", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    const r = await exports.default.fetch(
+      `http://localhost/unsubscribe?token=${encodeURIComponent(token)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "List-Unsubscribe=One-Click",
+      },
+    );
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { email: string; status: string };
+    expect(body).toMatchObject({
+      email: "alice@example.com",
+      status: "suppressed",
+    });
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("POST /unsubscribe/undo (bare, no /api prefix) deletes the row", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    // Insert first
+    await exports.default.fetch(
+      `http://localhost/unsubscribe?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    const r = await exports.default.fetch(
+      `http://localhost/unsubscribe/undo?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(200);
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/worker/src/__tests__/unsubscribe-router.test.ts
+++ b/worker/src/__tests__/unsubscribe-router.test.ts
@@ -68,14 +68,16 @@ describe("public unsubscribe endpoints", () => {
   });
 
   it("POST /api/unsubscribe/undo deletes the row", async () => {
-    await getDb().insert(suppressions).values({
-      id: "s1",
-      email: "alice@example.com",
-      reason: "unsubscribe",
-      source: "user-link",
-      note: null,
-      createdAt: Math.floor(Date.now() / 1000),
-    });
+    await getDb()
+      .insert(suppressions)
+      .values({
+        id: "s1",
+        email: "alice@example.com",
+        reason: "unsubscribe",
+        source: "user-link",
+        note: null,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
     const token = await signToken("alice@example.com", SECRET);
     const r = await exports.default.fetch(
       `http://localhost/api/unsubscribe/undo?token=${encodeURIComponent(token)}`,

--- a/worker/src/__tests__/unsubscribe-router.test.ts
+++ b/worker/src/__tests__/unsubscribe-router.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations, cleanDb, getDb } from "./helpers";
+import { signToken } from "../lib/unsubscribe-token";
+import { suppressions } from "../db/suppressions.schema";
+
+// Matches the binding in vitest.config.test.ts.
+const SECRET = "test-secret-do-not-use-in-prod";
+
+beforeAll(applyMigrations);
+beforeEach(cleanDb);
+
+describe("public unsubscribe endpoints", () => {
+  it("POST /api/unsubscribe with valid token writes a suppression row", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    const r = await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { email: string; status: string };
+    expect(body).toMatchObject({
+      email: "alice@example.com",
+      status: "suppressed",
+    });
+
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].reason).toBe("unsubscribe");
+    expect(rows[0].source).toBe("one-click");
+  });
+
+  it("source=user-link query overrides the default", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(token)}&source=user-link`,
+      { method: "POST" },
+    );
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows[0].source).toBe("user-link");
+  });
+
+  it("rejects a tampered token with 401", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    const tampered = token.slice(0, -2) + "AA";
+    const r = await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(tampered)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(401);
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("is idempotent: replaying does NOT duplicate or overwrite source", async () => {
+    const token = await signToken("alice@example.com", SECRET);
+    await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(token)}&source=user-link`,
+      { method: "POST" },
+    );
+    await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe("user-link"); // first source preserved
+  });
+
+  it("POST /api/unsubscribe/undo deletes the row", async () => {
+    await getDb().insert(suppressions).values({
+      id: "s1",
+      email: "alice@example.com",
+      reason: "unsubscribe",
+      source: "user-link",
+      note: null,
+      createdAt: Math.floor(Date.now() / 1000),
+    });
+    const token = await signToken("alice@example.com", SECRET);
+    const r = await exports.default.fetch(
+      `http://localhost/api/unsubscribe/undo?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { email: string; status: string };
+    expect(body).toMatchObject({
+      email: "alice@example.com",
+      status: "subscribed",
+    });
+    const rows = await getDb().query.suppressions.findMany();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("undo is idempotent if no row exists", async () => {
+    const token = await signToken("nobody@example.com", SECRET);
+    const r = await exports.default.fetch(
+      `http://localhost/api/unsubscribe/undo?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(200);
+  });
+
+  it("public endpoints work without any auth headers", async () => {
+    // Critical bypass check: NO API key, NO session, just the token.
+    const token = await signToken("alice@example.com", SECRET);
+    const r = await exports.default.fetch(
+      `http://localhost/api/unsubscribe?token=${encodeURIComponent(token)}`,
+      { method: "POST" },
+    );
+    expect(r.status).toBe(200); // not 401 — the allowlist must let this through
+  });
+});

--- a/worker/src/__tests__/unsubscribe-token.test.ts
+++ b/worker/src/__tests__/unsubscribe-token.test.ts
@@ -6,12 +6,16 @@ const SECRET = "test-secret-do-not-use-in-prod";
 describe("unsubscribe-token", () => {
   it("round-trips: signed token verifies back to the input email", async () => {
     const t = await signToken("alice@example.com", SECRET);
-    expect(await verifyToken(t, SECRET)).toEqual({ email: "alice@example.com" });
+    expect(await verifyToken(t, SECRET)).toEqual({
+      email: "alice@example.com",
+    });
   });
 
   it("lowercases the email in the payload", async () => {
     const t = await signToken("Alice@Example.COM", SECRET);
-    expect(await verifyToken(t, SECRET)).toEqual({ email: "alice@example.com" });
+    expect(await verifyToken(t, SECRET)).toEqual({
+      email: "alice@example.com",
+    });
   });
 
   it("rejects a tampered signature", async () => {

--- a/worker/src/__tests__/unsubscribe-token.test.ts
+++ b/worker/src/__tests__/unsubscribe-token.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { signToken, verifyToken } from "../lib/unsubscribe-token";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+
+describe("unsubscribe-token", () => {
+  it("round-trips: signed token verifies back to the input email", async () => {
+    const t = await signToken("alice@example.com", SECRET);
+    expect(await verifyToken(t, SECRET)).toEqual({ email: "alice@example.com" });
+  });
+
+  it("lowercases the email in the payload", async () => {
+    const t = await signToken("Alice@Example.COM", SECRET);
+    expect(await verifyToken(t, SECRET)).toEqual({ email: "alice@example.com" });
+  });
+
+  it("rejects a tampered signature", async () => {
+    const t = await signToken("alice@example.com", SECRET);
+    const [payload, sig] = t.split(".");
+    const tampered = `${payload}.${sig.slice(0, -1)}A`;
+    expect(await verifyToken(tampered, SECRET)).toBeNull();
+  });
+
+  it("rejects a tampered payload", async () => {
+    const t = await signToken("alice@example.com", SECRET);
+    const [, sig] = t.split(".");
+    // Re-encode with a different email but keep the original signature
+    const newPayload = btoa(JSON.stringify({ e: "bob@example.com", v: 1 }))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const tampered = `${newPayload}.${sig}`;
+    expect(await verifyToken(tampered, SECRET)).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const t = await signToken("alice@example.com", SECRET);
+    expect(await verifyToken(t, "other-secret")).toBeNull();
+  });
+
+  it("returns null (does not throw) for malformed input", async () => {
+    expect(await verifyToken("", SECRET)).toBeNull();
+    expect(await verifyToken("no-dot", SECRET)).toBeNull();
+    expect(await verifyToken("a.b.c", SECRET)).toBeNull();
+    expect(await verifyToken("not-base64.not-base64", SECRET)).toBeNull();
+  });
+});

--- a/worker/src/db/index.ts
+++ b/worker/src/db/index.ts
@@ -14,4 +14,5 @@ export * from "./sender-identities.schema";
 export * from "./inbox-permissions.schema";
 export * from "./push-subscriptions.schema";
 export * from "./app-settings.schema";
+export * from "./suppressions.schema";
 export * from "./schema";

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -13,6 +13,7 @@ import { senderIdentities } from "./sender-identities.schema";
 import { inboxPermissions } from "./inbox-permissions.schema";
 import { pushSubscriptions } from "./push-subscriptions.schema";
 import { appSettings } from "./app-settings.schema";
+import { suppressions } from "./suppressions.schema";
 
 export const schema = {
   ...authSchema,
@@ -30,4 +31,5 @@ export const schema = {
   inboxPermissions,
   pushSubscriptions,
   appSettings,
+  suppressions,
 } as const;

--- a/worker/src/db/suppressions.schema.ts
+++ b/worker/src/db/suppressions.schema.ts
@@ -1,0 +1,13 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const suppressions = sqliteTable("suppressions", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  reason: text("reason", { enum: ["unsubscribe", "manual"] }).notNull(),
+  source: text("source"),
+  note: text("note"),
+  createdAt: integer("created_at").notNull(),
+});
+
+export type Suppression = typeof suppressions.$inferSelect;
+export type NewSuppression = typeof suppressions.$inferInsert;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -27,6 +27,7 @@ import { handleScheduled, handleQueueBatch } from "./lib/sequence-processor";
 import type { SequenceEmailMessage } from "./lib/sequence-processor";
 import { notificationsRouter } from "./routers/notifications-router";
 import { suppressionsRouter } from "./routers/suppressions-router";
+import { unsubscribeRouter } from "./routers/unsubscribe-router";
 export { NotificationsHub } from "./do/notifications";
 import type { Variables } from "./variables";
 import type { MiddlewareHandler } from "hono";
@@ -54,6 +55,7 @@ function isUnauthenticatedPath(path: string): boolean {
     path.startsWith("/api/auth") ||
     path.startsWith("/api/setup") ||
     path.startsWith("/api/invites") ||
+    path.startsWith("/api/unsubscribe") ||
     path === "/api/health" ||
     path === "/api/config"
   );
@@ -212,6 +214,10 @@ app.route("/api/admin/inboxes", adminInboxesRouter);
 app.use("/api/suppressions/*", requireAdmin);
 app.use("/api/suppressions", requireAdmin);
 app.route("/api/suppressions", suppressionsRouter);
+
+// Public unsubscribe endpoints — token-authenticated, no session/API key.
+// Allowlisted in `isUnauthenticatedPath` above.
+app.route("/api/unsubscribe", unsubscribeRouter);
 
 // Health check (no auth)
 app.get("/api/health", (c) => c.json({ status: "ok" }));

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -219,6 +219,12 @@ app.route("/api/suppressions", suppressionsRouter);
 // Allowlisted in `isUnauthenticatedPath` above.
 app.route("/api/unsubscribe", unsubscribeRouter);
 
+// Also mount at `/unsubscribe` so the same URL we put in the `List-Unsubscribe`
+// email header (which doubles as the body link → SPA at GET /unsubscribe) handles
+// RFC 8058 one-click POSTs from mail clients like Fastmail / Gmail / Apple Mail.
+// GET requests don't match the router and fall through to the SPA assets handler.
+app.route("/unsubscribe", unsubscribeRouter);
+
 // Health check (no auth)
 app.get("/api/health", (c) => c.json({ status: "ok" }));
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ import { sequencesRouter } from "./routers/sequences-router";
 import { handleScheduled, handleQueueBatch } from "./lib/sequence-processor";
 import type { SequenceEmailMessage } from "./lib/sequence-processor";
 import { notificationsRouter } from "./routers/notifications-router";
+import { suppressionsRouter } from "./routers/suppressions-router";
 export { NotificationsHub } from "./do/notifications";
 import type { Variables } from "./variables";
 import type { MiddlewareHandler } from "hono";
@@ -205,6 +206,12 @@ app.route("/api/notifications", notificationsRouter);
 app.use("/api/admin/*", requireAdmin);
 app.route("/api/admin", adminRouter);
 app.route("/api/admin/inboxes", adminInboxesRouter);
+
+// Suppressions CRUD — admin-only (not under /api/admin/ for UX but enforced
+// here with the same role guard).
+app.use("/api/suppressions/*", requireAdmin);
+app.use("/api/suppressions", requireAdmin);
+app.route("/api/suppressions", suppressionsRouter);
 
 // Health check (no auth)
 app.get("/api/health", (c) => c.json({ status: "ok" }));

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -1,0 +1,176 @@
+import { isSuppressed, type Database } from "./suppressions";
+import { signToken } from "./unsubscribe-token";
+import type {
+  EmailSender,
+  SendEmailParams,
+  SendEmailResult,
+} from "./email-sender";
+
+export interface SendInput {
+  db: Database;
+  env: { UNSUBSCRIBE_SECRET: string; BASE_URL: string };
+  sender: EmailSender;
+  from: SendEmailParams["from"];
+  to: string[];
+  cc?: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  headers?: Record<string, string>;
+  attachments?: SendEmailParams["attachments"];
+  transactional?: boolean;
+}
+
+export interface SendOutput {
+  delivered: string[];
+  suppressed: string[];
+  result?: SendEmailResult;
+}
+
+const UNSUB_PLACEHOLDER = /\{\{unsubscribe_url\}\}/g;
+
+function buildUnsubscribeUrl(baseUrl: string, token: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/unsubscribe?token=${encodeURIComponent(
+    token,
+  )}`;
+}
+
+function appendHtmlFooter(html: string, url: string): string {
+  return (
+    html +
+    `<hr/>\n<p style="font-size:12px;color:#666">You received this email because you're on our list. <a href="${url}">Unsubscribe</a></p>`
+  );
+}
+
+function appendTextFooter(text: string, url: string): string {
+  return (
+    text +
+    `\n\n---\nYou received this email because you're on our list.\nUnsubscribe: ${url}`
+  );
+}
+
+export async function sendWithSuppressionCheck(
+  input: SendInput,
+): Promise<SendOutput> {
+  const {
+    db,
+    env,
+    sender,
+    from,
+    to,
+    cc,
+    subject,
+    headers,
+    attachments,
+    transactional,
+  } = input;
+  let { html, text } = input;
+
+  const deliveredTo: string[] = [];
+  const deliveredCc: string[] = [];
+  const suppressed: string[] = [];
+
+  if (transactional === true) {
+    deliveredTo.push(...to);
+    if (cc && cc.length > 0) deliveredCc.push(...cc);
+  } else {
+    for (const addr of to) {
+      if (await isSuppressed(db, addr)) {
+        suppressed.push(addr);
+      } else {
+        deliveredTo.push(addr);
+      }
+    }
+    if (cc) {
+      for (const addr of cc) {
+        if (await isSuppressed(db, addr)) {
+          suppressed.push(addr);
+        } else {
+          deliveredCc.push(addr);
+        }
+      }
+    }
+  }
+
+  // Nothing to send if every recipient was suppressed.
+  if (deliveredTo.length === 0 && deliveredCc.length === 0) {
+    return { delivered: [], suppressed };
+  }
+
+  let finalHeaders: Record<string, string> | undefined = headers
+    ? { ...headers }
+    : undefined;
+
+  if (transactional !== true) {
+    // Pick the primary recipient for token generation. Prefer the first `to`,
+    // fall back to the first `cc` if `to` is empty after partitioning.
+    const primary = deliveredTo[0] ?? deliveredCc[0];
+    const token = await signToken(primary, env.UNSUBSCRIBE_SECRET);
+    const url = buildUnsubscribeUrl(env.BASE_URL, token);
+
+    if (typeof html === "string") {
+      html = html.replace(UNSUB_PLACEHOLDER, url);
+      if (!html.includes(url)) {
+        html = appendHtmlFooter(html, url);
+      }
+    }
+
+    if (typeof text === "string") {
+      text = text.replace(UNSUB_PLACEHOLDER, url);
+      if (!text.includes(url)) {
+        text = appendTextFooter(text, url);
+      }
+    }
+
+    finalHeaders = {
+      ...(headers ?? {}),
+      "List-Unsubscribe": `<${url}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    };
+  }
+
+  // The transport accepts a single `to` per call. Loop over delivered `to`
+  // recipients; if there are none but there are `cc` recipients, send a single
+  // call using the first `cc` as the primary address.
+  let lastResult: SendEmailResult | undefined;
+  const ccArg = deliveredCc.length > 0 ? deliveredCc : undefined;
+
+  if (deliveredTo.length === 0) {
+    // Edge case: only cc recipients survived. Use the first cc as `to` so the
+    // transport has a recipient; remaining cc stays in the cc list.
+    const [primary, ...rest] = deliveredCc;
+    lastResult = await sender.send({
+      from,
+      to: primary,
+      ...(rest.length > 0 ? { cc: rest } : {}),
+      subject,
+      html: html ?? "",
+      ...(text !== undefined ? { text } : {}),
+      ...(finalHeaders ? { headers: finalHeaders } : {}),
+      ...(attachments ? { attachments } : {}),
+    });
+  } else {
+    for (let i = 0; i < deliveredTo.length; i++) {
+      const recipient = deliveredTo[i];
+      // Only include cc on the first call to avoid duplicate cc deliveries
+      // when `to` has multiple entries.
+      const includeCc = i === 0 && ccArg !== undefined;
+      lastResult = await sender.send({
+        from,
+        to: recipient,
+        ...(includeCc ? { cc: ccArg } : {}),
+        subject,
+        html: html ?? "",
+        ...(text !== undefined ? { text } : {}),
+        ...(finalHeaders ? { headers: finalHeaders } : {}),
+        ...(attachments ? { attachments } : {}),
+      });
+    }
+  }
+
+  return {
+    delivered: [...deliveredTo, ...deliveredCc],
+    suppressed,
+    result: lastResult,
+  };
+}

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -11,7 +11,7 @@ export interface SendInput {
   env: { UNSUBSCRIBE_SECRET: string; BASE_URL: string };
   sender: EmailSender;
   from: SendEmailParams["from"];
-  to: string[];
+  to: string;
   cc?: string[];
   subject: string;
   html?: string;
@@ -66,21 +66,19 @@ export async function sendWithSuppressionCheck(
   } = input;
   let { html, text } = input;
 
-  const deliveredTo: string[] = [];
+  // Partition recipients into delivered vs suppressed. Transactional sends
+  // bypass the suppression list entirely.
+  let primaryTo: string | null;
   const deliveredCc: string[] = [];
   const suppressed: string[] = [];
 
   if (transactional === true) {
-    deliveredTo.push(...to);
+    primaryTo = to;
     if (cc && cc.length > 0) deliveredCc.push(...cc);
   } else {
-    for (const addr of to) {
-      if (await isSuppressed(db, addr)) {
-        suppressed.push(addr);
-      } else {
-        deliveredTo.push(addr);
-      }
-    }
+    primaryTo = (await isSuppressed(db, to)) ? null : to;
+    if (primaryTo === null) suppressed.push(to);
+
     if (cc) {
       for (const addr of cc) {
         if (await isSuppressed(db, addr)) {
@@ -90,10 +88,16 @@ export async function sendWithSuppressionCheck(
         }
       }
     }
+
+    // If the primary `to` was suppressed, promote the first surviving cc to
+    // be the new `to`; remaining cc stays in the cc list.
+    if (primaryTo === null && deliveredCc.length > 0) {
+      primaryTo = deliveredCc.shift() as string;
+    }
   }
 
   // Nothing to send if every recipient was suppressed.
-  if (deliveredTo.length === 0 && deliveredCc.length === 0) {
+  if (primaryTo === null) {
     return { delivered: [], suppressed };
   }
 
@@ -102,10 +106,10 @@ export async function sendWithSuppressionCheck(
     : undefined;
 
   if (transactional !== true) {
-    // Pick the primary recipient for token generation. Prefer the first `to`,
-    // fall back to the first `cc` if `to` is empty after partitioning.
-    const primary = deliveredTo[0] ?? deliveredCc[0];
-    const token = await signToken(primary, env.UNSUBSCRIBE_SECRET);
+    // Build the unsubscribe token from the FINAL primary recipient — the one
+    // actually receiving the email as `to`. This ensures the recipient who
+    // clicks unsubscribe is the one who gets suppressed.
+    const token = await signToken(primaryTo, env.UNSUBSCRIBE_SECRET);
     const url = buildUnsubscribeUrl(env.BASE_URL, token);
 
     if (typeof html === "string") {
@@ -129,48 +133,22 @@ export async function sendWithSuppressionCheck(
     };
   }
 
-  // The transport accepts a single `to` per call. Loop over delivered `to`
-  // recipients; if there are none but there are `cc` recipients, send a single
-  // call using the first `cc` as the primary address.
-  let lastResult: SendEmailResult | undefined;
   const ccArg = deliveredCc.length > 0 ? deliveredCc : undefined;
 
-  if (deliveredTo.length === 0) {
-    // Edge case: only cc recipients survived. Use the first cc as `to` so the
-    // transport has a recipient; remaining cc stays in the cc list.
-    const [primary, ...rest] = deliveredCc;
-    lastResult = await sender.send({
-      from,
-      to: primary,
-      ...(rest.length > 0 ? { cc: rest } : {}),
-      subject,
-      html: html ?? "",
-      ...(text !== undefined ? { text } : {}),
-      ...(finalHeaders ? { headers: finalHeaders } : {}),
-      ...(attachments ? { attachments } : {}),
-    });
-  } else {
-    for (let i = 0; i < deliveredTo.length; i++) {
-      const recipient = deliveredTo[i];
-      // Only include cc on the first call to avoid duplicate cc deliveries
-      // when `to` has multiple entries.
-      const includeCc = i === 0 && ccArg !== undefined;
-      lastResult = await sender.send({
-        from,
-        to: recipient,
-        ...(includeCc ? { cc: ccArg } : {}),
-        subject,
-        html: html ?? "",
-        ...(text !== undefined ? { text } : {}),
-        ...(finalHeaders ? { headers: finalHeaders } : {}),
-        ...(attachments ? { attachments } : {}),
-      });
-    }
-  }
+  const result = await sender.send({
+    from,
+    to: primaryTo,
+    ...(ccArg ? { cc: ccArg } : {}),
+    subject,
+    html: html ?? "",
+    ...(text !== undefined ? { text } : {}),
+    ...(finalHeaders ? { headers: finalHeaders } : {}),
+    ...(attachments ? { attachments } : {}),
+  });
 
   return {
-    delivered: [...deliveredTo, ...deliveredCc],
+    delivered: [primaryTo, ...deliveredCc],
     suppressed,
-    result: lastResult,
+    result,
   };
 }

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -110,12 +110,6 @@ export async function sendWithSuppressionCheck(
       }
     }
 
-    // If the primary `to` was suppressed, promote the first surviving cc to
-    // be the new `to`; remaining cc stays in the cc list.
-    if (primaryTo === null && deliveredCc.length > 0) {
-      const promoted = deliveredCc.shift()!;
-      primaryTo = promoted.email;
-    }
   }
 
   // Nothing to send if every recipient was suppressed.

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -109,7 +109,6 @@ export async function sendWithSuppressionCheck(
         }
       }
     }
-
   }
 
   // Nothing to send if every recipient was suppressed.

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -158,54 +158,56 @@ export async function sendWithSuppressionCheck(
       ...deliveredCc.map((c) => ({ email: c.email, cc: c })),
     ];
 
-    for (let i = 0; i < allDelivered.length; i++) {
-      const recipient = allDelivered[i];
-      const token = await signToken(recipient.email, env.UNSUBSCRIBE_SECRET);
-      const url = buildUnsubscribeUrl(env.BASE_URL, token);
+    const results = await Promise.all(
+      allDelivered.map(async (recipient) => {
+        const token = await signToken(recipient.email, env.UNSUBSCRIBE_SECRET);
+        const url = buildUnsubscribeUrl(env.BASE_URL, token);
 
-      let recipientHtml = html;
-      let recipientText = text;
-      if (typeof recipientHtml === "string") {
-        recipientHtml = recipientHtml.replace(UNSUB_PLACEHOLDER, url);
-        if (!recipientHtml.includes(url)) {
-          recipientHtml = appendHtmlFooter(recipientHtml, url);
+        let recipientHtml = html;
+        let recipientText = text;
+        if (typeof recipientHtml === "string") {
+          recipientHtml = recipientHtml.replace(UNSUB_PLACEHOLDER, url);
+          if (!recipientHtml.includes(url)) {
+            recipientHtml = appendHtmlFooter(recipientHtml, url);
+          }
         }
-      }
-      if (typeof recipientText === "string") {
-        recipientText = recipientText.replace(UNSUB_PLACEHOLDER, url);
-        if (!recipientText.includes(url)) {
-          recipientText = appendTextFooter(recipientText, url);
+        if (typeof recipientText === "string") {
+          recipientText = recipientText.replace(UNSUB_PLACEHOLDER, url);
+          if (!recipientText.includes(url)) {
+            recipientText = appendTextFooter(recipientText, url);
+          }
         }
-      }
 
-      const recipientHeaders: Record<string, string> = {
-        ...(headers ?? {}),
-        "List-Unsubscribe": `<${url}>`,
-        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-      };
+        const recipientHeaders: Record<string, string> = {
+          ...(headers ?? {}),
+          "List-Unsubscribe": `<${url}>`,
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        };
 
-      // The header-formatted "to" is `"Name <addr>"` only when this entry
-      // came from a cc with a display name; the original `to` is a bare
-      // string by signature.
-      const toForTransport = recipient.cc
-        ? formatCcForTransport(recipient.cc)
-        : recipient.email;
+        // The header-formatted "to" is `"Name <addr>"` only when this entry
+        // came from a cc with a display name; the original `to` is a bare
+        // string by signature.
+        const toForTransport = recipient.cc
+          ? formatCcForTransport(recipient.cc)
+          : recipient.email;
 
-      lastResult = await sender.send({
-        from,
-        to: toForTransport,
-        subject,
-        html: recipientHtml ?? "",
-        ...(recipientText !== undefined ? { text: recipientText } : {}),
-        headers: recipientHeaders,
-        ...(attachments ? { attachments } : {}),
-      });
+        const result = await sender.send({
+          from,
+          to: toForTransport,
+          subject,
+          html: recipientHtml ?? "",
+          ...(recipientText !== undefined ? { text: recipientText } : {}),
+          headers: recipientHeaders,
+          ...(attachments ? { attachments } : {}),
+        });
 
-      if (i === 0) {
-        renderedHtml = recipientHtml;
-        renderedText = recipientText;
-      }
-    }
+        return { result, recipientHtml, recipientText };
+      }),
+    );
+
+    lastResult = results[0].result;
+    renderedHtml = results[0].recipientHtml;
+    renderedText = results[0].recipientText;
   }
 
   return {

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -38,15 +38,12 @@ function buildUnsubscribeUrl(baseUrl: string, token: string): string {
 function appendHtmlFooter(html: string, url: string): string {
   return (
     html +
-    `<hr/>\n<p style="font-size:12px;color:#666">You received this email because you're on our list. <a href="${url}">Unsubscribe</a></p>`
+    `<hr/>\n<p style="font-size:12px;color:#666"><a href="${url}">Unsubscribe</a></p>`
   );
 }
 
 function appendTextFooter(text: string, url: string): string {
-  return (
-    text +
-    `\n\n---\nYou received this email because you're on our list.\nUnsubscribe: ${url}`
-  );
+  return text + `\n\n---\nUnsubscribe: ${url}`;
 }
 
 export async function sendWithSuppressionCheck(

--- a/worker/src/lib/send.ts
+++ b/worker/src/lib/send.ts
@@ -6,13 +6,23 @@ import type {
   SendEmailResult,
 } from "./email-sender";
 
+/**
+ * A CC entry the caller hands us. We need the bare `email` for suppression
+ * lookups AND for per-recipient token signing; the optional `name` is only
+ * used when we format the final `"Name <addr>"` header value for the wire.
+ */
+export interface CcRecipient {
+  email: string;
+  name?: string | null;
+}
+
 export interface SendInput {
   db: Database;
   env: { UNSUBSCRIBE_SECRET: string; BASE_URL: string };
   sender: EmailSender;
   from: SendEmailParams["from"];
   to: string;
-  cc?: string[];
+  cc?: CcRecipient[];
   subject: string;
   html?: string;
   text?: string;
@@ -25,6 +35,14 @@ export interface SendOutput {
   delivered: string[];
   suppressed: string[];
   result?: SendEmailResult;
+  /**
+   * For audit logging: the rendered html/text actually sent to the FIRST
+   * delivered recipient. For multi-recipient marketing sends each recipient
+   * gets their own per-recipient token, so this is a representative copy of
+   * one wire payload, not all of them.
+   */
+  renderedHtml?: string;
+  renderedText?: string;
 }
 
 const UNSUB_PLACEHOLDER = /\{\{unsubscribe_url\}\}/g;
@@ -46,6 +64,11 @@ function appendTextFooter(text: string, url: string): string {
   return text + `\n\n---\nUnsubscribe: ${url}`;
 }
 
+/** Format a CcRecipient as a header-friendly `"Name <addr>"` string. */
+function formatCcForTransport(c: CcRecipient): string {
+  return c.name ? `${c.name} <${c.email}>` : c.email;
+}
+
 export async function sendWithSuppressionCheck(
   input: SendInput,
 ): Promise<SendOutput> {
@@ -57,16 +80,17 @@ export async function sendWithSuppressionCheck(
     to,
     cc,
     subject,
+    html,
+    text,
     headers,
     attachments,
     transactional,
   } = input;
-  let { html, text } = input;
 
   // Partition recipients into delivered vs suppressed. Transactional sends
   // bypass the suppression list entirely.
   let primaryTo: string | null;
-  const deliveredCc: string[] = [];
+  const deliveredCc: CcRecipient[] = [];
   const suppressed: string[] = [];
 
   if (transactional === true) {
@@ -77,11 +101,11 @@ export async function sendWithSuppressionCheck(
     if (primaryTo === null) suppressed.push(to);
 
     if (cc) {
-      for (const addr of cc) {
-        if (await isSuppressed(db, addr)) {
-          suppressed.push(addr);
+      for (const entry of cc) {
+        if (await isSuppressed(db, entry.email)) {
+          suppressed.push(entry.email);
         } else {
-          deliveredCc.push(addr);
+          deliveredCc.push(entry);
         }
       }
     }
@@ -89,7 +113,8 @@ export async function sendWithSuppressionCheck(
     // If the primary `to` was suppressed, promote the first surviving cc to
     // be the new `to`; remaining cc stays in the cc list.
     if (primaryTo === null && deliveredCc.length > 0) {
-      primaryTo = deliveredCc.shift() as string;
+      const promoted = deliveredCc.shift()!;
+      primaryTo = promoted.email;
     }
   }
 
@@ -98,54 +123,96 @@ export async function sendWithSuppressionCheck(
     return { delivered: [], suppressed };
   }
 
-  let finalHeaders: Record<string, string> | undefined = headers
-    ? { ...headers }
-    : undefined;
+  let lastResult: SendEmailResult | undefined;
+  let renderedHtml: string | undefined;
+  let renderedText: string | undefined;
 
-  if (transactional !== true) {
-    // Build the unsubscribe token from the FINAL primary recipient — the one
-    // actually receiving the email as `to`. This ensures the recipient who
-    // clicks unsubscribe is the one who gets suppressed.
-    const token = await signToken(primaryTo, env.UNSUBSCRIBE_SECRET);
-    const url = buildUnsubscribeUrl(env.BASE_URL, token);
+  if (transactional === true) {
+    // Transactional: single transport call, no per-recipient personalization,
+    // no List-Unsubscribe headers, no footer auto-append.
+    const ccArg =
+      deliveredCc.length > 0
+        ? deliveredCc.map(formatCcForTransport)
+        : undefined;
 
-    if (typeof html === "string") {
-      html = html.replace(UNSUB_PLACEHOLDER, url);
-      if (!html.includes(url)) {
-        html = appendHtmlFooter(html, url);
+    lastResult = await sender.send({
+      from,
+      to: primaryTo,
+      ...(ccArg ? { cc: ccArg } : {}),
+      subject,
+      html: html ?? "",
+      ...(text !== undefined ? { text } : {}),
+      ...(headers ? { headers } : {}),
+      ...(attachments ? { attachments } : {}),
+    });
+
+    renderedHtml = html;
+    renderedText = text;
+  } else {
+    // Marketing: one transport call per delivered recipient, each with its
+    // own per-recipient unsubscribe token + headers + body interpolation.
+    // Every recipient sees themselves as the sole `to` (no cc list), so
+    // clicking the unsubscribe link suppresses them — not somebody else.
+    const allDelivered: Array<{ email: string; cc?: CcRecipient }> = [
+      { email: primaryTo },
+      ...deliveredCc.map((c) => ({ email: c.email, cc: c })),
+    ];
+
+    for (let i = 0; i < allDelivered.length; i++) {
+      const recipient = allDelivered[i];
+      const token = await signToken(recipient.email, env.UNSUBSCRIBE_SECRET);
+      const url = buildUnsubscribeUrl(env.BASE_URL, token);
+
+      let recipientHtml = html;
+      let recipientText = text;
+      if (typeof recipientHtml === "string") {
+        recipientHtml = recipientHtml.replace(UNSUB_PLACEHOLDER, url);
+        if (!recipientHtml.includes(url)) {
+          recipientHtml = appendHtmlFooter(recipientHtml, url);
+        }
+      }
+      if (typeof recipientText === "string") {
+        recipientText = recipientText.replace(UNSUB_PLACEHOLDER, url);
+        if (!recipientText.includes(url)) {
+          recipientText = appendTextFooter(recipientText, url);
+        }
+      }
+
+      const recipientHeaders: Record<string, string> = {
+        ...(headers ?? {}),
+        "List-Unsubscribe": `<${url}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      };
+
+      // The header-formatted "to" is `"Name <addr>"` only when this entry
+      // came from a cc with a display name; the original `to` is a bare
+      // string by signature.
+      const toForTransport = recipient.cc
+        ? formatCcForTransport(recipient.cc)
+        : recipient.email;
+
+      lastResult = await sender.send({
+        from,
+        to: toForTransport,
+        subject,
+        html: recipientHtml ?? "",
+        ...(recipientText !== undefined ? { text: recipientText } : {}),
+        headers: recipientHeaders,
+        ...(attachments ? { attachments } : {}),
+      });
+
+      if (i === 0) {
+        renderedHtml = recipientHtml;
+        renderedText = recipientText;
       }
     }
-
-    if (typeof text === "string") {
-      text = text.replace(UNSUB_PLACEHOLDER, url);
-      if (!text.includes(url)) {
-        text = appendTextFooter(text, url);
-      }
-    }
-
-    finalHeaders = {
-      ...(headers ?? {}),
-      "List-Unsubscribe": `<${url}>`,
-      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-    };
   }
 
-  const ccArg = deliveredCc.length > 0 ? deliveredCc : undefined;
-
-  const result = await sender.send({
-    from,
-    to: primaryTo,
-    ...(ccArg ? { cc: ccArg } : {}),
-    subject,
-    html: html ?? "",
-    ...(text !== undefined ? { text } : {}),
-    ...(finalHeaders ? { headers: finalHeaders } : {}),
-    ...(attachments ? { attachments } : {}),
-  });
-
   return {
-    delivered: [primaryTo, ...deliveredCc],
+    delivered: [primaryTo, ...deliveredCc.map((c) => c.email)],
     suppressed,
-    result,
+    result: lastResult,
+    ...(renderedHtml !== undefined ? { renderedHtml } : {}),
+    ...(renderedText !== undefined ? { renderedText } : {}),
   };
 }

--- a/worker/src/lib/sequence-processor.ts
+++ b/worker/src/lib/sequence-processor.ts
@@ -12,6 +12,7 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { interpolate } from "./interpolate";
 import { formatFromAddress } from "./format-from-address";
 import { generateMessageId } from "./message-id";
+import { sendWithSuppressionCheck } from "./send";
 
 export interface SequenceEmailMessage {
   sequenceEmailId: string;
@@ -75,7 +76,7 @@ export async function handleQueueBatch(
 
   for (const msg of batch.messages) {
     try {
-      await processSequenceEmail(db, sender, msg.body.sequenceEmailId);
+      await processSequenceEmail(db, sender, env, msg.body.sequenceEmailId);
       msg.ack();
     } catch (err) {
       console.error(
@@ -87,9 +88,10 @@ export async function handleQueueBatch(
   }
 }
 
-async function processSequenceEmail(
+export async function processSequenceEmail(
   db: ReturnType<typeof drizzle>,
   sender: EmailSender,
+  env: CloudflareBindings,
   sequenceEmailId: string,
 ): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
@@ -176,7 +178,10 @@ async function processSequenceEmail(
 
   const messageId = generateMessageId(fromAddress);
   const formattedFrom = await formatFromAddress(db, fromAddress);
-  const result = await sender.send({
+  const sendResult = await sendWithSuppressionCheck({
+    db,
+    env,
+    sender,
     from: formattedFrom,
     to: person.email,
     subject: renderedSubject,
@@ -184,36 +189,59 @@ async function processSequenceEmail(
     headers: { "Message-ID": messageId },
   });
 
-  // Store sent email record
-  const sentId = nanoid();
-  await db.insert(sentEmails).values({
-    id: sentId,
-    personId: person.id,
-    fromAddress,
-    toAddress: person.email,
-    subject: renderedSubject,
-    bodyHtml: renderedHtml,
-    bodyText: null,
-    messageId,
-    resendId: result.id,
-    status: result.error ? "failed" : "sent",
-    sentAt: now,
-    createdAt: now,
-  });
-
-  // Update outbox row
-  if (result.error) {
+  // Recipient is on the suppression list — skip transport, mark suppressed,
+  // do NOT retry. Suppression is a final state.
+  if (sendResult.delivered.length === 0) {
+    console.log(
+      "[sequence] recipient suppressed",
+      JSON.stringify({
+        sequenceEmailId,
+        from: fromAddress,
+        suppressed: sendResult.suppressed,
+      }),
+    );
     await db
       .update(sequenceEmails)
-      .set({ status: "failed" })
+      .set({ status: "suppressed", sentAt: now })
       .where(eq(sequenceEmails.id, sequenceEmailId));
-    return;
-  }
 
-  await db
-    .update(sequenceEmails)
-    .set({ status: "sent", sentAt: now, sentEmailId: sentId })
-    .where(eq(sequenceEmails.id, sequenceEmailId));
+    // Treat as terminal for enrollment completion: fall through to the same
+    // remaining-step check below so an enrollment whose only outstanding step
+    // was suppressed still gets completed.
+  } else {
+    const result = sendResult.result!;
+
+    // Store sent email record
+    const sentId = nanoid();
+    await db.insert(sentEmails).values({
+      id: sentId,
+      personId: person.id,
+      fromAddress,
+      toAddress: person.email,
+      subject: renderedSubject,
+      bodyHtml: renderedHtml,
+      bodyText: null,
+      messageId,
+      resendId: result.id,
+      status: result.error ? "failed" : "sent",
+      sentAt: now,
+      createdAt: now,
+    });
+
+    // Update outbox row
+    if (result.error) {
+      await db
+        .update(sequenceEmails)
+        .set({ status: "failed" })
+        .where(eq(sequenceEmails.id, sequenceEmailId));
+      return;
+    }
+
+    await db
+      .update(sequenceEmails)
+      .set({ status: "sent", sentAt: now, sentEmailId: sentId })
+      .where(eq(sequenceEmails.id, sequenceEmailId));
+  }
 
   // Check if this was the last step — if so, mark enrollment completed
   const remainingPending = await db

--- a/worker/src/lib/sequence-processor.ts
+++ b/worker/src/lib/sequence-processor.ts
@@ -200,9 +200,12 @@ export async function processSequenceEmail(
         suppressed: sendResult.suppressed,
       }),
     );
+    // sentAt's semantic is "time the transport was called" — no transport
+    // call happened on a suppressed step, so leave sentAt alone (it should
+    // stay null).
     await db
       .update(sequenceEmails)
-      .set({ status: "suppressed", sentAt: now })
+      .set({ status: "suppressed" })
       .where(eq(sequenceEmails.id, sequenceEmailId));
 
     // Treat as terminal for enrollment completion: fall through to the same
@@ -211,7 +214,9 @@ export async function processSequenceEmail(
   } else {
     const result = sendResult.result!;
 
-    // Store sent email record
+    // Store sent email record. The helper may have mutated the body to
+    // interpolate {{unsubscribe_url}} or auto-append a footer — record
+    // exactly what was on the wire, not the pre-helper template render.
     const sentId = nanoid();
     await db.insert(sentEmails).values({
       id: sentId,
@@ -219,8 +224,8 @@ export async function processSequenceEmail(
       fromAddress,
       toAddress: person.email,
       subject: renderedSubject,
-      bodyHtml: renderedHtml,
-      bodyText: null,
+      bodyHtml: sendResult.renderedHtml ?? renderedHtml,
+      bodyText: sendResult.renderedText ?? null,
       messageId,
       resendId: result.id,
       status: result.error ? "failed" : "sent",

--- a/worker/src/lib/suppressions.ts
+++ b/worker/src/lib/suppressions.ts
@@ -1,0 +1,17 @@
+import { eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { schema } from "../db/schema";
+import { suppressions } from "../db/suppressions.schema";
+
+export type Database = DrizzleD1Database<typeof schema>;
+
+export async function isSuppressed(
+  db: Database,
+  email: string,
+): Promise<boolean> {
+  const row = await db.query.suppressions.findFirst({
+    where: eq(suppressions.email, email.toLowerCase()),
+    columns: { id: true },
+  });
+  return !!row;
+}

--- a/worker/src/lib/unsubscribe-token.ts
+++ b/worker/src/lib/unsubscribe-token.ts
@@ -1,0 +1,73 @@
+const encoder = new TextEncoder();
+
+function b64urlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function b64urlDecode(s: string): Uint8Array | null {
+  try {
+    const pad = "=".repeat((4 - (s.length % 4)) % 4);
+    const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+export async function signToken(email: string, secret: string): Promise<string> {
+  const payload = JSON.stringify({ e: email.toLowerCase(), v: 1 });
+  const payloadBytes = encoder.encode(payload);
+  const key = await hmacKey(secret);
+  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, payloadBytes));
+  return `${b64urlEncode(payloadBytes)}.${b64urlEncode(sig)}`;
+}
+
+export async function verifyToken(
+  token: string,
+  secret: string,
+): Promise<{ email: string } | null> {
+  if (!token || typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [payloadEnc, sigEnc] = parts;
+
+  const payloadBytes = b64urlDecode(payloadEnc);
+  const sigBytes = b64urlDecode(sigEnc);
+  if (!payloadBytes || !sigBytes) return null;
+
+  const key = await hmacKey(secret);
+  const expected = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, payloadBytes),
+  );
+  if (!timingSafeEqual(sigBytes, expected)) return null;
+
+  try {
+    const decoded = JSON.parse(new TextDecoder().decode(payloadBytes));
+    if (typeof decoded?.e !== "string" || decoded?.v !== 1) return null;
+    return { email: decoded.e };
+  } catch {
+    return null;
+  }
+}

--- a/worker/src/lib/unsubscribe-token.ts
+++ b/worker/src/lib/unsubscribe-token.ts
@@ -36,11 +36,16 @@ function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
   return diff === 0;
 }
 
-export async function signToken(email: string, secret: string): Promise<string> {
+export async function signToken(
+  email: string,
+  secret: string,
+): Promise<string> {
   const payload = JSON.stringify({ e: email.toLowerCase(), v: 1 });
   const payloadBytes = encoder.encode(payload);
   const key = await hmacKey(secret);
-  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, payloadBytes));
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, payloadBytes),
+  );
   return `${b64urlEncode(payloadBytes)}.${b64urlEncode(sig)}`;
 }
 

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -8,6 +8,7 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { people } from "../db/people.schema";
 import { json200Response, json201Response } from "../lib/helpers";
 import { interpolate, extractVariables } from "../lib/interpolate";
+import { sendWithSuppressionCheck } from "../lib/send";
 import type { Variables } from "../variables";
 
 export const emailTemplatesRouter = new OpenAPIHono<{
@@ -302,9 +303,11 @@ const sendTemplateRoute = createRoute({
   responses: {
     ...json201Response(
       z.object({
-        id: z.string(),
+        id: z.string().nullable(),
         resendId: z.string().nullable(),
         status: z.string(),
+        delivered: z.array(z.string()),
+        suppressed: z.array(z.string()),
       }),
       "Email sent",
     ),
@@ -365,12 +368,36 @@ emailTemplatesRouter.openapi(sendTemplateRoute, async (c) => {
   const renderedHtml = interpolate(template.bodyHtml, variables);
 
   const sender = createEmailSender(c.env);
-  const result = await sender.send({
+  const sendResult = await sendWithSuppressionCheck({
+    db,
+    env: c.env,
+    sender,
     from: fromAddress,
     to,
     subject: renderedSubject,
     html: renderedHtml,
   });
+
+  // Recipient is on the suppression list — no transport call, no sent_emails
+  // write. Tell the admin caller so the UI can surface "suppressed".
+  if (sendResult.delivered.length === 0) {
+    console.log(
+      "[template-send] recipient suppressed",
+      JSON.stringify({ from: fromAddress, suppressed: sendResult.suppressed }),
+    );
+    return c.json(
+      {
+        id: null,
+        resendId: null,
+        status: "suppressed",
+        delivered: [],
+        suppressed: sendResult.suppressed,
+      },
+      201,
+    );
+  }
+
+  const result = sendResult.result!;
 
   // Find person if they exist
   const existingPerson = await db
@@ -403,6 +430,8 @@ emailTemplatesRouter.openapi(sendTemplateRoute, async (c) => {
       id,
       resendId: result.id,
       status: result.error ? "failed" : "sent",
+      delivered: sendResult.delivered,
+      suppressed: sendResult.suppressed,
     },
     201,
   );

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -417,8 +417,11 @@ emailTemplatesRouter.openapi(sendTemplateRoute, async (c) => {
     fromAddress,
     toAddress: to,
     subject: renderedSubject,
-    bodyHtml: renderedHtml,
-    bodyText: null,
+    // Record what was on the wire (helper may have interpolated
+    // {{unsubscribe_url}} or auto-appended a footer), not the pre-helper
+    // template render.
+    bodyHtml: sendResult.renderedHtml ?? renderedHtml,
+    bodyText: sendResult.renderedText ?? null,
     resendId: result.id,
     status: result.error ? "failed" : "sent",
     sentAt: now,

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -17,6 +17,7 @@ import { generateMessageId } from "../lib/message-id";
 import { computeConversationId, externalsOnly } from "../lib/conversation-id";
 import { parseSendBody, sendParseErrorResponse } from "../lib/multipart-send";
 import { attachments } from "../db/attachments.schema";
+import { sendWithSuppressionCheck } from "../lib/send";
 
 /**
  * Fetch the set of "internal" domains (domains owned by our
@@ -114,14 +115,22 @@ const SendEmailSchema = z
         "Address that receives the response when the recipient hits Reply. If omitted, replies go to fromAddress. Useful for contact-form-style flows where messages are sent from a tenant-owned address like noreply@ but replies should go to the actual submitter.",
       example: "submitter@example.com",
     }),
+    // Transactional sends bypass the suppression list (password resets, OTPs,
+    // receipts). Marketing-style sends default to false and respect the list.
+    transactional: z.boolean().optional().default(false).openapi({
+      description:
+        "When true, bypasses the suppression list (for transactional mail like password resets, OTPs, and receipts). Defaults to false, which respects the suppression list.",
+    }),
   })
   .openapi("SendEmailSchema");
 
 const SentEmailResponseSchema = z.object({
-  id: z.string(),
+  id: z.string().nullable(),
   resendId: z.string().nullable(),
   status: z.string(),
   attachmentIds: z.array(z.string()),
+  delivered: z.array(z.string()).default([]),
+  suppressed: z.array(z.string()).default([]),
 });
 
 // Compose and send a new email
@@ -186,7 +195,7 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     email: c.email.trim().toLowerCase(),
     name: c.name ?? null,
   }));
-  const { subject, bodyHtml, bodyText } = raw;
+  const { subject, bodyHtml, bodyText, transactional } = raw;
   const replyTo = raw.replyTo?.trim().toLowerCase();
   const allowed = c.get("allowedInboxes")!;
   assertInboxAllowed(allowed, fromAddress);
@@ -195,10 +204,24 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
   const messageId = generateMessageId(fromAddress);
   const formattedFrom = await formatFromAddress(db, fromAddress);
 
-  const result = await sender.send({
+  const ccHeaderList =
+    cc && cc.length > 0 ? cc.map(formatCc) : undefined;
+  const attachmentList =
+    files.length > 0
+      ? files.map((f) => ({
+          filename: f.filename,
+          contentType: f.contentType,
+          content: f.bytes,
+        }))
+      : undefined;
+
+  const sendResult = await sendWithSuppressionCheck({
+    db,
+    env: c.env,
+    sender,
     from: formattedFrom,
     to,
-    ...(cc && cc.length > 0 ? { cc: cc.map(formatCc) } : {}),
+    cc: ccHeaderList,
     subject,
     html: bodyHtml,
     text: bodyText,
@@ -206,16 +229,33 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
       "Message-ID": messageId,
       ...(replyTo ? { "Reply-To": replyTo } : {}),
     },
-    ...(files.length > 0
-      ? {
-          attachments: files.map((f) => ({
-            filename: f.filename,
-            contentType: f.contentType,
-            content: f.bytes,
-          })),
-        }
-      : {}),
+    attachments: attachmentList,
+    transactional,
   });
+
+  // Every recipient was suppressed — no send happened. Skip sent_emails write
+  // and sequence cancellation. Log the dropped recipients so they appear in
+  // worker logs for v1 (no audit-table write yet).
+  if (sendResult.delivered.length === 0) {
+    console.log(
+      "[send] all recipients suppressed",
+      JSON.stringify({ from: fromAddress, suppressed: sendResult.suppressed }),
+    );
+    return c.json(
+      {
+        id: null,
+        resendId: null,
+        status: "suppressed",
+        attachmentIds: [],
+        delivered: [],
+        suppressed: sendResult.suppressed,
+      },
+      201,
+    );
+  }
+
+  // The transport was called; reflect its result in sent_emails.
+  const result = sendResult.result!;
 
   // Find or create the person row for this recipient.
   const existingPerson = await db
@@ -287,6 +327,8 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
       resendId: result.id,
       status: result.error ? "failed" : "sent",
       attachmentIds,
+      delivered: sendResult.delivered,
+      suppressed: sendResult.suppressed,
     },
     201,
   );

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -204,8 +204,6 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
   const messageId = generateMessageId(fromAddress);
   const formattedFrom = await formatFromAddress(db, fromAddress);
 
-  const ccHeaderList =
-    cc && cc.length > 0 ? cc.map(formatCc) : undefined;
   const attachmentList =
     files.length > 0
       ? files.map((f) => ({
@@ -221,7 +219,7 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     sender,
     from: formattedFrom,
     to,
-    cc: ccHeaderList,
+    cc,
     subject,
     html: bodyHtml,
     text: bodyText,
@@ -501,13 +499,21 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
 
   const messageId = generateMessageId(fromAddress);
   const formattedFrom = await formatFromAddress(db, fromAddress);
-  const result = await sender.send({
+  // Replies are 1:1 conversational responses to an inbound — the recipient
+  // initiated by emailing first, so route through sendWithSuppressionCheck
+  // with transactional: true. That bypasses the suppression list AND skips
+  // the unsubscribe footer / List-Unsubscribe header (this is a reply, not
+  // a bulk send).
+  const sendResult = await sendWithSuppressionCheck({
+    db,
+    env: c.env,
+    sender,
     from: formattedFrom,
     to: toAddress,
-    ...(cc && cc.length > 0 ? { cc: cc.map(formatCc) } : {}),
+    cc,
     subject: finalSubject,
     html: finalBodyHtml,
-    text: bodyText,
+    ...(bodyText !== undefined ? { text: bodyText } : {}),
     headers: {
       "Message-ID": messageId,
       ...(origInReplyToMessageId
@@ -524,7 +530,10 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
           })),
         }
       : {}),
+    transactional: true,
   });
+  // transactional: true always yields delivered=[to], suppressed=[].
+  const result = sendResult.result!;
 
   // Compute conversation_id for this reply.
   const internalDomainsReply = await fetchInternalDomains(db);

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -231,10 +231,19 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     transactional,
   });
 
-  // Every recipient was suppressed — no send happened. Skip sent_emails write
-  // and sequence cancellation. Log the dropped recipients so they appear in
-  // worker logs for v1 (no audit-table write yet).
+  // Every recipient was suppressed — no send happened. Skip sent_emails write,
+  // but still cancel any pending sequence enrollments for the recipient so we
+  // stop scheduling steps that will all individually re-suppress at dispatch.
   if (sendResult.delivered.length === 0) {
+    const existingPerson = await db
+      .select({ id: people.id })
+      .from(people)
+      .where(eq(people.email, to))
+      .limit(1);
+    if (existingPerson[0]) {
+      await cancelSequencesForPerson(db, existingPerson[0].id);
+    }
+
     console.log(
       "[send] all recipients suppressed",
       JSON.stringify({ from: fromAddress, suppressed: sendResult.suppressed }),
@@ -254,12 +263,16 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
 
   // The transport was called; reflect its result in sent_emails.
   const result = sendResult.result!;
+  // When the primary `to` was suppressed, the helper promoted a surviving cc
+  // to be the actual primary recipient. Use that for audit + person lookup so
+  // the row reflects who actually got the email.
+  const recordedTo = sendResult.delivered[0];
 
-  // Find or create the person row for this recipient.
+  // Find or create the person row for the actual recipient.
   const existingPerson = await db
     .select({ id: people.id })
     .from(people)
-    .where(eq(people.email, to))
+    .where(eq(people.email, recordedTo))
     .limit(1);
 
   let personId: string;
@@ -271,7 +284,7 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
       .insert(people)
       .values({
         id: personId,
-        email: to,
+        email: recordedTo,
         name: null,
         lastEmailAt: now,
         unreadCount: 0,
@@ -283,14 +296,14 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     const refetched = await db
       .select({ id: people.id })
       .from(people)
-      .where(eq(people.email, to))
+      .where(eq(people.email, recordedTo))
       .limit(1);
     personId = refetched[0]!.id;
   }
 
   const internalDomains = await fetchInternalDomains(db);
   const externals = externalsOnly(
-    [to, ...(cc ?? []).map((c) => c.email)],
+    [recordedTo, ...(cc ?? []).map((c) => c.email)],
     internalDomains,
   );
   const conversationId = await computeConversationId(fromAddress, externals);
@@ -300,10 +313,10 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     id,
     personId,
     fromAddress,
-    toAddress: to,
+    toAddress: recordedTo,
     subject,
-    bodyHtml,
-    bodyText: bodyText ?? null,
+    bodyHtml: sendResult.renderedHtml ?? bodyHtml,
+    bodyText: sendResult.renderedText ?? bodyText ?? null,
     messageId,
     resendId: result.id,
     status: result.error ? "failed" : "sent",

--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -675,7 +675,12 @@ sequencesRouter.openapi(listEnrollmentsRoute, async (c) => {
       personEmail: personRow[0]?.email ?? "unknown",
       personName: personRow[0]?.name ?? null,
       totalSteps: emailRows.length,
-      sentSteps: emailRows.filter((e) => e.status === "sent").length,
+      // 'suppressed' is a completed-but-not-delivered terminal state —
+      // count it toward sentSteps so completed-via-suppression enrollments
+      // show full progress in the UI.
+      sentSteps: emailRows.filter(
+        (e) => e.status === "sent" || e.status === "suppressed",
+      ).length,
     });
   }
 

--- a/worker/src/routers/suppressions-router.ts
+++ b/worker/src/routers/suppressions-router.ts
@@ -1,0 +1,219 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { desc, eq, lt } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { suppressions } from "../db/suppressions.schema";
+import { json200Response, json201Response } from "../lib/helpers";
+import type { Variables } from "../variables";
+
+export const suppressionsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+// --- Schemas ---
+
+const SuppressionSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  reason: z.enum(["unsubscribe", "manual"]),
+  source: z.string().nullable(),
+  note: z.string().nullable(),
+  createdAt: z.number(),
+});
+
+const ListResponseSchema = z.object({
+  items: z.array(SuppressionSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const CreateSuppressionSchema = z.object({
+  email: z.string().email(),
+});
+
+const DeleteResponseSchema = z.object({
+  deleted: z.literal(true),
+});
+
+const ErrorSchema = z.object({ error: z.string() });
+
+// --- GET /api/suppressions ---
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Suppressions"],
+  description:
+    "List suppressions, newest first. Cursor-based pagination via `cursor` (the `createdAt` of the last item returned).",
+  request: {
+    query: z.object({
+      cursor: z.string().optional(),
+      limit: z.string().optional(),
+    }),
+  },
+  responses: {
+    ...json200Response(ListResponseSchema, "List of suppressions"),
+  },
+});
+
+suppressionsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const { cursor, limit: limitRaw } = c.req.valid("query");
+
+  let limit = DEFAULT_LIMIT;
+  if (limitRaw) {
+    const parsed = Number.parseInt(limitRaw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      limit = Math.min(parsed, MAX_LIMIT);
+    }
+  }
+
+  const whereClause = cursor
+    ? lt(suppressions.createdAt, Number.parseInt(cursor, 10))
+    : undefined;
+
+  const rows = await db
+    .select()
+    .from(suppressions)
+    .where(whereClause)
+    .orderBy(desc(suppressions.createdAt))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor =
+    hasMore && items.length > 0
+      ? String(items[items.length - 1].createdAt)
+      : null;
+
+  return c.json(
+    {
+      items: items.map((r) => ({
+        id: r.id,
+        email: r.email,
+        reason: r.reason,
+        source: r.source,
+        note: r.note,
+        createdAt: r.createdAt,
+      })),
+      nextCursor,
+    },
+    200,
+  );
+});
+
+// --- POST /api/suppressions ---
+
+const createRouteDef = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Suppressions"],
+  description:
+    "Add a manual suppression. Idempotent: returns 200 + the existing row if the email is already suppressed.",
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateSuppressionSchema } },
+    },
+  },
+  responses: {
+    ...json200Response(SuppressionSchema, "Existing suppression returned"),
+    ...json201Response(SuppressionSchema, "Suppression created"),
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+suppressionsRouter.openapi(createRouteDef, async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const { email: rawEmail } = c.req.valid("json");
+
+  const email = rawEmail.trim().toLowerCase();
+
+  // If already suppressed, return the existing row (idempotent).
+  const existing = await db
+    .select()
+    .from(suppressions)
+    .where(eq(suppressions.email, email))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const row = existing[0];
+    return c.json(
+      {
+        id: row.id,
+        email: row.email,
+        reason: row.reason,
+        source: row.source,
+        note: row.note,
+        createdAt: row.createdAt,
+      },
+      200,
+    );
+  }
+
+  const id = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+  const source = `admin:${user.email}`;
+
+  await db
+    .insert(suppressions)
+    .values({
+      id,
+      email,
+      reason: "manual",
+      source,
+      note: null,
+      createdAt: now,
+    })
+    .onConflictDoNothing({ target: suppressions.email });
+
+  // Re-fetch in case a concurrent insert won the race.
+  const row = (
+    await db
+      .select()
+      .from(suppressions)
+      .where(eq(suppressions.email, email))
+      .limit(1)
+  )[0];
+
+  return c.json(
+    {
+      id: row.id,
+      email: row.email,
+      reason: row.reason,
+      source: row.source,
+      note: row.note,
+      createdAt: row.createdAt,
+    },
+    row.id === id ? 201 : 200,
+  );
+});
+
+// --- DELETE /api/suppressions/:id ---
+
+const deleteRouteDef = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Suppressions"],
+  description:
+    "Remove a suppression by id. Idempotent — returns 200 even if the row doesn't exist.",
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    ...json200Response(DeleteResponseSchema, "Suppression deleted (or absent)"),
+  },
+});
+
+suppressionsRouter.openapi(deleteRouteDef, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  await db.delete(suppressions).where(eq(suppressions.id, id));
+  return c.json({ deleted: true as const }, 200);
+});
+

--- a/worker/src/routers/suppressions-router.ts
+++ b/worker/src/routers/suppressions-router.ts
@@ -216,4 +216,3 @@ suppressionsRouter.openapi(deleteRouteDef, async (c) => {
   await db.delete(suppressions).where(eq(suppressions.id, id));
   return c.json({ deleted: true as const }, 200);
 });
-

--- a/worker/src/routers/unsubscribe-router.ts
+++ b/worker/src/routers/unsubscribe-router.ts
@@ -1,0 +1,137 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { suppressions } from "../db/suppressions.schema";
+import { verifyToken } from "../lib/unsubscribe-token";
+import { json200Response } from "../lib/helpers";
+import type { Variables } from "../variables";
+
+export const unsubscribeRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+// --- Schemas ---
+
+const UnsubscribeResponseSchema = z.object({
+  email: z.string(),
+  status: z.enum(["suppressed", "subscribed"]),
+});
+
+const ErrorSchema = z.object({ error: z.string() });
+
+// --- POST /api/unsubscribe ---
+//
+// Public, token-authenticated endpoint. Records a suppression row for the
+// email encoded in the HMAC token. Used for both List-Unsubscribe one-click
+// POSTs (RFC 8058) and user-driven links in transactional/marketing emails.
+// Idempotent: replaying with the same token does not duplicate the row or
+// overwrite the original `source`.
+
+const unsubscribeRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Unsubscribe"],
+  description:
+    "Record a suppression from a signed unsubscribe token. Idempotent.",
+  request: {
+    query: z.object({
+      token: z.string(),
+      source: z.enum(["one-click", "user-link"]).optional(),
+    }),
+  },
+  responses: {
+    ...json200Response(
+      UnsubscribeResponseSchema,
+      "Suppression recorded (or already present)",
+    ),
+    401: {
+      description: "Invalid or tampered token",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+unsubscribeRouter.openapi(unsubscribeRoute, async (c) => {
+  const { token, source } = c.req.valid("query");
+
+  const result = await verifyToken(token, c.env.UNSUBSCRIBE_SECRET);
+  if (!result) {
+    return c.json({ error: "Invalid token" }, 401);
+  }
+
+  const email = result.email.toLowerCase();
+  const db = c.get("db");
+
+  const existing = await db
+    .select()
+    .from(suppressions)
+    .where(eq(suppressions.email, email))
+    .limit(1);
+
+  if (existing.length > 0) {
+    // Idempotent — do not overwrite the original source/note.
+    return c.json(
+      { email, status: "suppressed" as const },
+      200,
+    );
+  }
+
+  await db
+    .insert(suppressions)
+    .values({
+      id: nanoid(),
+      email,
+      reason: "unsubscribe",
+      source: source ?? "one-click",
+      note: null,
+      createdAt: Math.floor(Date.now() / 1000),
+    })
+    .onConflictDoNothing({ target: suppressions.email });
+
+  return c.json({ email, status: "suppressed" as const }, 200);
+});
+
+// --- POST /api/unsubscribe/undo ---
+//
+// Public, token-authenticated endpoint. Removes the suppression row for the
+// email encoded in the HMAC token. Idempotent — deleting an already-absent
+// row succeeds.
+
+const undoRoute = createRoute({
+  method: "post",
+  path: "/undo",
+  tags: ["Unsubscribe"],
+  description: "Remove a suppression via signed token. Idempotent.",
+  request: {
+    query: z.object({
+      token: z.string(),
+    }),
+  },
+  responses: {
+    ...json200Response(
+      UnsubscribeResponseSchema,
+      "Suppression removed (or already absent)",
+    ),
+    401: {
+      description: "Invalid or tampered token",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+unsubscribeRouter.openapi(undoRoute, async (c) => {
+  const { token } = c.req.valid("query");
+
+  const result = await verifyToken(token, c.env.UNSUBSCRIBE_SECRET);
+  if (!result) {
+    return c.json({ error: "Invalid token" }, 401);
+  }
+
+  const email = result.email.toLowerCase();
+  const db = c.get("db");
+
+  await db.delete(suppressions).where(eq(suppressions.email, email));
+
+  return c.json({ email, status: "subscribed" as const }, 200);
+});

--- a/worker/src/routers/unsubscribe-router.ts
+++ b/worker/src/routers/unsubscribe-router.ts
@@ -71,10 +71,7 @@ unsubscribeRouter.openapi(unsubscribeRoute, async (c) => {
 
   if (existing.length > 0) {
     // Idempotent — do not overwrite the original source/note.
-    return c.json(
-      { email, status: "suppressed" as const },
-      200,
-    );
+    return c.json({ email, status: "suppressed" as const }, 200);
   }
 
   await db


### PR DESCRIPTION
## Summary

Implements part 1 of #94 — suppression list, send-path check, and user-initiated unsubscribe surface. Async bounce/complaint intake remains deferred to part 2 (per the issue).

Deployed and smoke-tested on two real Cloudflare instances (`mail.redleg.dev` and `mail.esferas.io`) before this PR, including the Fastmail one-click flow.

## What's in this PR

- New `suppressions` D1 table (Drizzle schema at `worker/src/db/suppressions.schema.ts` + auto-generated migration `0026_kind_miracleman.sql`).
- `worker/src/lib/suppressions.ts` — `isSuppressed(db, email)` with case-insensitive exact-match lookup (no Gmail-style `+tag` or dot stripping; matches Resend's behavior).
- `worker/src/lib/unsubscribe-token.ts` — HMAC-SHA256 signed stateless tokens, format `base64url(payload).base64url(sig)`, with `{v:1}` versioning so the format can evolve. No DB writes per send, no expiry — an old email's link still works.
- `worker/src/lib/send.ts` — `sendWithSuppressionCheck` helper that wraps the transport. Single source of truth for every dispatch path. Partitions recipients (`to` + each `cc`), injects `{{unsubscribe_url}}` interpolation and an auto-append fallback footer (HTML + plaintext) on marketing sends, sets `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers. The transport is called at most once.
- `worker/src/routers/unsubscribe-router.ts` — public `POST /unsubscribe` and `POST /unsubscribe/undo` endpoints (token-auth, no session). Mounted at both `/api/unsubscribe` (used by the SPA's mount-time POST) AND `/unsubscribe` (for RFC 8058 one-click POSTs from mail clients — the URL in the `List-Unsubscribe` header is the same as the body link, and one-click clients POST to it directly).
- `worker/src/routers/suppressions-router.ts` — admin `GET` / `POST` / `DELETE` at `/api/suppressions`, guarded by the existing `requireAdmin` middleware. Paginated, cursor-based.
- Refactor: `/api/send`, the sequence-step queue consumer (`processSequenceEmail`), and the template-preview endpoint all now route through `sendWithSuppressionCheck`. The `sequence_emails.status` column gains the value `suppressed` (no migration — column is free-text).
- Frontend: public SPA page at `/unsubscribe` (mounts → JS-mediated POST → success + Re-subscribe button → optional undo). Admin page at `/admin/suppressions` with paginated list + add/remove modals, matching `AdminUsersPage` conventions (imperative fetch + `useState`, Radix Dialog, existing color tokens).
- `transactional: boolean` flag added to the `/api/send` request body and `suppressed: string[]` added to the response so callers can distinguish account-critical mail from marketing.

## Behavior shift for API integrators

⚠️ Sends through `POST /api/send` now have `List-Unsubscribe` headers added and (if the body lacks `{{unsubscribe_url}}`) an unsubscribe footer auto-appended **unless** the caller passes `transactional: true`. To preserve previous behavior for account-critical mail (password resets, OTPs, system notifications), set the flag explicitly. CHANGELOG and README document this.

Additionally, the `id` field on the `/api/send` response is now nullable. When every recipient is suppressed, the response is `{ id: null, status: "suppressed", delivered: [], suppressed: [...] }` with no transport call.

## New configuration

- `UNSUBSCRIBE_SECRET` — Worker secret used to HMAC-sign unsubscribe tokens. Set via `wrangler secret put UNSUBSCRIBE_SECRET`. Generate with `openssl rand -hex 32`.
- The existing `BASE_URL` var is reused to build absolute unsubscribe URLs — no new `APP_URL` introduced.

`.dev.vars.example` and the README setup section both updated.

## Out of scope (deferred to part 2 of #94)

- Async bounce + complaint intake (DSN/ARF parsing via Cloudflare Email Routing or Resend webhooks)
- CSV bulk import/export of the suppression list
- Per-list / per-sequence suppression scoping (no list concept exists yet)
- Preference center on the unsubscribe page
- `mailto:` form in `List-Unsubscribe` (HTTPS-only in v1; wiring up the mailto requires the inbound-email infrastructure from part 2)
- Search/filter on the admin UI (intentional v1 cut — easy follow-up)

## Test plan

- [x] All 288 existing tests still green; added 43 new tests across helpers and routers (final count: 331 passing, 1 skipped). `yarn tsc --noEmit` clean.
- [x] Unit tests: `isSuppressed` (case-insensitivity, no `+tag` stripping), `unsubscribe-token` (round-trip, tampered sig, tampered payload, wrong secret, malformed input never throws), per-recipient token correctness on `sendWithSuppressionCheck` (regression test for an earlier bug where a single token was reused across cc-promoted recipients).
- [x] Integration tests: suppressions CRUD with admin and non-admin auth, public unsubscribe + undo with token validation, idempotency on both directions, source detection (`one-click` vs `user-link` query param), POST works at both `/api/unsubscribe` and `/unsubscribe` mount points.
- [x] Send-router tests: `transactional: true` bypasses; suppressed recipients surface in response; sent_emails row skipped when no transport call.
- [x] Sequence-processor tests: suppressed recipient → status `suppressed`, no transport call, no sent_emails row, enrollment still completes.
- [x] Deployed to `mail.redleg.dev` and `mail.esferas.io`. Verified end-to-end on Fastmail (body link + native header one-click), Gmail, and direct curl. Confirmed `List-Unsubscribe` headers visible via "Show original".

## Notes for reviewers

- The `/unsubscribe` mount (in addition to `/api/unsubscribe`) was added to handle RFC 8058 one-click POSTs from mail clients. The URL placed in the `List-Unsubscribe` header is the same URL as the body link (`/unsubscribe?token=...`), so the same URL serves both the human GET (→ SPA confirmation page) and the machine POST (→ writes the suppression). Different mount points would mean two URLs in the email; sharing the URL is simpler and gives the cleanest user experience.
- Token format is intentionally stateless. The trade-off is no individual revocation, which is the right choice for unsubscribe — a one-year-old email's link should still work.
- `sendWithSuppressionCheck` lives above the transport (in `lib/`, called by routers and the queue consumer) rather than inside the `EmailSender` interface. The transport abstraction is about *how* mail is sent; suppression is policy. Future transports inherit the policy automatically without re-implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)