### PR TITLE
feat(inbox): deep-link to filtered inbox via ?q= and shareable per-message links

### DIFF
--- a/e2e/specs/global-search.spec.ts
+++ b/e2e/specs/global-search.spec.ts
@@ -125,4 +125,38 @@ test.describe.serial("global search", () => {
     await page.getByTestId(TEST_IDS.personSearchClear).click();
     await expect(bobRow).toBeVisible();
   });
+
+  test("?q= query param seeds the search box and filters the list", async ({
+    page,
+  }) => {
+    await page.goto("/?q=alice");
+
+    const input = page.getByTestId(TEST_IDS.personSearchInput);
+    await expect(input).toHaveValue("alice");
+
+    const aliceRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_alice"]`,
+    );
+    const bobRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_bob"]`,
+    );
+    await expect(aliceRow).toBeVisible();
+    await expect(bobRow).not.toBeVisible();
+  });
+
+  test("?search= alias also seeds the search box", async ({ page }) => {
+    await page.goto("/?search=billing");
+
+    const input = page.getByTestId(TEST_IDS.personSearchInput);
+    await expect(input).toHaveValue("billing");
+
+    const bobRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_bob"]`,
+    );
+    const aliceRow = page.locator(
+      `[data-testid="${TEST_IDS.personRow}"][data-person-id="p_alice"]`,
+    );
+    await expect(bobRow).toBeVisible();
+    await expect(aliceRow).not.toBeVisible();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import SequenceDetailPage from "@/pages/SequenceDetailPage";
 import SequenceEditorPage from "@/pages/SequenceEditorPage";
 import InboxesPage from "./pages/InboxesPage";
 import SettingsPage from "@/pages/SettingsPage";
+import MessageLinkPage from "@/pages/MessageLinkPage";
 
 const queryClient = new QueryClient();
 
@@ -149,6 +150,10 @@ function App() {
                 {/* Deep link from Web Push notifications — see
                     worker/src/do/notifications.ts where data.url is set. */}
                 <Route path="/inbox/:inbox/:personId" element={<InboxPage />} />
+                {/* Shareable link to a specific message — resolves the
+                    email's person/inbox and forwards to the route above
+                    with a `#m=<id>` hash for scroll/flash. */}
+                <Route path="/m/:emailId" element={<MessageLinkPage />} />
                 <Route path="/*" element={<InboxPage />} />
               </Route>
             </Route>

--- a/src/components/ChatInboxSection.tsx
+++ b/src/components/ChatInboxSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
 import {
   Inbox,
+  Link2,
   Maximize2,
   Paperclip,
   Trash2,
@@ -15,6 +16,7 @@ import CcChips, { RosterDiffNotice } from "@/components/CcChips";
 import { rosterOf, diffRosters } from "@/lib/roster";
 import type { ComposePrefill } from "@/pages/ComposeModal";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
+import { copyMessageLink, messageDomId } from "@/lib/message-link";
 import {
   HIDE_SIGNATURES_EVENT,
   readHideSignatures,
@@ -191,8 +193,10 @@ function Bubble({
 
   return (
     <div
+      id={messageDomId(email.id)}
       data-testid="chat-bubble"
-      className={`group flex flex-col px-4 py-1 sm:px-6 ${
+      data-email-id={email.id}
+      className={`group flex flex-col px-4 py-1 sm:px-6 scroll-mt-20 ${
         isSent ? "items-end" : "items-start"
       }`}
       onClick={handleClick}
@@ -311,6 +315,18 @@ function Bubble({
             View original
           </button>
         )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void copyMessageLink(email.id);
+          }}
+          data-testid="message-copy-link"
+          className="flex items-center gap-1 opacity-0 transition-opacity hover:text-text-secondary group-hover:opacity-100"
+          title="Copy link to this message"
+        >
+          <Link2 size={10} />
+        </button>
         <button
           type="button"
           onClick={(e) => {

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
-import { Maximize2, Paperclip, Trash2 } from "lucide-react";
+import { Link2, Maximize2, Paperclip, Trash2 } from "lucide-react";
 import CcChips from "@/components/CcChips";
 import type { Email } from "@/lib/api";
+import { copyMessageLink, messageDomId } from "@/lib/message-link";
 
 interface MessageBubbleProps {
   email: Email;
@@ -94,8 +95,10 @@ export default function MessageBubble({
 
   return (
     <div
+      id={messageDomId(email.id)}
       data-testid="thread-message"
-      className={`group ${compact ? "px-3 py-1.5" : "px-4 sm:px-6 py-2"} hover:bg-bg-muted/50 transition-colors ${
+      data-email-id={email.id}
+      className={`group ${compact ? "px-3 py-1.5" : "px-4 sm:px-6 py-2"} hover:bg-bg-muted/50 transition-colors scroll-mt-20 ${
         isUnread ? "bg-accent/5" : ""
       }`}
       onClick={handleClick}
@@ -209,6 +212,18 @@ export default function MessageBubble({
           className="text-[11px] text-text-tertiary hover:text-text-secondary"
         >
           Reply
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void copyMessageLink(email.id);
+          }}
+          data-testid="message-copy-link"
+          className="flex items-center gap-1 text-[11px] text-text-tertiary hover:text-text-secondary"
+          title="Copy link to this message"
+        >
+          <Link2 size={12} />
+          Copy link
         </button>
         <button
           onClick={(e) => {

--- a/src/index.css
+++ b/src/index.css
@@ -513,3 +513,21 @@ body {
 .notion-editor .notion-image-resize-handle[data-visible="true"] {
   opacity: 1;
 }
+
+/* Deep-link landing flash — applied to a message bubble (id="m-<emailId>")
+   after PersonDetail scrolls to a `?#m=<id>` target so the user can see
+   which message the link pointed at. */
+@keyframes message-link-flash {
+  0% {
+    box-shadow: 0 0 0 2px rgba(124, 92, 252, 0.55);
+    background-color: rgba(124, 92, 252, 0.12);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(124, 92, 252, 0);
+    background-color: transparent;
+  }
+}
+.message-link-flash {
+  animation: message-link-flash 2200ms ease-out 1;
+  border-radius: 6px;
+}

--- a/src/lib/message-link.ts
+++ b/src/lib/message-link.ts
@@ -1,0 +1,41 @@
+import { showToast } from "@/lib/toast";
+
+/** Stable DOM id used to scroll/flash a deep-linked message. */
+export function messageDomId(emailId: string): string {
+  return `m-${emailId}`;
+}
+
+/** Public, shareable URL that resolves to a specific message in context. */
+export function buildMessageUrl(emailId: string): string {
+  return `${window.location.origin}/m/${encodeURIComponent(emailId)}`;
+}
+
+/**
+ * Reads a deep-linked message id from the URL hash. The router lands a deep
+ * link as `…/inbox/<inbox>/<personId>#m=<emailId>`; consumers (PersonDetail)
+ * use this to scroll the target into view after emails finish loading.
+ */
+export function readMessageHash(hash: string): string | null {
+  const m = hash.match(/^#m=(.+)$/);
+  if (!m) return null;
+  try {
+    return decodeURIComponent(m[1]);
+  } catch {
+    return m[1];
+  }
+}
+
+export async function copyMessageLink(emailId: string): Promise<void> {
+  const url = buildMessageUrl(emailId);
+  try {
+    await navigator.clipboard.writeText(url);
+    showToast({ kind: "success", message: "Message link copied" });
+  } catch {
+    showToast({
+      kind: "error",
+      message: "Couldn't copy link",
+      description: url,
+      durationMs: 8000,
+    });
+  }
+}

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useParams, useOutletContext } from "react-router-dom";
+import { useParams, useOutletContext, useSearchParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
 import type { ComposePrefill } from "@/pages/ComposeModal";
@@ -62,7 +62,12 @@ export default function InboxPage() {
   });
   const [stats, setStats] = useState<Stats | null>(null);
   const [filters, setFilters] = useState<InboxFilters>({});
-  const [search, setSearch] = useState("");
+  // Deep-link support: seed search from `?q=` (or `?search=`) so an
+  // external admin link like `/?q=user@example.com` lands pre-filtered.
+  const [searchParams] = useSearchParams();
+  const [search, setSearch] = useState(
+    () => searchParams.get("q") ?? searchParams.get("search") ?? "",
+  );
   const [view, setView] = useState<InboxView>("list");
   const [sortSpec, setSortSpec] = useState<InboxSortSpec>(() => {
     // Persisted as JSON now ({key, direction}). For back-compat, also

--- a/src/pages/MessageLinkPage.tsx
+++ b/src/pages/MessageLinkPage.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { fetchEmail } from "@/lib/api";
+
+/**
+ * Resolves a shareable `/m/<emailId>` link to the in-app location of the
+ * message. Looks up the email's person + owning inbox, then redirects to
+ * the existing person route with a `#m=<emailId>` hash for PersonDetail
+ * to scroll/flash. `replace` keeps the resolver URL out of history so the
+ * back button doesn't bounce.
+ */
+export default function MessageLinkPage() {
+  const { emailId } = useParams<{ emailId: string }>();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!emailId) {
+      setError("Missing message id");
+      return;
+    }
+    let cancelled = false;
+    fetchEmail(emailId)
+      .then((email) => {
+        if (cancelled) return;
+        // For received emails the owning inbox is `recipient`; for sent
+        // emails the API returns recipient: null and the inbox is the
+        // outbound identity in `fromAddress`. Mirror inboxOf() in PersonDetail.
+        const inbox =
+          email.type === "received" ? email.recipient : email.fromAddress;
+        const personId = email.personId;
+        if (!personId || !inbox) {
+          setError("This message can't be opened in the inbox view.");
+          return;
+        }
+        navigate(
+          `/inbox/${encodeURIComponent(inbox)}/${encodeURIComponent(personId)}#m=${encodeURIComponent(emailId)}`,
+          { replace: true },
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError("Message not found, or you don't have access to it.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [emailId, navigate]);
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center px-6 py-16">
+        <div className="max-w-sm rounded-2xl bg-card p-8 text-center ring-1 ring-border">
+          <h2 className="text-base font-semibold text-text-primary">
+            Can't open this message
+          </h2>
+          <p className="mt-2 text-sm text-text-secondary">{error}</p>
+          <Link
+            to="/"
+            className="mt-4 inline-block text-sm font-medium text-accent hover:underline"
+          >
+            Back to inbox
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-1 items-center justify-center text-sm text-text-tertiary">
+      Opening message…
+    </div>
+  );
+}

--- a/src/pages/PersonDetail.tsx
+++ b/src/pages/PersonDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import { CheckCheck } from "lucide-react";
 import {
   fetchPersonEmails,
@@ -12,6 +13,7 @@ import {
   type PersonEnrollmentInfo,
   type InboxDisplayMode,
 } from "@/lib/api";
+import { messageDomId, readMessageHash } from "@/lib/message-link";
 import EnrollSequenceModal from "@/components/EnrollSequenceModal";
 import SequenceStatus from "@/components/SequenceStatus";
 import EmailHtmlModal from "@/components/EmailHtmlModal";
@@ -231,6 +233,54 @@ export default function PersonDetail({
       setActiveInbox(inboxGroups[0].inbox);
     }
   }, [inboxGroups, activeInbox]);
+
+  // Deep-link landing: if the URL has `#m=<emailId>` and that message
+  // belongs to this person, switch to its inbox tab, auto-expand the
+  // older-messages drawer when needed (thread mode), and scroll/flash
+  // the bubble. Fires once per (person, hash) pair so paging or
+  // re-renders don't keep yanking the scroll position.
+  const location = useLocation();
+  const lastHashHandled = useRef<string | null>(null);
+  useEffect(() => {
+    if (emails.length === 0) return;
+    const targetEmailId = readMessageHash(location.hash);
+    if (!targetEmailId) return;
+    const key = `${person.id}:${targetEmailId}`;
+    if (lastHashHandled.current === key) return;
+    const target = emails.find((e) => e.id === targetEmailId);
+    if (!target) return;
+    lastHashHandled.current = key;
+
+    const targetInbox = inboxOf(target);
+    setActiveInbox(targetInbox);
+
+    // Thread mode collapses older messages behind a toggle. If the
+    // target isn't the latest in its group, force the drawer open so
+    // the bubble is actually in the DOM when we try to scroll to it.
+    const group = inboxGroups.find((g) => g.inbox === targetInbox);
+    if (group && group.emails[0]?.id !== target.id) {
+      setExpandedOlder((prev) =>
+        prev[targetInbox] ? prev : { ...prev, [targetInbox]: true },
+      );
+    }
+
+    // Two rAFs: first lets React commit the tab switch / expand; second
+    // lets the new bubble mount before we measure for scrollIntoView.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(messageDomId(target.id));
+        if (!el) return;
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.remove("message-link-flash");
+        // Reflow so re-adding the class restarts the animation.
+        void el.offsetWidth;
+        el.classList.add("message-link-flash");
+        window.setTimeout(() => {
+          el.classList.remove("message-link-flash");
+        }, 2400);
+      });
+    });
+  }, [emails, location.hash, inboxGroups, person.id]);
 
   // Listen for the global "email sent" event so we can:
   //   1) Refetch emails immediately — already happens via the existing


### PR DESCRIPTION
Closes #99.

Adds both pieces of the issue — the `?q=` deep-link to a pre-filtered inbox, and the copy-link-to-a-specific-message action mentioned in the follow-up comment.

## Summary

**Pre-filtered inbox via `?q=`**
- `InboxPage` reads `q` (or `search`) from the URL on mount and seeds the search state. A link like `https://your-saasmail-instance.com/?q=user@example.com` lands on a pre-filtered inbox — no new UI, the existing search input and FTS filtering pick up the value the same as if a user had typed it.

**Shareable link to a specific message**
- Every message bubble (both thread and chat modes) has a new **Copy link** action in its hover toolbar. It writes `${origin}/m/<emailId>` to the clipboard and toasts.
- Visiting that URL hits a small `/m/:emailId` resolver page that calls the existing `GET /api/emails/{id}` endpoint, then redirects to the existing person route (`/inbox/<inbox>/<personId>`) with a `#m=<emailId>` hash. `replace: true` keeps the resolver out of history so back-button works.
- `PersonDetail` honours the hash: switches to the message's inbox tab, auto-expands the older-messages drawer in thread mode if the target isn't the latest, then scrolls the bubble into view and runs a brief violet flash so the user can see which message the link pointed at.
- Inbox ACLs are enforced server-side by the existing endpoint — a link to a message you can't see returns "Can't open this message", not a leak.

## Why

- **Admin integrations / support workflows:** link from a user record (or a Slack thread) straight to that user's email history, or to one specific message.
- **Bookmarks:** save a filtered view, or a permanent reference to a single message.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Manually verified on a Cloudflare deployment (`mail.redleg.dev`): `?q=` and `?search=` both seed the search box; Copy link on a thread bubble and a chat bubble copies a working URL; opening it lands on the right person/inbox tab, expands older messages when needed, and flashes the target bubble.
- [x] New e2e tests in `global-search.spec.ts` for the `?q=` and `?search=` aliases.
- [ ] CI e2e suite.