### PR TITLE
feat(send): support optional Reply-To on /api/send

### DIFF
--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -232,6 +232,26 @@ describe("BavimailSender", () => {
     expect(body.in_reply_to).toBe("<orig@msg>");
   });
 
+  it("includes reply_to when headers contain Reply-To", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "x" }), { status: 201 }),
+      );
+    const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+      headers: { "Reply-To": "submitter@example.com" },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.reply_to).toBe("submitter@example.com");
+  });
+
   it("uploads attachments first, then sends email with attachment IDs", async () => {
     const uploadResponse = new Response(
       JSON.stringify({

--- a/worker/src/__tests__/send-router.test.ts
+++ b/worker/src/__tests__/send-router.test.ts
@@ -152,6 +152,36 @@ describe("send router", () => {
       expect(rows[0].size).toBe(5);
     });
 
+    it("accepts an optional replyTo address", async () => {
+      const res = await authFetch("/api/send", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          to: "newperson@example.com",
+          fromAddress: "me@saasmail.test",
+          subject: "Hello",
+          bodyHtml: "<p>Hi</p>",
+          replyTo: "submitter@example.com",
+        }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it("rejects an invalid replyTo with 400", async () => {
+      const res = await authFetch("/api/send", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          to: "newperson@example.com",
+          fromAddress: "me@saasmail.test",
+          subject: "Hello",
+          bodyHtml: "<p>Hi</p>",
+          replyTo: "not-an-email",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
     it("rejects more than 50 files with 400", async () => {
       const payload = {
         to: "a@example.com",
@@ -189,6 +219,31 @@ describe("send router", () => {
   });
 
   describe("POST /api/send/reply/:emailId", () => {
+    it("accepts an optional replyTo address", async () => {
+      const person = await createTestPerson({
+        id: "p-rt",
+        email: "submitter@example.com",
+      });
+      await createTestEmail({
+        id: "rcv-rt",
+        personId: person.id,
+        recipient: "me@saasmail.test",
+        subject: "Contact form submission",
+        messageId: "contact-rt@example.com",
+      });
+
+      const res = await authFetch("/api/send/reply/rcv-rt", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: "me@saasmail.test",
+          bodyHtml: "<p>thanks</p>",
+          replyTo: "team@example.com",
+        }),
+      });
+      expect(res.status).toBe(201);
+    });
+
     it("persists attachments on a reply", async () => {
       const person = await createTestPerson({
         id: "p1",

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -236,6 +236,10 @@ export class BavimailSender implements EmailSender {
       if (inReplyTo) {
         payload.in_reply_to = inReplyTo;
       }
+      const replyTo = params.headers?.["Reply-To"];
+      if (replyTo) {
+        payload.reply_to = replyTo;
+      }
       if (attachmentIds.length > 0) {
         payload.attachments = attachmentIds.map((id) => ({
           attachment_id: id,

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -109,6 +109,11 @@ const SendEmailSchema = z
         "Plain-text fallback body. Recommended for accessibility and deliverability.",
       example: "Hello, world!",
     }),
+    replyTo: z.string().email().optional().openapi({
+      description:
+        "Address that receives the response when the recipient hits Reply. If omitted, replies go to fromAddress. Useful for contact-form-style flows where messages are sent from a tenant-owned address like noreply@ but replies should go to the actual submitter.",
+      example: "submitter@example.com",
+    }),
   })
   .openapi("SendEmailSchema");
 
@@ -182,6 +187,7 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     name: c.name ?? null,
   }));
   const { subject, bodyHtml, bodyText } = raw;
+  const replyTo = raw.replyTo?.trim().toLowerCase();
   const allowed = c.get("allowedInboxes")!;
   assertInboxAllowed(allowed, fromAddress);
   const now = Math.floor(Date.now() / 1000);
@@ -196,7 +202,10 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     subject,
     html: bodyHtml,
     text: bodyText,
-    headers: { "Message-ID": messageId },
+    headers: {
+      "Message-ID": messageId,
+      ...(replyTo ? { "Reply-To": replyTo } : {}),
+    },
     ...(files.length > 0
       ? {
           attachments: files.map((f) => ({
@@ -290,6 +299,7 @@ const ReplyEmailSchema = z.object({
   cc: z.array(CcEntrySchema).max(MAX_CC_ENTRIES).optional(),
   templateSlug: z.string().optional(),
   variables: z.record(z.string(), z.string()).optional(),
+  replyTo: z.string().email().optional(),
 });
 
 // Reply to an existing email
@@ -341,6 +351,7 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
     name: c.name ?? null,
   }));
   const { bodyHtml, bodyText, templateSlug, variables } = raw;
+  const replyTo = raw.replyTo?.trim().toLowerCase();
   const allowed = c.get("allowedInboxes")!;
   assertInboxAllowed(allowed, fromAddress);
   const now = Math.floor(Date.now() / 1000);
@@ -460,6 +471,7 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
       ...(origInReplyToMessageId
         ? { "In-Reply-To": origInReplyToMessageId }
         : {}),
+      ...(replyTo ? { "Reply-To": replyTo } : {}),
     },
     ...(files.length > 0
       ? {


### PR DESCRIPTION
## Summary

- Adds an optional `replyTo: email` field to `SendEmailSchema` and `ReplyEmailSchema`. When present, the address is forwarded as the `Reply-To` header on the outbound message.
- Resend and Cloudflare senders already pass arbitrary headers through, so no adapter change is needed for those. Bavimail explicitly maps known headers into named JSON fields, so I added the parallel `Reply-To` → `reply_to` mapping alongside the existing `In-Reply-To` → `in_reply_to`.
- Closes #113.

## Use case

A Next.js contact form sends `fromAddress: noreply@…` (the only address Cloudflare's `send_email` binding allows) to a SaaSMail inbox. With `replyTo: <submitter>` set, the team can hit Reply in the SaaSMail UI and the response goes to the actual submitter instead of `noreply@`.

## Backward compatibility

Additive — existing callers continue to work unchanged.

## Test plan

- [x] `yarn test` — all 309 tests pass (4 new)
- [x] `yarn tsc --noEmit` — clean
- [x] New unit test: `BavimailSender` maps `Reply-To` header to `reply_to` field in API payload
- [x] New route test: `POST /api/send` with valid `replyTo` returns 201
- [x] New route test: `POST /api/send` with invalid `replyTo` (`"not-an-email"`) returns 400
- [x] New route test: `POST /api/send/reply/{emailId}` with valid `replyTo` returns 201
- [ ] Manually verify via Cloudflare provider in dev: `Reply-To` header lands in the outbound MIME (CloudflareSender's existing generic-headers passthrough already covered by `email-sender.test.ts:68-103`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)