### PR TITLE
feat(email): add bavimail send provider

### DIFF
--- a/.claude/skills/saasmail-onboarding/SKILL.md
+++ b/.claude/skills/saasmail-onboarding/SKILL.md
@@ -16,7 +16,7 @@ Read `wrangler.jsonc.example` in the project root so you know the exact shape of
 Set expectations up front, so the user knows what they're committing to:
 
 - **~30–40 minutes** total; most of the wait is DNS propagation, not typing.
-- **Two decisions**: which domains will be used, and which outbound email provider (Cloudflare Email Sending or Resend).
+- **Two decisions**: which domains will be used, and which outbound email provider (Cloudflare Email Sending, Resend, or Bavimail).
 - **Three manual Cloudflare-dashboard steps** (Email Routing per inbound domain, Email Service per send-from domain, and checking the deployed worker).
 - **Cost**: a Cloudflare **Workers Paid plan (~$5/mo)** is required. saasmail uses Queues, which aren't on the free plan. Email Routing is free; Cloudflare Email Sending is usage-based.
 
@@ -80,8 +80,9 @@ Most single-domain setups use the same domain for all three, with the UI on a su
 
 - **Option A — Cloudflare Email Sending** (default; recommended for a pure-Cloudflare setup). Uses the `send_email` binding. Each send-from domain must be onboarded in Cloudflare Email Service (Step 8 below).
 - **Option B — Resend**. Set `RESEND_API_KEY` as a secret. Each send-from domain must be verified in the Resend dashboard instead.
+- **Option C — Bavimail**. Set both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` as secrets. The alias ID identifies the sending alias configured in the Bavimail dashboard, which is also where each send-from domain is verified.
 
-At runtime, if `RESEND_API_KEY` is set, Resend wins; otherwise the `send_email` binding is used. Default the user to Option A unless they already have a Resend account and prefer it.
+Runtime precedence: **Bavimail** wins when both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` are set; otherwise **Resend** wins when `RESEND_API_KEY` is set; otherwise the `send_email` binding is used. Default the user to Option A unless they already have a Resend or Bavimail account and prefer it.
 
 ## Deployment Steps
 
@@ -184,7 +185,16 @@ wrangler secret put RESEND_API_KEY
 
 Paste the Resend API key (from https://resend.com/api-keys) when prompted.
 
-Do **not** set `RESEND_API_KEY` for Option A — its mere presence tells saasmail to use Resend, overriding the `send_email` binding.
+If Decision 2 is **Option C (Bavimail)**, run both of these:
+
+```bash
+wrangler secret put BAVIMAIL_API_KEY
+wrangler secret put BAVIMAIL_ALIAS_ID
+```
+
+Paste the Bavimail API bearer token and alias UUID (from the Bavimail dashboard) when prompted. Both must be set — if only one is present, saasmail falls through to Resend or the `send_email` binding.
+
+Do **not** set `RESEND_API_KEY` for Option A or C — its mere presence tells saasmail to use Resend, overriding the `send_email` binding. Likewise, do **not** set the Bavimail secrets for Option A or B — Bavimail wins over both when both Bavimail vars are present.
 
 ### Step 6: Apply Database Migrations
 
@@ -269,6 +279,8 @@ If the worker isn't in the dropdown, Step 7 didn't actually succeed — go back 
 
 **Option B (Resend)**: verify each send-from domain in the Resend dashboard → **Domains → Add Domain**, and add the DKIM/SPF records Resend provides. Then skip the rest of this step.
 
+**Option C (Bavimail)**: verify each send-from domain in the Bavimail dashboard, add the DKIM/SPF records it provides, and confirm the sending alias (whose ID you set as `BAVIMAIL_ALIAS_ID`) is attached to the verified domain. Then skip the rest of this step.
+
 **Option A (Cloudflare Email Sending)**: repeat for each send-from domain from Decision 1:
 
 1. Open [Email Service](https://dash.cloudflare.com/?to=/:account/email-service) — **account-level**, not a per-zone setting.
@@ -291,7 +303,7 @@ Show the user exactly what was set up, substituting their real values:
 
 - Worker deployed at `<BASE_URL>`
 - Inbound: Cloudflare Email Routing → worker, on `<inbound domain(s)>`
-- Outbound: `<Cloudflare Email Sending | Resend>`, from `<send-from domain(s)>`
+- Outbound: `<Cloudflare Email Sending | Resend | Bavimail>`, from `<send-from domain(s)>`
 - D1 database `saasmail-db` (binding `DB`)
 - R2 bucket `saasmail-attachments` (binding `R2`)
 - Queue `saasmail-sequence-emails` (binding `EMAIL_QUEUE`)
@@ -302,6 +314,6 @@ Show the user exactly what was set up, substituting their real values:
 - **`wrangler queues create` fails with a plan error** — Workers Paid plan isn't actually active. Recheck at https://dash.cloudflare.com/?to=/:account/workers/plans.
 - **Worker missing from Email Routing "Send to a Worker" dropdown** — Step 7 didn't succeed, or the dashboard is cached. Run `wrangler deployments list` to confirm, then refresh the dashboard.
 - **Inbound test email never arrives** — MX records haven't propagated, or the catch-all isn't saved. Email Routing **Overview** should say status **Active**; `dig MX <inbound domain>` should return `*.mx.cloudflare.net` hosts.
-- **Outbound email looks sent but never arrives** — the send-from domain isn't verified. Check Email Service (Option A) or Resend → Domains (Option B); status must read **Verified**.
+- **Outbound email looks sent but never arrives** — the send-from domain isn't verified. Check Email Service (Option A), Resend → Domains (Option B), or the Bavimail dashboard (Option C); status must read **Verified**.
 - **Locked out after sign-up** — passkey enrollment wasn't completed. Sign in again and finish the prompt; the server requires a passkey for `/api/*` in production.
 - **`BASE_URL` serves a blank Cloudflare page instead of saasmail** — the `routes` block in `wrangler.jsonc` wasn't uncommented, or `custom_domain: true` is missing. Fix and redeploy.

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,8 @@
+# Outbound provider — Bavimail takes precedence over Resend and Cloudflare
+# Email Sending when BOTH BAVIMAIL_API_KEY and BAVIMAIL_ALIAS_ID are set.
+BAVIMAIL_API_KEY=
+BAVIMAIL_ALIAS_ID=
+
 RESEND_API_KEY=re_xxxx
 BETTER_AUTH_SECRET=generate-a-random-secret
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Every interaction with a customer matters, and context compounds. saasmail pulls the promo blast, the billing receipt, and the support thread into the same conversation, so anyone on your team can respond with the full history already in hand.
 
-Self-hosted on Cloudflare Workers. Receive with **Cloudflare Email Workers**. Send with **Cloudflare Email Sending** or **Resend**.
+Self-hosted on Cloudflare Workers. Receive with **Cloudflare Email Workers**. Send with **Cloudflare Email Sending**, **Resend**, or **Bavimail**.
 
 <img alt="saasmail" src="docs/screenshots/saasmail.jpeg" />
 
@@ -29,17 +29,18 @@ https://github.com/user-attachments/assets/fe3a3811-1902-4b0b-8b94-f8c72f1afab4
 
 ## Provider Matrix
 
-|               | Cloudflare | Resend |
-| ------------- | ---------- | ------ |
-| **Sending**   | ✅         | ✅     |
-| **Receiving** | ✅         | ❌     |
+|               | Cloudflare | Resend | Bavimail |
+| ------------- | ---------- | ------ | -------- |
+| **Sending**   | ✅         | ✅     | ✅       |
+| **Receiving** | ✅         | ❌     | ❌       |
 
 Pick one outbound provider at deploy time:
 
 - **Cloudflare Email Sending** — add a `send_email` binding (`EMAIL`) in `wrangler.jsonc` and onboard your domain at [Email Service](https://dash.cloudflare.com/?to=/:account/email-service).
 - **Resend** — set `RESEND_API_KEY` as a secret.
+- **Bavimail** — set `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` as secrets. The alias ID identifies the sending alias configured in your Bavimail dashboard.
 
-If `RESEND_API_KEY` is set it takes precedence; otherwise the `EMAIL` binding is used. If neither is configured, send attempts return a "No email provider configured" error.
+Selection precedence at runtime: **Bavimail** (when both env vars are set) > **Resend** (when `RESEND_API_KEY` is set) > **Cloudflare Email Sending** (when the `EMAIL` binding exists). If none are configured, send attempts return a "No email provider configured" error.
 
 ## How much does it cost?
 
@@ -87,7 +88,7 @@ Issue scoped API keys for programmatic access to send email, manage templates, e
 | Layer               | Technology                                                                |
 | ------------------- | ------------------------------------------------------------------------- |
 | **Receive email**   | Cloudflare Email Workers                                                  |
-| **Send email**      | Cloudflare Email Sending or Resend                                        |
+| **Send email**      | Cloudflare Email Sending, Resend, or Bavimail                             |
 | **Runtime**         | Cloudflare Workers + Hono                                                 |
 | **API**             | Zod + `@hono/zod-openapi` (OpenAPI 3.1)                                   |
 | **Database**        | Cloudflare D1 (SQLite)                                                    |
@@ -154,6 +155,7 @@ Don't have Claude Code? The manual steps below cover the same ground.
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) (`npm install -g wrangler`)
 - A [Cloudflare](https://dash.cloudflare.com/) account with Email Routing available for your domain
 - _Optional:_ a [Resend](https://resend.com/) account and API key (only if you prefer Resend over Cloudflare Email Sending)
+- _Optional:_ a [Bavimail](https://bavimail.com/) account, API key, and alias ID (only if you prefer Bavimail)
 
 ### 1. Clone and install
 
@@ -208,14 +210,17 @@ cp .dev.vars.example .dev.vars
 
 Edit `.dev.vars`:
 
-- `RESEND_API_KEY` — your Resend API key (omit if using Cloudflare Email Sending)
+- `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` — your Bavimail bearer token and alias UUID (only if using Bavimail; both must be set)
+- `RESEND_API_KEY` — your Resend API key (omit if using Cloudflare Email Sending or Bavimail)
 - `BETTER_AUTH_SECRET` — generate a random string (`openssl rand -hex 32`)
 
 For production, set these as Cloudflare secrets:
 
 ```bash
 wrangler secret put BETTER_AUTH_SECRET
-wrangler secret put RESEND_API_KEY   # only if using Resend
+wrangler secret put RESEND_API_KEY      # only if using Resend
+wrangler secret put BAVIMAIL_API_KEY    # only if using Bavimail
+wrangler secret put BAVIMAIL_ALIAS_ID   # only if using Bavimail
 ```
 
 ### 6. Run migrations
@@ -334,6 +339,8 @@ To rebrand the UI, drop a replacement `public/saasmail-logo.png` — it's used a
 
 Local development secrets. Created from `.dev.vars.example`. This file is gitignored.
 
+- `BAVIMAIL_API_KEY` — Bavimail API bearer token (required for Bavimail, must be paired with `BAVIMAIL_ALIAS_ID`)
+- `BAVIMAIL_ALIAS_ID` — Bavimail alias UUID identifying the sending alias (required for Bavimail)
 - `RESEND_API_KEY` — Resend API key (if using Resend)
 - `BETTER_AUTH_SECRET` — Secret for session signing
 - `DISABLE_PASSKEY_GATE` — Local-only: set to `"true"` to skip the server-side passkey requirement so you can sign in with email+password during development. **Never set this in production.**

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createEmailSender } from "../lib/email-sender";
+import { createEmailSender, BavimailSender } from "../lib/email-sender";
 
 describe("createEmailSender", () => {
   it("picks Resend when RESEND_API_KEY is set", () => {
@@ -156,16 +156,7 @@ describe("maxAttachmentBytes", () => {
 
 describe("BavimailSender", () => {
   function makeBavimailSender(fetchFn: typeof fetch) {
-    // Reach into the module to construct directly with a custom fetch.
-    // createEmailSender uses globalThis.fetch which is harder to stub
-    // inside the Cloudflare Workers test pool.
-    const sender = createEmailSender({
-      BAVIMAIL_API_KEY: "bm_test",
-      BAVIMAIL_ALIAS_ID: "alias-uuid",
-    } as any);
-    // Inject the mock fetch on the instance for tests.
-    (sender as unknown as { fetchFn: typeof fetch }).fetchFn = fetchFn;
-    return sender;
+    return new BavimailSender("bm_test", "alias-uuid", fetchFn);
   }
 
   it("sends a basic email with bearer token and correct body", async () => {

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -231,4 +231,94 @@ describe("BavimailSender", () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.in_reply_to).toBe("<orig@msg>");
   });
+
+  it("uploads attachments first, then sends email with attachment IDs", async () => {
+    const uploadResponse = new Response(
+      JSON.stringify({
+        attachments: [
+          { id: "att-1", filename: "a.txt" },
+          { id: "att-2", filename: "b.txt" },
+        ],
+        uploaded_at: "2026-05-25T00:00:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    const sendResponse = new Response(JSON.stringify({ id: "bm-msg-xyz" }), {
+      status: 201,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(uploadResponse)
+      .mockResolvedValueOnce(sendResponse);
+
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "with attachments",
+      html: "<p>h</p>",
+      attachments: [
+        {
+          filename: "a.txt",
+          contentType: "text/plain",
+          content: new TextEncoder().encode("alpha"),
+        },
+        {
+          filename: "b.txt",
+          contentType: "text/plain",
+          content: new TextEncoder().encode("bravo"),
+        },
+      ],
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.id).toBe("bm-msg-xyz");
+
+    // First call: upload
+    const [uploadUrl, uploadInit] = fetchMock.mock.calls[0];
+    expect(uploadUrl).toBe("https://api.bavimail.com/attachments");
+    expect((uploadInit as RequestInit).method).toBe("POST");
+    // Crucial: do NOT manually set Content-Type for FormData — fetch sets the
+    // boundary automatically. Manually setting it omits the boundary and
+    // breaks the upload.
+    const uploadHeaders = (uploadInit as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(uploadHeaders["Content-Type"]).toBeUndefined();
+    expect(uploadHeaders["Authorization"]).toBe("Bearer bm_test");
+    expect((uploadInit as RequestInit).body).toBeInstanceOf(FormData);
+    const fd = (uploadInit as RequestInit).body as FormData;
+    const files = fd.getAll("files");
+    expect(files).toHaveLength(2);
+
+    // Second call: send
+    const [sendUrl, sendInit] = fetchMock.mock.calls[1];
+    expect(sendUrl).toBe("https://api.bavimail.com/emails");
+    const sendBody = JSON.parse((sendInit as RequestInit).body as string);
+    expect(sendBody.attachments).toEqual([
+      { attachment_id: "att-1", is_inline: false },
+      { attachment_id: "att-2", is_inline: false },
+    ]);
+  });
+
+  it("makes only one fetch call when there are no attachments", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "x" }), { status: 201 }),
+      );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.bavimail.com/emails");
+  });
 });

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -153,3 +153,91 @@ describe("maxAttachmentBytes", () => {
     expect(sender.maxAttachmentBytes()).toBe(25 * 1024 * 1024);
   });
 });
+
+describe("BavimailSender", () => {
+  function makeBavimailSender(fetchFn: typeof fetch) {
+    // Reach into the module to construct directly with a custom fetch.
+    // createEmailSender uses globalThis.fetch which is harder to stub
+    // inside the Cloudflare Workers test pool.
+    const sender = createEmailSender({
+      BAVIMAIL_API_KEY: "bm_test",
+      BAVIMAIL_ALIAS_ID: "alias-uuid",
+    } as any);
+    // Inject the mock fetch on the instance for tests.
+    (sender as unknown as { fetchFn: typeof fetch }).fetchFn = fetchFn;
+    return sender;
+  }
+
+  it("sends a basic email with bearer token and correct body", async () => {
+    const sendResponse = new Response(JSON.stringify({ id: "bm-msg-123" }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(sendResponse);
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: '"Alice" <a@b.com>',
+      to: '"Bob" <c@d.com>',
+      subject: "hello",
+      html: "<p>hi</p>",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.id).toBe("bm-msg-123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.bavimail.com/emails");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer bm_test");
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      alias_id: "alias-uuid",
+      to_email: "c@d.com",
+      subject: "hello",
+      body: "<p>hi</p>",
+    });
+  });
+
+  it("includes cc_emails when cc is present, omits when empty", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "x" }), { status: 201 }),
+      );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      cc: ['"Eve" <e@f.com>', "g@h.com"],
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.cc_emails).toEqual(["e@f.com", "g@h.com"]);
+  });
+
+  it("includes in_reply_to when headers contain In-Reply-To", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "x" }), { status: 201 }),
+      );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+      headers: { "In-Reply-To": "<orig@msg>" },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.in_reply_to).toBe("<orig@msg>");
+  });
+});

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -36,6 +36,32 @@ describe("createEmailSender", () => {
     expect(result.id).toBeNull();
     expect(result.error?.message).toBe("No email provider configured");
   });
+
+  it("picks Bavimail when BAVIMAIL_API_KEY and BAVIMAIL_ALIAS_ID are set, even over Resend and Cloudflare", () => {
+    const sender = createEmailSender({
+      BAVIMAIL_API_KEY: "bm_test",
+      BAVIMAIL_ALIAS_ID: "alias-uuid",
+      RESEND_API_KEY: "re_test",
+      EMAIL: { send: vi.fn() },
+    } as unknown as CloudflareBindings);
+    expect(sender.provider).toBe("bavimail");
+  });
+
+  it("falls through to Resend if BAVIMAIL_ALIAS_ID is missing", () => {
+    const sender = createEmailSender({
+      BAVIMAIL_API_KEY: "bm_test",
+      RESEND_API_KEY: "re_test",
+    } as unknown as CloudflareBindings);
+    expect(sender.provider).toBe("resend");
+  });
+
+  it("falls through to Resend if BAVIMAIL_API_KEY is missing", () => {
+    const sender = createEmailSender({
+      BAVIMAIL_ALIAS_ID: "alias-uuid",
+      RESEND_API_KEY: "re_test",
+    } as unknown as CloudflareBindings);
+    expect(sender.provider).toBe("resend");
+  });
 });
 
 describe("CloudflareSender", () => {
@@ -117,5 +143,13 @@ describe("maxAttachmentBytes", () => {
   it("returns 0 for NoopSender", () => {
     const sender = createEmailSender({} as any);
     expect(sender.maxAttachmentBytes()).toBe(0);
+  });
+
+  it("returns 25MB for Bavimail", () => {
+    const sender = createEmailSender({
+      BAVIMAIL_API_KEY: "bm_test",
+      BAVIMAIL_ALIAS_ID: "alias-uuid",
+    } as any);
+    expect(sender.maxAttachmentBytes()).toBe(25 * 1024 * 1024);
   });
 });

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -321,4 +321,83 @@ describe("BavimailSender", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe("https://api.bavimail.com/emails");
   });
+
+  it("returns error and skips /emails when /attachments returns non-2xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "file too large" }), {
+        status: 413,
+      }),
+    );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+      attachments: [
+        {
+          filename: "a.txt",
+          contentType: "text/plain",
+          content: new TextEncoder().encode("alpha"),
+        },
+      ],
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("file too large");
+    // Only the upload call was made.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns error when /emails returns non-2xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid alias" }), {
+        status: 400,
+      }),
+    );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("invalid alias");
+  });
+
+  it("falls back to status text when the error body cannot be parsed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("not json", { status: 500 }));
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toMatch(/500/);
+  });
+
+  it("normalizes thrown fetch errors", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("network down");
+  });
 });

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -184,6 +184,23 @@ class DemoSender implements EmailSender {
   }
 }
 
+async function extractBavimailError(res: Response): Promise<string> {
+  try {
+    const data = (await res.json()) as {
+      message?: string;
+      error?: string | { message?: string };
+    };
+    if (typeof data.error === "string") return data.error;
+    if (data.error && typeof data.error === "object" && data.error.message) {
+      return data.error.message;
+    }
+    if (data.message) return data.message;
+  } catch {
+    // fall through
+  }
+  return `Bavimail request failed: ${res.status} ${res.statusText}`.trim();
+}
+
 class BavimailSender implements EmailSender {
   readonly provider = "bavimail" as const;
   constructor(
@@ -192,12 +209,47 @@ class BavimailSender implements EmailSender {
     private fetchFn: typeof fetch = fetch,
   ) {}
 
-  async send(_params: SendEmailParams): Promise<SendEmailResult> {
-    // Implemented in Task 2.
-    return {
-      id: null,
-      error: { message: "Bavimail send not yet implemented" },
-    };
+  async send(params: SendEmailParams): Promise<SendEmailResult> {
+    try {
+      const toAddress = parseFrom(params.to).address;
+      const ccAddresses = (params.cc ?? []).map((c) => parseFrom(c).address);
+
+      const payload: Record<string, unknown> = {
+        alias_id: this.aliasId,
+        to_email: toAddress,
+        subject: params.subject,
+        body: params.html,
+      };
+      if (ccAddresses.length > 0) {
+        payload.cc_emails = ccAddresses;
+      }
+      const inReplyTo = params.headers?.["In-Reply-To"];
+      if (inReplyTo) {
+        payload.in_reply_to = inReplyTo;
+      }
+
+      const res = await this.fetchFn("https://api.bavimail.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const message = await extractBavimailError(res);
+        return { id: null, error: { message } };
+      }
+
+      const data = (await res.json().catch(() => ({}))) as {
+        id?: string;
+      };
+      return { id: data.id ?? null, error: null };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { id: null, error: { message } };
+    }
   }
 
   maxAttachmentBytes(): number {

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -201,7 +201,7 @@ async function extractBavimailError(res: Response): Promise<string> {
   return `Bavimail request failed: ${res.status} ${res.statusText}`.trim();
 }
 
-class BavimailSender implements EmailSender {
+export class BavimailSender implements EmailSender {
   readonly provider = "bavimail" as const;
   constructor(
     private apiKey: string,

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -38,7 +38,7 @@ export interface SendEmailResult {
 }
 
 export interface EmailSender {
-  provider: "resend" | "cloudflare" | "none" | "demo";
+  provider: "resend" | "cloudflare" | "none" | "demo" | "bavimail";
   send(params: SendEmailParams): Promise<SendEmailResult>;
   maxAttachmentBytes(): number;
 }
@@ -184,11 +184,40 @@ class DemoSender implements EmailSender {
   }
 }
 
+class BavimailSender implements EmailSender {
+  readonly provider = "bavimail" as const;
+  constructor(
+    private apiKey: string,
+    private aliasId: string,
+    private fetchFn: typeof fetch = fetch,
+  ) {}
+
+  async send(_params: SendEmailParams): Promise<SendEmailResult> {
+    // Implemented in Task 2.
+    return {
+      id: null,
+      error: { message: "Bavimail send not yet implemented" },
+    };
+  }
+
+  maxAttachmentBytes(): number {
+    return 25 * 1024 * 1024;
+  }
+}
+
 export function createEmailSender(
-  env: CloudflareBindings & { RESEND_API_KEY?: string; EMAIL?: SendEmail },
+  env: CloudflareBindings & {
+    RESEND_API_KEY?: string;
+    EMAIL?: SendEmail;
+    BAVIMAIL_API_KEY?: string;
+    BAVIMAIL_ALIAS_ID?: string;
+  },
 ): EmailSender {
   if (isDemoMode(env)) {
     return new DemoSender();
+  }
+  if (env.BAVIMAIL_API_KEY && env.BAVIMAIL_ALIAS_ID) {
+    return new BavimailSender(env.BAVIMAIL_API_KEY, env.BAVIMAIL_ALIAS_ID);
   }
   if (env.RESEND_API_KEY) {
     return new ResendSender(env.RESEND_API_KEY);

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -211,6 +211,15 @@ export class BavimailSender implements EmailSender {
 
   async send(params: SendEmailParams): Promise<SendEmailResult> {
     try {
+      let attachmentIds: string[] = [];
+      if (params.attachments && params.attachments.length > 0) {
+        const uploadResult = await this.uploadAttachments(params.attachments);
+        if (uploadResult.error) {
+          return { id: null, error: uploadResult.error };
+        }
+        attachmentIds = uploadResult.ids;
+      }
+
       const toAddress = parseFrom(params.to).address;
       const ccAddresses = (params.cc ?? []).map((c) => parseFrom(c).address);
 
@@ -227,6 +236,12 @@ export class BavimailSender implements EmailSender {
       if (inReplyTo) {
         payload.in_reply_to = inReplyTo;
       }
+      if (attachmentIds.length > 0) {
+        payload.attachments = attachmentIds.map((id) => ({
+          attachment_id: id,
+          is_inline: false,
+        }));
+      }
 
       const res = await this.fetchFn("https://api.bavimail.com/emails", {
         method: "POST",
@@ -242,14 +257,61 @@ export class BavimailSender implements EmailSender {
         return { id: null, error: { message } };
       }
 
-      const data = (await res.json().catch(() => ({}))) as {
-        id?: string;
-      };
+      const data = (await res.json().catch(() => ({}))) as { id?: string };
       return { id: data.id ?? null, error: null };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       return { id: null, error: { message } };
     }
+  }
+
+  private async uploadAttachments(
+    attachments: SendEmailAttachment[],
+  ): Promise<
+    | { ids: string[]; error: null }
+    | { ids: never[]; error: { message: string } }
+  > {
+    const form = new FormData();
+    for (const a of attachments) {
+      const u8 =
+        a.content instanceof Uint8Array ? a.content : new Uint8Array(a.content);
+      // Blob copy to detach from any shared buffer.
+      const blob = new Blob([u8], { type: a.contentType });
+      form.append("files", blob, a.filename);
+    }
+
+    // IMPORTANT: do NOT set Content-Type — fetch sets it with the multipart
+    // boundary automatically when the body is FormData.
+    const res = await this.fetchFn("https://api.bavimail.com/attachments", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: form,
+    });
+
+    if (!res.ok) {
+      const message = await extractBavimailError(res);
+      return { ids: [], error: { message } };
+    }
+
+    const data = (await res.json().catch(() => ({}))) as {
+      attachments?: Array<{ id?: string }>;
+    };
+    const ids = (data.attachments ?? [])
+      .map((a) => a.id)
+      .filter((id): id is string => typeof id === "string");
+
+    if (ids.length !== attachments.length) {
+      return {
+        ids: [],
+        error: {
+          message: `Bavimail upload returned ${ids.length} ids for ${attachments.length} attachments`,
+        },
+      };
+    }
+
+    return { ids, error: null };
   }
 
   maxAttachmentBytes(): number {

--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -27,8 +27,9 @@
     }
   ],
   // Optional: enable Cloudflare Email Sending as the outbound provider.
-  // If RESEND_API_KEY is set, Resend is used instead. Requires onboarding
-  // your domain at Email Service → https://dash.cloudflare.com/?to=/:account/email-service
+  // If Bavimail (BAVIMAIL_API_KEY + BAVIMAIL_ALIAS_ID) or RESEND_API_KEY is
+  // set, those win instead. Requires onboarding your domain at Email Service
+  // → https://dash.cloudflare.com/?to=/:account/email-service
   // "send_email": [
   //   { "name": "EMAIL" }
   // ],
@@ -77,9 +78,11 @@
     "crons": ["0 * * * *"]
   },
   // Outbound email provider selection (runtime, no explicit toggle):
+  //   - Set BOTH BAVIMAIL_API_KEY and BAVIMAIL_ALIAS_ID (via `wrangler secret put`)
+  //     to use Bavimail. Takes precedence over Resend and the EMAIL binding.
   //   - Set RESEND_API_KEY (via `wrangler secret put RESEND_API_KEY`) to use Resend.
   //   - Or uncomment the `send_email` binding above to use Cloudflare Email Sending.
-  //   - If neither is configured, send attempts return a "No email provider configured" error.
+  //   - If none are configured, send attempts return a "No email provider configured" error.
   "vars": {
     "BASE_URL": "<your-deployed-url>",
     "TRUSTED_ORIGINS": "http://localhost:8080,http://localhost:8788,<your-deployed-url>",


### PR DESCRIPTION
## Summary
- Adds **Bavimail** as a third outbound email provider alongside Resend and Cloudflare Email Sending. Activated when both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` are set; takes precedence over the other providers.
- Implements Bavimail's two-step send flow: uploads attachments via multipart `POST /attachments` first, then threads the returned IDs into `POST /emails`. Bearer-token auth, error normalization mirrors the existing `ResendSender` shape.
- Documents the new provider end-to-end: README provider matrix, configuration sections, and the `.dev.vars.example` / `wrangler.jsonc.example` templates.

**Known limitations** (documented in the design spec): `text` body is dropped (Bavimail has a single `body` field), BCC is not wired up (not in the internal interface), and the `from` param is ignored (alias controls sender identity).

## Test plan
- [x] `yarn test` — 301 passing (+22 new in `email-sender.test.ts` covering selection, send, attachments, and error paths)
- [x] `yarn tsc --noEmit` — clean
- [ ] Manual smoke: set `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` in `.dev.vars`, send a test email with and without attachments, verify 201 response from Bavimail
- [ ] Verify Resend and Cloudflare paths still select correctly when Bavimail vars are absent