### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-01
+
 ### Added
 
+- Support optional `Reply-To` header on `POST /api/send` and the reply route.
+- Inbox can be deep-linked to a filtered view via `?q=` query parameter; individual messages now have shareable per-message links.
 - Admins can revoke invitations from the admin users page.
+
+### Fixed
+
+- Prevented iOS auto-zoom on focused inputs across forms.
+- Sequence step delays now accumulate correctly so emails space out as configured instead of all sending at once.
+
+### Dependencies
+
+- Bumped the tiptap group with 5 updates.
+- Bumped the cloudflare dev-dependency group with 4 updates.
+- Bumped `resend` from 6.11.0 to 6.12.4.
 
 ## [0.5.2] - 2026-05-26
 
@@ -317,7 +332,9 @@ and admin tooling all changed; the data model is unchanged.
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/choyiny/saasmail/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/choyiny/saasmail/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/choyiny/saasmail/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/choyiny/saasmail/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/choyiny/saasmail/compare/v0.4.2...v0.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2026-06-01
+## [0.6.0] - 2026-06-02
 
 ### Added
 
 - Support optional `Reply-To` header on `POST /api/send` and the reply route.
+- Inbound `Reply-To` is now surfaced on the single-email endpoint (`GET /api/emails/:id`).
 - Inbox can be deep-linked to a filtered view via `?q=` query parameter; individual messages now have shareable per-message links.
 - Admins can revoke invitations from the admin users page.
+- Added `/use-saasmail` skill documenting how to call a deployed saasmail instance from Claude.
 
 ### Fixed
 
 - Prevented iOS auto-zoom on focused inputs across forms.
 - Sequence step delays now accumulate correctly so emails space out as configured instead of all sending at once.
+- Wrapped `Reply-To` values in a mimetext `Mailbox` on the Cloudflare sender path so sends with a `replyTo` no longer silently fail.
 
 ### Dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps `package.json` version from `0.5.2` to `0.6.0` and updates `CHANGELOG.md` with all changes through 2026-06-02.

## Changes

- Updated `CHANGELOG.md` v0.6.0 entry with three additional items from `main`:
  - Inbound `Reply-To` is now surfaced on the single-email endpoint (`GET /api/emails/:id`) (#124)
  - Cloudflare sender wraps `Reply-To` in a mimetext `Mailbox` so sends with `replyTo` no longer silently fail (#123)
  - Added `/use-saasmail` Claude skill documenting how to call a deployed saasmail instance (#122)
- Rebased branch onto latest `main` (includes all commits from #122, #123, #124)
- Updated release date to `2026-06-02`

**What's in v0.6.0**

*Added*
- Optional `Reply-To` header support on `POST /api/send` and the reply route (#119)
- Inbound `Reply-To` surfaced on the single-email endpoint `GET /api/emails/:id` (#124)
- Inbox deep-links via `?q=` and shareable per-message links (#114)
- Admins can revoke invitations from the admin users page
- `/use-saasmail` skill documenting HTTP API usage for Claude integrations (#122)

*Fixed*
- Prevented iOS auto-zoom on focused inputs (#120)
- Sequence step delays now accumulate correctly (#110)
- Cloudflare sender wraps `Reply-To` in a `Mailbox` so sends with `replyTo` no longer silently fail (#123)

*Dependencies*
- Bumped tiptap group with 5 updates (#115)
- Bumped cloudflare dev-dependency group with 4 updates (#116)
- Bumped `resend` from 6.11.0 to 6.12.4 (#118)

## Test plan

- [ ] CI passes on this branch

## Notes for reviewers

Branch is rebased on top of the latest `main` tip (`efcb0fc`).

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed
- [x] Updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [ ] Updated docs (`README.md`, `docs/`) if behavior or setup changed