### PR TITLE
fix(sequences): accumulate step delays so emails space out correctly

### DIFF
--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -437,8 +437,10 @@ sequencesRouter.openapi(enrollRoute, async (c) => {
   await db.insert(sequenceEnrollments).values(enrollment);
 
   // Create outbox emails with computed schedule
-  // First email sends immediately; subsequent emails use snapToNextHour as base
+  // First email sends immediately; subsequent emails accumulate delays from
+  // snapToNextHour(now) so each step fires delayHours after the previous one.
   const baseTime = snapToNextHour(now);
+  let cumulativeHours = 0;
   const scheduledEmails = activeSteps.map((step, index) => {
     const delayHours =
       step.order.toString() in delayOverrides
@@ -446,12 +448,13 @@ sequencesRouter.openapi(enrollRoute, async (c) => {
         : step.delayHours;
 
     const isFirstEmail = index === 0;
+    if (!isFirstEmail) cumulativeHours += delayHours;
     return {
       id: nanoid(),
       enrollmentId,
       stepOrder: step.order,
       templateSlug: step.templateSlug,
-      scheduledAt: isFirstEmail ? now : baseTime + delayHours * 3600,
+      scheduledAt: isFirstEmail ? now : baseTime + cumulativeHours * 3600,
       // In demo mode there is no queue/cron to advance "queued" emails, so
       // leave everything as "pending" — the records exist for the UI to show
       // but nothing is dispatched.


### PR DESCRIPTION
Fixes #109.

## Root cause

When scheduling enrollment emails, each step's `scheduledAt` was computed as:

```ts
scheduledAt: isFirstEmail ? now : baseTime + delayHours * 3600,
```

`delayHours` here is the **single step's** delay value. In a typical sequence every non-first step has the same value (e.g. 24 hours), so all of them resolve to the same timestamp — `baseTime + 24h` — and fire in the same cron window.

## Fix

Accumulate delays across steps so step N is scheduled at `baseTime + sum(delayHours[1..N])`:

```ts
let cumulativeHours = 0;
// inside .map():
if (!isFirstEmail) cumulativeHours += delayHours;
scheduledAt: isFirstEmail ? now : baseTime + cumulativeHours * 3600,
```

For a 7-step sequence with 24h delays this produces:

| Step | scheduledAt |
|------|-------------|
| 1 | now (immediate) |
| 2 | baseTime + 24h |
| 3 | baseTime + 48h |
| 4 | baseTime + 72h |
| 5 | baseTime + 96h |
| 6 | baseTime + 120h |
| 7 | baseTime + 144h |

🤖 Generated with [Claude Code](https://claude.com/claude-code)