### PR TITLE
fix(cloudflare): wrap Reply-To in a Mailbox so sends don't fail

### DIFF
--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -102,6 +102,34 @@ describe("CloudflareSender", () => {
     expect(serialized).toContain("text/html");
   });
 
+  it("serializes a Reply-To header without throwing", async () => {
+    // Regression: Reply-To is a single-mailbox header in mimetext, so a bare
+    // string threw MIMETEXT_INVALID_HEADER_VALUE and was swallowed as a failed
+    // send. It must be wrapped in a Mailbox and round-trip into the raw MIME.
+    const fakeBinding = {
+      send: vi.fn().mockResolvedValue({ messageId: "msg-rt" }),
+    };
+    const sender = createEmailSender({
+      EMAIL: fakeBinding,
+    } as unknown as CloudflareBindings);
+
+    const result = await sender.send({
+      from: "noreply@readerful.com",
+      to: "team@readerful.com",
+      subject: "contact form",
+      html: "<p>hi</p>",
+      headers: {
+        "Message-ID": "<new@msg>",
+        "Reply-To": "submitter@example.com",
+      },
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.id).toBe("msg-rt");
+    const sent = fakeBinding.send.mock.calls[0][0];
+    expect(JSON.stringify(sent)).toContain("Reply-To: <submitter@example.com>");
+  });
+
   it("catches thrown errors and returns normalized result", async () => {
     const fakeBinding = {
       send: vi.fn().mockRejectedValue(new Error("sender not allowed")),

--- a/worker/src/lib/email-sender.ts
+++ b/worker/src/lib/email-sender.ts
@@ -1,7 +1,7 @@
 import { Resend } from "resend";
 import { nanoid } from "nanoid";
 import { EmailMessage } from "cloudflare:email";
-import { createMimeMessage } from "mimetext";
+import { createMimeMessage, Mailbox } from "mimetext";
 import { isDemoMode } from "./is-dev";
 
 function parseFrom(input: string): { name?: string; address: string } {
@@ -136,7 +136,16 @@ class CloudflareSender implements EmailSender {
       }
       if (params.headers) {
         for (const [key, value] of Object.entries(params.headers)) {
-          msg.setHeader(key, value);
+          // Reply-To is a predefined address-type header in mimetext, so a bare
+          // string fails its mailbox validate/dump (unlike plain headers like
+          // Message-ID / In-Reply-To). Wrap it in a Mailbox so it serializes.
+          if (key.toLowerCase() === "reply-to") {
+            // mimetext defines Reply-To as a single-mailbox header
+            // (validateMailboxSingle), so it needs one Mailbox, not an array.
+            msg.setHeader(key, new Mailbox(value));
+          } else {
+            msg.setHeader(key, value);
+          }
         }
       }
       const message = new EmailMessage(address, params.to, msg.asRaw());
@@ -144,6 +153,13 @@ class CloudflareSender implements EmailSender {
       return { id: result?.messageId ?? null, error: null };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
+      // Surface the cause: this path was previously swallowed, making send
+      // failures invisible in logs and the API response.
+      console.error(
+        "[CloudflareSender] send failed:",
+        message,
+        e instanceof Error ? e.stack : "",
+      );
       return { id: null, error: { message } };
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #119. That PR added an optional `replyTo` that the senders forward as a `Reply-To` header. On the **Cloudflare** sender path, setting that header fails and the send is silently dropped.

## Root cause

`CloudflareSender` sets custom headers via a generic string loop (`msg.setHeader(key, value)`). That's fine for plain headers like `Message-ID` / `In-Reply-To`, but mimetext defines `Reply-To` as a **single-mailbox** header (`validateMailboxSingle`). Passing a bare string throws `MIMETEXT_INVALID_HEADER_VALUE`, which `CloudflareSender`'s `catch` swallowed — so every `replyTo` send returned `status: "failed"` and never delivered. (Resend and Bavimail paths were unaffected; #119's test plan left the Cloudflare manual-verify item unchecked.)

## Fix

- Wrap `Reply-To` values in a mimetext `Mailbox` before `setHeader`.
- Log the previously-swallowed error in `CloudflareSender`'s `catch`, so send failures are visible in `wrangler tail` and the API instead of disappearing.
- Add a regression test: a `Reply-To` header serializes into the raw MIME without throwing.

## Test plan

- [x] `vitest` — sender suite passes (24, +1 new regression test)
- [x] `tsc --noEmit` — clean
- [x] Verified live on a Cloudflare-provider instance: a `replyTo` send now returns `status: "sent"` and the `Reply-To` header lands in the delivered message (previously `failed` + no delivery).

## Backward compatibility

Additive and path-specific — only changes how the Cloudflare sender serializes a `Reply-To` header. No schema or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
