### PR TITLE
fix(mobile): prevent iOS auto-zoom on focused inputs

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,10 @@
 
 html {
   font-size: 16px;
+  /* Stop iOS Safari from inflating text on rotate / when zoomed.
+     We control text size explicitly. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {
@@ -83,6 +87,35 @@ body {
   font-feature-settings: "cv11", "ss01";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Kill the gray flash on tap on iOS / Android — we rely on
+     hover/focus rings for affordance. */
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ── Mobile form controls ────────────────────────────────────────
+   iOS Safari (and some Android browsers) zoom the viewport in when
+   the focused input's computed font-size is below 16px. Many of our
+   inputs use `text-sm` (14px) for visual density on desktop — fine
+   on a trackpad, but it kicks off an annoying zoom on phones.
+
+   Force 16px on the actual form controls (input / textarea / select)
+   and the rich-text editor's contenteditable surface when the viewport
+   is in the mobile range. Above 640px the original utility classes
+   win again so the desktop look is unchanged. */
+@media (max-width: 639.98px) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not(
+      [type="color"]
+    ),
+  textarea,
+  select,
+  [contenteditable="true"],
+  .notion-editor {
+    /* !important is required because Tailwind utility classes
+       (text-xs / text-sm) carry higher specificity than a bare
+       element selector. The point of this rule is to override
+       those at the mobile breakpoint only. */
+    font-size: 16px !important;
+  }
 }
 
 /* ── Brand utilities ─────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Audited the frontend on mobile and found the main culprit behind the iOS \"zoom in on focus\" UX bug: most form controls (`Input`, `Textarea`, search bar, login, compose subject, CC chips, admin inbox form, template variables, etc.) use Tailwind's `text-sm` (14px). iOS Safari zooms the viewport any time the focused input's computed font-size is < 16px.
- Fixed it once, globally, in `src/index.css` instead of editing every component:
  - Under the `sm` breakpoint, force `font-size: 16px` on `input` / `textarea` / `select` / `[contenteditable=\"true\"]` / `.notion-editor`.
  - Above 640px the original utility classes win, so desktop visuals are unchanged.
  - Used `!important` because plain element selectors can't outrank Tailwind utility classes — standard pattern for this fix.
- Bonus mobile niceties while we were in there:
  - `-webkit-text-size-adjust: 100%` on `html` so iOS doesn't re-inflate body text on rotate.
  - `-webkit-tap-highlight-color: transparent` on `body` to remove the gray flash on tap (we already use focus/hover rings).

## Test plan
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn build` — clean
- [x] `yarn test` — 305 passed / 1 skipped
- [ ] On an iPhone / iOS simulator, focus the search bar, login email/password, compose subject, Tiptap editor — viewport should stay put instead of zooming in.
- [ ] On desktop (≥ 640px) inputs still render at `text-sm` (14px) — no visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)