### PR TITLE
feat(emails): surface inbound Reply-To on the single-email endpoint

### DIFF
--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -214,6 +214,33 @@ describe("emails router", () => {
       expect(data.attachments).toEqual([]);
     });
 
+    it("surfaces replyTo from the inbound Reply-To header", async () => {
+      await createTestPerson({ id: "s1", email: "noreply@readerful.com" });
+      await createTestEmail({
+        id: "e-rt",
+        personId: "s1",
+        rawHeaders: JSON.stringify({
+          "reply-to": "Submitter Name <submitter@example.com>",
+        }),
+      });
+
+      const res = await authFetch("/api/emails/e-rt", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // Bare address, unwrapped from "Name <addr>" and lower-cased.
+      expect(data.replyTo).toBe("submitter@example.com");
+    });
+
+    it("returns replyTo null when there is no Reply-To header", async () => {
+      await createTestPerson({ id: "s1", email: "a@test.com" });
+      await createTestEmail({ id: "e-no-rt", personId: "s1" });
+
+      const res = await authFetch("/api/emails/e-no-rt", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.replyTo).toBeNull();
+    });
+
     it("returns 404 for missing email", async () => {
       const res = await authFetch("/api/emails/nonexistent", { apiKey });
       expect(res.status).toBe(404);

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -165,6 +165,7 @@ export async function createTestEmail(
     bodyText?: string;
     messageId?: string;
     isRead?: number;
+    rawHeaders?: string;
   } = {},
 ) {
   const db = getDb();
@@ -176,7 +177,7 @@ export async function createTestEmail(
     subject: opts.subject ?? "Test Subject",
     bodyHtml: "<p>Hello</p>",
     bodyText: opts.bodyText ?? "Hello",
-    rawHeaders: "{}",
+    rawHeaders: opts.rawHeaders ?? "{}",
     messageId: opts.messageId ?? "msg-1@example.com",
     isRead: opts.isRead ?? 0,
     receivedAt: now,

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -48,7 +48,41 @@ export const EmailSchema = z.object({
   cc: z.array(CcEntrySchema),
   timestamp: z.number(),
   attachmentCount: z.number().optional(),
+  replyTo: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        "Address from the inbound Reply-To header, when present (e.g. a " +
+        "contact form's actual submitter behind a noreply@ sender). Parsed " +
+        "from stored raw headers and returned by the single-email endpoint; " +
+        "null when there is no Reply-To.",
+    }),
 });
+
+/**
+ * Pull the Reply-To address out of an email's stored raw headers.
+ * `raw_headers` is a JSON object of all inbound headers (see email-handler),
+ * so no schema change is needed to surface this. Returns the bare address
+ * (lower-cased), unwrapping a "Name <addr>" form. Null when absent/malformed.
+ */
+function extractReplyTo(rawHeaders: string | null): string | null {
+  if (!rawHeaders) return null;
+  try {
+    const headers = JSON.parse(rawHeaders) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === "reply-to" && typeof value === "string") {
+        const angle = value.match(/<([^>]+)>/);
+        const addr = (angle ? angle[1] : value).trim().toLowerCase();
+        return addr || null;
+      }
+    }
+  } catch {
+    // Malformed raw_headers — treat as no Reply-To rather than failing the read.
+  }
+  return null;
+}
 
 const InboxMetaSchema = z.object({
   email: z.string(),
@@ -337,6 +371,7 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
         timestamp: row[0].receivedAt,
         fromAddress: null,
         toAddress: null,
+        replyTo: extractReplyTo(row[0].rawHeaders),
         cc: parseCc(row[0].cc),
         attachments: atts,
       },
@@ -382,6 +417,7 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
       bodyHtml: sent.bodyHtml,
       bodyText: sent.bodyText,
       isRead: null,
+      replyTo: null,
       cc: parseCc(sent.cc),
       timestamp: sent.sentAt,
       attachments: sentAtts,


### PR DESCRIPTION
## Summary

Inbound emails already persist every header in `raw_headers` (see `email-handler.ts`), so a received message's `Reply-To` is **already stored** — it just isn't exposed by the API. Contact-form-style messages arrive from a tenant `noreply@` sender with the real submitter in `Reply-To`, so surfacing it lets clients reply to the actual person.

## Changes

- Add an optional `replyTo` field to `EmailSchema`.
- `GET /api/emails/{id}` parses `Reply-To` out of `raw_headers` and returns the bare address (unwrapping `"Name <addr>"`, lower-cased), or `null` when absent. **No schema migration** — the data is already persisted.
- Sent emails return `replyTo: null`.

## Test plan

- [x] `vitest` — full suite passes (311 passed, 1 skipped; +2 new: surfaces from a `Reply-To` header, and `null` without one)
- [x] `tsc --noEmit` — clean
- [x] Verified live on a Cloudflare-provider instance: the `replyTo` field is present on the single-email response and returns `null` for a message with no `Reply-To` header (no regression).

## Notes

Pairs with the outbound Reply-To fix (#123). Together they make `Reply-To` work end-to-end: set on send, captured on receive, and exposed for clients to reply to.

## Backward compatibility

Additive — a new optional response field; no schema or breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
