### PR TITLE
Add inbox refresh: mobile pull-to-refresh, desktop button

### DIFF
--- a/src/components/InboxToolbar.tsx
+++ b/src/components/InboxToolbar.tsx
@@ -10,6 +10,7 @@ import {
   LayoutGrid,
   PenSquare,
   ArrowUpDown,
+  RefreshCw,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -44,6 +45,11 @@ interface InboxToolbarProps {
    *  toggle button next to the dropdown for discoverability. */
   sortSpec: InboxSortSpec;
   onSortChange: (spec: InboxSortSpec) => void;
+  /** Manually re-fetch the people list. Desktop-only button; mobile uses
+   *  pull-to-refresh in the list itself. */
+  onRefresh?: () => void;
+  /** True while a refresh is in flight — spins the refresh icon. */
+  refreshing?: boolean;
   /** Optional Compose button. Rendered to the right of the view toggle. */
   onCompose?: () => void;
 }
@@ -73,6 +79,8 @@ export default function InboxToolbar({
   onViewChange,
   sortSpec,
   onSortChange,
+  onRefresh,
+  refreshing,
   onCompose,
 }: InboxToolbarProps) {
   const [inboxOpen, setInboxOpen] = useState(false);
@@ -326,6 +334,27 @@ export default function InboxToolbar({
           </div>
         )}
       </div>
+
+      {/* Refresh — desktop only. Mobile refreshes via pull-to-refresh on the
+          list itself, so the button would be redundant there. */}
+      {onRefresh && (
+        <>
+          <span
+            className="mx-0.5 hidden h-4 w-px bg-border sm:block"
+            aria-hidden
+          />
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            aria-label="Refresh"
+            title="Refresh"
+            className="hidden h-7 w-7 shrink-0 items-center justify-center rounded-[5px] text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary disabled:opacity-60 sm:inline-flex"
+          >
+            <RefreshCw size={13} className={cn(refreshing && "animate-spin")} />
+          </button>
+        </>
+      )}
 
       {/* View toggle — pinned to the right edge. Hidden on mobile (the
           table view is unusable at narrow widths). */}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from "react";
+
+interface UsePullToRefreshOptions {
+  /** Called when the user pulls past the threshold and releases. May be async;
+   *  the spinner stays until the returned promise settles. */
+  onRefresh: () => Promise<unknown> | void;
+  /** Pull distance (px) required to trigger a refresh. */
+  threshold?: number;
+  /** Max distance the indicator travels — pulling further has no extra effect. */
+  maxPull?: number;
+}
+
+/**
+ * Touch-driven pull-to-refresh for a scrollable container. Attach `ref` to the
+ * element that scrolls and spread `handlers` onto the same element. The pull is
+ * only armed when the container is already scrolled to the top, so it never
+ * fights an in-progress scroll.
+ *
+ * Touch-only by design — desktop never fires these events, so it's inert there.
+ */
+export function usePullToRefresh<T extends HTMLElement>({
+  onRefresh,
+  threshold = 70,
+  maxPull = 110,
+}: UsePullToRefreshOptions) {
+  const ref = useRef<T | null>(null);
+  const startY = useRef<number | null>(null);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      const el = ref.current;
+      // Only arm when resting at the top and not mid-refresh.
+      if (!el || el.scrollTop > 0 || refreshing) {
+        startY.current = null;
+        return;
+      }
+      startY.current = e.touches[0].clientY;
+    },
+    [refreshing],
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (startY.current === null || refreshing) return;
+      const el = ref.current;
+      if (!el) return;
+      // If the container scrolled away from the top mid-gesture, bail out so a
+      // normal scroll wins.
+      if (el.scrollTop > 0) {
+        startY.current = null;
+        setPullDistance(0);
+        return;
+      }
+      const delta = e.touches[0].clientY - startY.current;
+      if (delta <= 0) {
+        setPullDistance(0);
+        return;
+      }
+      // Rubber-band resistance so the pull feels heavier the further it goes.
+      setPullDistance(Math.min(maxPull, delta * 0.5));
+    },
+    [maxPull, refreshing],
+  );
+
+  const onTouchEnd = useCallback(() => {
+    if (startY.current === null) return;
+    startY.current = null;
+    if (pullDistance >= threshold) {
+      setRefreshing(true);
+      // Hold the indicator at the threshold while the refresh runs.
+      setPullDistance(threshold);
+      Promise.resolve(onRefresh()).finally(() => {
+        setRefreshing(false);
+        setPullDistance(0);
+      });
+    } else {
+      setPullDistance(0);
+    }
+  }, [pullDistance, threshold, onRefresh]);
+
+  return {
+    ref,
+    pullDistance,
+    refreshing,
+    threshold,
+    /** Spread onto the same element that `ref` is attached to. */
+    handlers: { onTouchStart, onTouchMove, onTouchEnd },
+  };
+}

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useOutletContext, useSearchParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
@@ -116,6 +116,10 @@ export default function InboxPage() {
     Set<string>
   >(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Manual refresh (desktop button / mobile pull-to-refresh) — separate from
+  // `peopleLoading` so a refresh keeps the current list visible (just a
+  // spinner) instead of flashing the full-pane "Loading…" placeholder.
+  const [refreshing, setRefreshing] = useState(false);
 
   // Resizable sidebar — the user can drag the right edge to make the
   // people list narrower (down to "just avatar + unread badge" mode).
@@ -134,24 +138,39 @@ export default function InboxPage() {
     sortSpec.key,
   ]);
 
+  // The current people query, derived from search + filters + sort + page.
+  // Shared by the debounced auto-load below and the manual refresh path so
+  // both always hit the same parameters.
+  const peopleQuery = useMemo(
+    () => ({
+      q: search || undefined,
+      recipient: filters.recipient,
+      unread: filters.unread,
+      hasAttachment: filters.hasAttachment,
+      sort: sortSpec.key,
+      direction: sortSpec.direction,
+      page: peoplePage,
+      limit: PEOPLE_PAGE_SIZE,
+    }),
+    [
+      search,
+      filters.recipient,
+      filters.unread,
+      filters.hasAttachment,
+      sortSpec.key,
+      sortSpec.direction,
+      peoplePage,
+    ],
+  );
+
   // Fetch the people list at the InboxPage level so both Table view
   // (PeopleTable) and List view (PersonList sidebar) see the same data.
   // Previously the fetch lived inside PersonList, which meant Table view
   // showed an empty state because PersonList wasn't mounted.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setPeopleLoading(true);
     const t = setTimeout(() => {
-      fetchGroupedPeople({
-        q: search || undefined,
-        recipient: filters.recipient,
-        unread: filters.unread,
-        hasAttachment: filters.hasAttachment,
-        sort: sortSpec.key,
-        direction: sortSpec.direction,
-        page: peoplePage,
-        limit: PEOPLE_PAGE_SIZE,
-      })
+      fetchGroupedPeople(peopleQuery)
         .then((res) => {
           setItems(res.data);
           setPeopleTotal(res.total);
@@ -160,15 +179,21 @@ export default function InboxPage() {
         .finally(() => setPeopleLoading(false));
     }, 200);
     return () => clearTimeout(t);
-  }, [
-    search,
-    peoplePage,
-    filters.recipient,
-    filters.unread,
-    filters.hasAttachment,
-    sortSpec.key,
-    sortSpec.direction,
-  ]);
+  }, [peopleQuery]);
+
+  // Manual refresh: re-fetch the current page immediately (no debounce) while
+  // keeping the existing rows on screen. Returns the promise so the mobile
+  // pull-to-refresh spinner can wait on it.
+  const refreshPeople = useCallback(() => {
+    setRefreshing(true);
+    return fetchGroupedPeople(peopleQuery)
+      .then((res) => {
+        setItems(res.data);
+        setPeopleTotal(res.total);
+        setAggregates(res.aggregates);
+      })
+      .finally(() => setRefreshing(false));
+  }, [peopleQuery]);
 
   const toggleSelected = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -421,6 +446,8 @@ export default function InboxPage() {
             }}
             sortSpec={sortSpec}
             onSortChange={setSortSpec}
+            onRefresh={refreshPeople}
+            refreshing={refreshing}
             onCompose={onCompose}
           />
         </div>
@@ -594,6 +621,7 @@ export default function InboxPage() {
                 selectedIds={selectedIds}
                 onToggleSelected={toggleSelected}
                 onMarkPersonRead={handleMarkPersonRead}
+                onRefresh={refreshPeople}
                 compact={isCompact}
               />
               {/* Drag handle — visible on hover, full-height column. */}

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -7,6 +7,7 @@ import {
   MoreHorizontal,
   Trash2,
   CheckCheck,
+  RefreshCw,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -16,6 +17,7 @@ import {
   type GroupedConversation,
 } from "@/lib/api";
 import GroupRow from "@/components/GroupRow";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh";
 
 interface PersonListProps {
   /** Mixed list of person + group rows from /api/people/grouped. */
@@ -37,6 +39,11 @@ interface PersonListProps {
   onToggleSelected?: (id: string) => void;
   onMarkPersonRead?: (id: string) => void;
   onMarkConversationRead?: (id: string) => void;
+  /**
+   * Pull-to-refresh handler (mobile). When provided, pulling down from the top
+   * of the list re-fetches it. May be async; the spinner waits on the promise.
+   */
+  onRefresh?: () => Promise<unknown> | void;
   /**
    * When true, person rows collapse to just the avatar + unread badge
    * — the same shape group rows use in compact mode. Driven by the
@@ -109,6 +116,7 @@ export default function PersonList({
   onToggleSelected,
   onMarkPersonRead,
   onMarkConversationRead,
+  onRefresh,
   compact = false,
 }: PersonListProps) {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
@@ -116,6 +124,19 @@ export default function PersonList({
     null,
   );
   const menuRef = useRef<HTMLDivElement | null>(null);
+
+  // Mobile pull-to-refresh on the scrollable list. No-op when onRefresh isn't
+  // provided (e.g. the handler is wired through from InboxPage).
+  const {
+    ref: scrollRef,
+    pullDistance,
+    refreshing,
+    threshold,
+    handlers: pullHandlers,
+  } = usePullToRefresh<HTMLDivElement>({
+    onRefresh: onRefresh ?? (() => {}),
+  });
+  const pullActive = pullDistance > 0 || refreshing;
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -179,245 +200,284 @@ export default function PersonList({
       )}
 
       {/* Scrollable list — independent of the right pane */}
-      <div className="smooth-scroll min-h-0 flex-1 overflow-y-auto">
-        {loading ? (
-          <div className="flex flex-col items-center justify-center gap-2 px-4 py-16 text-center">
-            <p className="text-sm font-light text-text-tertiary">Loading…</p>
-          </div>
-        ) : items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
-            <p className="text-sm font-medium text-text-primary">
-              No people found
-            </p>
-            <p className="text-xs font-light text-text-tertiary">
-              Try a different search, or wait for new mail.
-            </p>
-          </div>
-        ) : (
-          <ul className="divide-y divide-border/60">
-            {items.map((item) => {
-              if (item.type === "group") {
-                return (
-                  <GroupRow
-                    key={`g_${item.id}`}
-                    group={item}
-                    isSelected={selectedConversationId === item.id}
-                    onSelect={() => onSelectConversation(item)}
-                    onMarkRead={onMarkConversationRead}
-                    compact={compact}
-                  />
-                );
+      <div
+        ref={scrollRef}
+        {...(onRefresh ? pullHandlers : {})}
+        className="smooth-scroll relative min-h-0 flex-1 overflow-y-auto"
+        style={onRefresh ? { overscrollBehaviorY: "contain" } : undefined}
+      >
+        {/* Pull-to-refresh indicator (mobile). Sits above the list; the list
+            content slides down to reveal it as the user pulls. */}
+        {onRefresh && pullActive && (
+          <div
+            className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-center"
+            style={{
+              height: pullDistance,
+              opacity: Math.min(1, pullDistance / threshold),
+            }}
+          >
+            <RefreshCw
+              size={18}
+              className={cn("text-text-tertiary", refreshing && "animate-spin")}
+              style={
+                refreshing
+                  ? undefined
+                  : {
+                      transform: `rotate(${(pullDistance / threshold) * 270}deg)`,
+                    }
               }
-              const person = item;
-              const isSelected = selectedPersonId === person.id;
-              const isChecked = selectedIds?.has(person.id) ?? false;
-              const selectionMode = selectedIds !== undefined;
-              const anySelected = (selectedIds?.size ?? 0) > 0;
-              const menuOpen = menuOpenId === person.id;
-              const color = avatarColor(person.email);
-              const display = person.name || person.email;
-              return (
-                <li
-                  key={person.id}
-                  className={cn(
-                    "group relative transition-colors",
-                    isSelected
-                      ? "bg-text-primary/[0.04]"
-                      : isChecked
-                        ? "bg-violet/[0.04]"
-                        : "hover:bg-text-primary/[0.025]",
-                  )}
-                >
-                  {isSelected && (
-                    <span
-                      className="absolute inset-y-2 left-0 w-0.5 rounded-full"
-                      style={{ backgroundColor: "#7c5cfc" }}
-                      aria-hidden
+            />
+          </div>
+        )}
+        <div
+          style={{
+            transform: pullActive ? `translateY(${pullDistance}px)` : undefined,
+            transition:
+              pullDistance === 0 ? "transform 0.2s ease-out" : undefined,
+          }}
+        >
+          {loading ? (
+            <div className="flex flex-col items-center justify-center gap-2 px-4 py-16 text-center">
+              <p className="text-sm font-light text-text-tertiary">Loading…</p>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+              <p className="text-sm font-medium text-text-primary">
+                No people found
+              </p>
+              <p className="text-xs font-light text-text-tertiary">
+                Try a different search, or wait for new mail.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-border/60">
+              {items.map((item) => {
+                if (item.type === "group") {
+                  return (
+                    <GroupRow
+                      key={`g_${item.id}`}
+                      group={item}
+                      isSelected={selectedConversationId === item.id}
+                      onSelect={() => onSelectConversation(item)}
+                      onMarkRead={onMarkConversationRead}
+                      compact={compact}
                     />
-                  )}
-
-                  <button
-                    data-testid="person-row"
-                    data-person-id={person.id}
-                    onClick={() => onSelectPerson(person)}
+                  );
+                }
+                const person = item;
+                const isSelected = selectedPersonId === person.id;
+                const isChecked = selectedIds?.has(person.id) ?? false;
+                const selectionMode = selectedIds !== undefined;
+                const anySelected = (selectedIds?.size ?? 0) > 0;
+                const menuOpen = menuOpenId === person.id;
+                const color = avatarColor(person.email);
+                const display = person.name || person.email;
+                return (
+                  <li
+                    key={person.id}
                     className={cn(
-                      "flex w-full items-start gap-2.5 px-3 py-2.5 text-left active:bg-text-primary/[0.04] sm:py-2",
-                      compact &&
-                        "items-center justify-center px-2 py-2 sm:py-1.5",
+                      "group relative transition-colors",
+                      isSelected
+                        ? "bg-text-primary/[0.04]"
+                        : isChecked
+                          ? "bg-violet/[0.04]"
+                          : "hover:bg-text-primary/[0.025]",
                     )}
                   >
-                    {/* Selection checkbox — appears on hover or when any selected.
-                        Clicking it toggles selection without opening the person. */}
-                    {selectionMode && (
+                    {isSelected && (
                       <span
-                        role="checkbox"
-                        aria-checked={isChecked}
-                        aria-label={`Select ${display}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onToggleSelected?.(person.id);
-                        }}
-                        className={cn(
-                          "mt-1.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border transition-all",
-                          isChecked
-                            ? "border-text-primary bg-text-primary text-white opacity-100"
-                            : anySelected
-                              ? "border-border bg-card opacity-100 hover:border-text-primary/40"
-                              : "border-border bg-card opacity-0 group-hover:opacity-100",
-                        )}
-                      >
-                        {isChecked && (
-                          <svg
-                            className="h-3 w-3"
-                            viewBox="0 0 12 12"
-                            fill="none"
-                          >
-                            <path
-                              d="M2.5 6.5L4.75 8.75L9.5 4"
-                              stroke="currentColor"
-                              strokeWidth="1.8"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                          </svg>
-                        )}
-                      </span>
+                        className="absolute inset-y-2 left-0 w-0.5 rounded-full"
+                        style={{ backgroundColor: "#7c5cfc" }}
+                        aria-hidden
+                      />
                     )}
 
-                    {/* Avatar — hidden behind checkbox when hovering in selection mode */}
-                    <span
+                    <button
+                      data-testid="person-row"
+                      data-person-id={person.id}
+                      onClick={() => onSelectPerson(person)}
                       className={cn(
-                        "relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold tracking-tight",
-                        selectionMode &&
-                          (anySelected || isChecked) &&
-                          "hidden sm:flex",
+                        "flex w-full items-start gap-2.5 px-3 py-2.5 text-left active:bg-text-primary/[0.04] sm:py-2",
+                        compact &&
+                          "items-center justify-center px-2 py-2 sm:py-1.5",
                       )}
-                      style={{ backgroundColor: color.bg, color: color.fg }}
                     >
-                      {initials(person.name, person.email)}
-                      {/* In compact mode, the unread badge is anchored to the avatar */}
-                      {compact && person.unreadCount > 0 && (
+                      {/* Selection checkbox — appears on hover or when any selected.
+                        Clicking it toggles selection without opening the person. */}
+                      {selectionMode && (
                         <span
-                          className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white ring-2 ring-bg-subtle"
-                          style={{ backgroundColor: "#7c5cfc" }}
-                          aria-label={`${person.unreadCount} unread`}
+                          role="checkbox"
+                          aria-checked={isChecked}
+                          aria-label={`Select ${display}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleSelected?.(person.id);
+                          }}
+                          className={cn(
+                            "mt-1.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border transition-all",
+                            isChecked
+                              ? "border-text-primary bg-text-primary text-white opacity-100"
+                              : anySelected
+                                ? "border-border bg-card opacity-100 hover:border-text-primary/40"
+                                : "border-border bg-card opacity-0 group-hover:opacity-100",
+                          )}
                         >
-                          {person.unreadCount}
+                          {isChecked && (
+                            <svg
+                              className="h-3 w-3"
+                              viewBox="0 0 12 12"
+                              fill="none"
+                            >
+                              <path
+                                d="M2.5 6.5L4.75 8.75L9.5 4"
+                                stroke="currentColor"
+                                strokeWidth="1.8"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          )}
                         </span>
                       )}
-                    </span>
 
-                    <div className={cn("min-w-0 flex-1", compact && "hidden")}>
-                      <div className="flex items-baseline justify-between gap-3">
-                        <span
-                          className={cn(
-                            "truncate text-sm",
-                            person.unreadCount > 0
-                              ? "font-semibold text-text-primary"
-                              : "font-medium text-text-primary",
-                          )}
-                        >
-                          {display}
-                          {person.name && (
-                            <span className="ml-1.5 font-light text-text-tertiary">
-                              {person.email}
-                            </span>
-                          )}
-                        </span>
-                        <span className="shrink-0 text-[11px] font-light text-text-tertiary">
-                          {formatTime(person.lastEmailAt)}
-                        </span>
-                      </div>
-
-                      <div className="mt-0.5 flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-1.5 text-[11px] text-text-tertiary">
-                          <span>
-                            {person.totalCount} email
-                            {person.totalCount !== 1 ? "s" : ""}
-                          </span>
-                          {person.recipientCount > 1 && (
-                            <>
-                              <span className="text-text-tertiary/40">·</span>
-                              <span>{person.recipientCount} inboxes</span>
-                            </>
-                          )}
-                          {person.hasAttachment === 1 && (
-                            <Paperclip
-                              size={10}
-                              className="text-text-tertiary"
-                              aria-label="Has attachment"
-                            />
-                          )}
-                        </div>
-
-                        {/* Click unread badge to mark all read for this person.
-                            Larger tap target on mobile (h-6 vs h-5). */}
-                        {person.unreadCount > 0 && (
+                      {/* Avatar — hidden behind checkbox when hovering in selection mode */}
+                      <span
+                        className={cn(
+                          "relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold tracking-tight",
+                          selectionMode &&
+                            (anySelected || isChecked) &&
+                            "hidden sm:flex",
+                        )}
+                        style={{ backgroundColor: color.bg, color: color.fg }}
+                      >
+                        {initials(person.name, person.email)}
+                        {/* In compact mode, the unread badge is anchored to the avatar */}
+                        {compact && person.unreadCount > 0 && (
                           <span
-                            role="button"
-                            tabIndex={0}
-                            data-testid="person-unread-badge"
-                            title="Tap to mark all as read"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onMarkPersonRead?.(person.id);
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onMarkPersonRead?.(person.id);
-                              }
-                            }}
-                            className="group/badge flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-full px-2 text-[11px] font-bold text-white transition-all active:scale-95 sm:h-5 sm:min-w-5 sm:px-1.5 sm:text-[10px] sm:hover:scale-110"
+                            className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white ring-2 ring-bg-subtle"
                             style={{ backgroundColor: "#7c5cfc" }}
+                            aria-label={`${person.unreadCount} unread`}
                           >
-                            <span className="group-hover/badge:hidden">
-                              {person.unreadCount}
-                            </span>
-                            <CheckCheck
-                              size={11}
-                              className="hidden group-hover/badge:block"
-                            />
+                            {person.unreadCount}
                           </span>
                         )}
-                      </div>
-                    </div>
-                  </button>
+                      </span>
 
-                  {isAdmin && !compact && (
-                    <button
-                      data-testid="person-kebab-menu"
-                      data-person-id={person.id}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (menuOpen) {
-                          setMenuOpenId(null);
-                        } else {
-                          const rect = e.currentTarget.getBoundingClientRect();
-                          setMenuPos({
-                            top: rect.bottom + 4,
-                            right: window.innerWidth - rect.right,
-                          });
-                          setMenuOpenId(person.id);
-                        }
-                      }}
-                      className={cn(
-                        "absolute right-2 top-3 rounded p-1 text-text-tertiary transition-opacity hover:bg-bg-subtle hover:text-text-secondary",
-                        menuOpen
-                          ? "opacity-100"
-                          : "opacity-0 group-hover:opacity-100",
-                      )}
-                      aria-label="Person actions"
-                    >
-                      <MoreHorizontal size={14} />
+                      <div
+                        className={cn("min-w-0 flex-1", compact && "hidden")}
+                      >
+                        <div className="flex items-baseline justify-between gap-3">
+                          <span
+                            className={cn(
+                              "truncate text-sm",
+                              person.unreadCount > 0
+                                ? "font-semibold text-text-primary"
+                                : "font-medium text-text-primary",
+                            )}
+                          >
+                            {display}
+                            {person.name && (
+                              <span className="ml-1.5 font-light text-text-tertiary">
+                                {person.email}
+                              </span>
+                            )}
+                          </span>
+                          <span className="shrink-0 text-[11px] font-light text-text-tertiary">
+                            {formatTime(person.lastEmailAt)}
+                          </span>
+                        </div>
+
+                        <div className="mt-0.5 flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-1.5 text-[11px] text-text-tertiary">
+                            <span>
+                              {person.totalCount} email
+                              {person.totalCount !== 1 ? "s" : ""}
+                            </span>
+                            {person.recipientCount > 1 && (
+                              <>
+                                <span className="text-text-tertiary/40">·</span>
+                                <span>{person.recipientCount} inboxes</span>
+                              </>
+                            )}
+                            {person.hasAttachment === 1 && (
+                              <Paperclip
+                                size={10}
+                                className="text-text-tertiary"
+                                aria-label="Has attachment"
+                              />
+                            )}
+                          </div>
+
+                          {/* Click unread badge to mark all read for this person.
+                            Larger tap target on mobile (h-6 vs h-5). */}
+                          {person.unreadCount > 0 && (
+                            <span
+                              role="button"
+                              tabIndex={0}
+                              data-testid="person-unread-badge"
+                              title="Tap to mark all as read"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onMarkPersonRead?.(person.id);
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  onMarkPersonRead?.(person.id);
+                                }
+                              }}
+                              className="group/badge flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-full px-2 text-[11px] font-bold text-white transition-all active:scale-95 sm:h-5 sm:min-w-5 sm:px-1.5 sm:text-[10px] sm:hover:scale-110"
+                              style={{ backgroundColor: "#7c5cfc" }}
+                            >
+                              <span className="group-hover/badge:hidden">
+                                {person.unreadCount}
+                              </span>
+                              <CheckCheck
+                                size={11}
+                                className="hidden group-hover/badge:block"
+                              />
+                            </span>
+                          )}
+                        </div>
+                      </div>
                     </button>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
+
+                    {isAdmin && !compact && (
+                      <button
+                        data-testid="person-kebab-menu"
+                        data-person-id={person.id}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (menuOpen) {
+                            setMenuOpenId(null);
+                          } else {
+                            const rect =
+                              e.currentTarget.getBoundingClientRect();
+                            setMenuPos({
+                              top: rect.bottom + 4,
+                              right: window.innerWidth - rect.right,
+                            });
+                            setMenuOpenId(person.id);
+                          }
+                        }}
+                        className={cn(
+                          "absolute right-2 top-3 rounded p-1 text-text-tertiary transition-opacity hover:bg-bg-subtle hover:text-text-secondary",
+                          menuOpen
+                            ? "opacity-100"
+                            : "opacity-0 group-hover:opacity-100",
+                        )}
+                        aria-label="Person actions"
+                      >
+                        <MoreHorizontal size={14} />
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
       </div>
 
       {menuOpenId &&


### PR DESCRIPTION
## What

Adds a way to manually refresh the people/inbox list for new mail:

- **Mobile** — pull down from the top of the people list to re-fetch. A rubber-band indicator follows the pull (the icon rotates as you drag) and spins while the refresh is in flight.
- **Desktop** — a refresh button (`RefreshCw`) in the inbox toolbar, between the sort and view-toggle controls. It spins while refreshing. Hidden on mobile, where pull-to-refresh takes over.

## How

- New `usePullToRefresh` hook (`src/hooks/usePullToRefresh.ts`) — touch-only, armed only when the scroll container is resting at the top, with rubber-band resistance and a configurable threshold. Inert on desktop (no touch events).
- `InboxPage` now derives the people query into a memo shared by the existing debounced auto-load and a new `refreshPeople` callback. The manual path re-fetches the current page **in place** (rows stay visible) using a separate `refreshing` flag, instead of flashing the full-pane "Loading…" placeholder.
- `refreshPeople` is wired to the desktop toolbar button and to `PersonList`'s pull-to-refresh.

## Notes

- `yarn tsc -b` passes with no new errors (the 6 pre-existing errors in unrelated files are unchanged).
- Pull-to-refresh only attaches its handlers when an `onRefresh` prop is provided, so other `PersonList` usages are unaffected.

https://claude.ai/code/session_01WTmXvvFbJxRiM8r1sd3eos

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTmXvvFbJxRiM8r1sd3eos)_