### PR TITLE
chore: release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-05-27
+
 ### Added
 
 - Admins can revoke invitations from the admin users page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version from `0.5.2` → `0.5.3`
- Promotes the [Unreleased] changelog entry (admin invitation revocation) to `[0.5.3] - 2026-05-27`

## Changes in this release

**Added**
- Admins can revoke invitations from the admin users page (DELETE `/api/admin/invites/{id}`)

## Test plan

- [ ] CI passes
- [ ] `package.json` version is `0.5.3`
- [ ] CHANGELOG `[0.5.3]` entry is present and `[Unreleased]` is empty

https://claude.ai/code/session_0123hTCDk9SH9Z5DjgCNPTnS

---
_Generated by [Claude Code](https://claude.ai/code/session_0123hTCDk9SH9Z5DjgCNPTnS)_