### PR TITLE
chore: release v0.7.0 — suppression list + one-click unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-04
+
 ### Added
 
 - Suppression list with admin UI at `/admin/suppressions` and CRUD API at `/api/suppressions` (admin-only).
@@ -356,7 +358,8 @@ and admin tooling all changed; the data model is unchanged.
 - Demo deploy mode (`deploy:demo`) for DB-only demo instances.
 - Project scaffolding: Vite build, Vitest tests, Prettier, Husky + lint-staged, TypeScript strict mode.
 
-[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/choyiny/saasmail/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/choyiny/saasmail/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/choyiny/saasmail/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/choyiny/saasmail/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/choyiny/saasmail/compare/v0.5.0...v0.5.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` CHANGELOG entries from the suppression-list / one-click unsubscribe feature (#95) to a versioned `[0.7.0] - 2026-06-04` release block.
- Bumps `package.json` version from `0.6.0` → `0.7.0`.
- Adds the `[0.7.0]` compare link in the CHANGELOG footer and updates `[Unreleased]` to diff against `v0.7.0`.

## Test plan

- [ ] Verify `package.json` `"version"` is `"0.7.0"`.
- [ ] Verify CHANGELOG.md has `## [0.7.0] - 2026-06-04` with the suppression list entries under it and an empty `## [Unreleased]` section above.
- [ ] Verify the compare links at the bottom of CHANGELOG.md are correct.

https://claude.ai/code/session_011kvcahGGA7zXxAmJ8xjihV

---
_Generated by [Claude Code](https://claude.ai/code/session_011kvcahGGA7zXxAmJ8xjihV)_