### PR TITLE
feat(emails): visual indicator for failed sends (#150)

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
-import { Link2, Maximize2, Paperclip, Trash2, UserPen } from "lucide-react";
+import {
+  AlertTriangle,
+  Link2,
+  Maximize2,
+  Paperclip,
+  Trash2,
+  UserPen,
+} from "lucide-react";
 import CcChips from "@/components/CcChips";
 import type { Email } from "@/lib/api";
 import { copyMessageLink, messageDomId } from "@/lib/message-link";
@@ -50,6 +57,7 @@ export default function MessageBubble({
   const [expanded, setExpanded] = useState(false);
   const isSent = email.type === "sent";
   const isUnread = email.type === "received" && email.isRead === 0;
+  const failedToSend = isSent && email.status === "failed";
 
   const text =
     email.bodyText ||
@@ -103,7 +111,11 @@ export default function MessageBubble({
       data-testid="thread-message"
       data-email-id={email.id}
       className={`group ${compact ? "px-3 py-1.5" : "px-4 sm:px-6 py-2"} hover:bg-bg-muted/50 transition-colors scroll-mt-20 ${
-        isUnread ? "bg-accent/5" : ""
+        failedToSend
+          ? "border-l-2 border-red-500/60 bg-red-500/5"
+          : isUnread
+            ? "bg-accent/5"
+            : ""
       }`}
       onClick={handleClick}
     >
@@ -119,6 +131,16 @@ export default function MessageBubble({
         <span className="text-[11px] text-text-tertiary truncate min-w-0">
           To: {toAddress}
         </span>
+        {failedToSend && (
+          <span
+            data-testid="message-failed-badge"
+            title="This message was rejected by the email provider and was not delivered."
+            className="inline-flex items-center gap-1 rounded-[5px] bg-red-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-500 shrink-0"
+          >
+            <AlertTriangle size={10} />
+            Failed to send
+          </span>
+        )}
         <span className="text-[10px] text-text-tertiary shrink-0 ml-auto">
           {dateStr} {timeStr}
         </span>

--- a/src/components/ThreadMessage.tsx
+++ b/src/components/ThreadMessage.tsx
@@ -1,4 +1,4 @@
-import { Send, Inbox as InboxIcon } from "lucide-react";
+import { Send, Inbox as InboxIcon, AlertTriangle } from "lucide-react";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
 import type { Email } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -24,6 +24,7 @@ export default function ThreadMessage({
   highlight,
 }: ThreadMessageProps) {
   const isSent = email.type === "sent";
+  const failedToSend = isSent && email.status === "failed";
   const sender = isSent
     ? `you (${email.fromAddress ?? "—"})`
     : (email.fromAddress ?? "Unknown");
@@ -43,13 +44,20 @@ export default function ThreadMessage({
         <span
           className={cn(
             "inline-flex items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider",
-            isSent
-              ? "bg-bg-muted text-text-secondary"
-              : "bg-violet/10 text-violet",
+            failedToSend
+              ? "bg-red-500/10 text-red-500"
+              : isSent
+                ? "bg-bg-muted text-text-secondary"
+                : "bg-violet/10 text-violet",
           )}
           style={!isSent ? { color: "#7c5cfc" } : undefined}
         >
-          {isSent ? (
+          {failedToSend ? (
+            <>
+              <AlertTriangle size={9} />
+              Failed to send
+            </>
+          ) : isSent ? (
             <>
               <Send size={9} />
               Sent

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -68,6 +68,8 @@ export interface Email {
   isRead: number | null;
   cc: CcEntry[];
   timestamp: number;
+  /** Delivery status for sent messages: "sent" | "failed". Null for received. */
+  status?: string | null;
   attachmentCount?: number;
   attachments?: Attachment[];
   /** Inbound Reply-To address, surfaced by the single-email endpoint. */

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -72,6 +72,35 @@ describe("emails router", () => {
       expect(data[1].type).toBe("received");
     });
 
+    it("surfaces delivery status: 'failed' on sent, null on received", async () => {
+      const db = getDb();
+      await createTestPerson({ id: "s1", email: "a@test.com" });
+      await createTestEmail({ id: "e1", personId: "s1" });
+
+      const now = Math.floor(Date.now() / 1000);
+      await db.insert(sentEmails).values({
+        id: "se-failed",
+        personId: "s1",
+        fromAddress: "me@saasmail.test",
+        toAddress: "a@test.com",
+        subject: "Rejected",
+        bodyHtml: "<p>nope</p>",
+        bodyText: null,
+        resendId: null,
+        status: "failed",
+        sentAt: now + 10,
+        createdAt: now + 10,
+      });
+
+      const res = await authFetch("/api/emails/by-person/s1", { apiKey });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { emails: any[] };
+      const sent = body.emails.find((e) => e.type === "sent");
+      const received = body.emails.find((e) => e.type === "received");
+      expect(sent.status).toBe("failed");
+      expect(received.status).toBeNull();
+    });
+
     it("includes sent replies when filtering by recipient", async () => {
       const db = getDb();
       await createTestPerson({ id: "s1", email: "a@test.com" });

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -48,6 +48,15 @@ export const EmailSchema = z.object({
   isRead: z.number().nullable(),
   cc: z.array(CcEntrySchema),
   timestamp: z.number(),
+  status: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        "Delivery status for sent messages: 'sent' or 'failed' (the provider " +
+        "rejected it). Null for received messages.",
+    }),
   attachmentCount: z.number().optional(),
   replyTo: z
     .string()
@@ -178,6 +187,7 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
       timestamp: sentEmails.sentAt,
       fromAddress: sentEmails.fromAddress,
       toAddress: sentEmails.toAddress,
+      status: sentEmails.status,
     })
     .from(sentEmails)
     .where(and(...sentConditions))
@@ -198,6 +208,7 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
       isRead: e.isRead,
       cc: parseCc(e.cc),
       timestamp: e.timestamp,
+      status: null,
     })),
     ...sent.map((e) => ({
       id: e.id,
@@ -212,6 +223,7 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
       isRead: null,
       cc: parseCc(e.cc),
       timestamp: e.timestamp,
+      status: e.status,
     })),
   ].sort((a, b) => b.timestamp - a.timestamp);
 
@@ -421,6 +433,7 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
       replyTo: null,
       cc: parseCc(sent.cc),
       timestamp: sent.sentAt,
+      status: sent.status,
       attachments: sentAtts,
     },
     200,


### PR DESCRIPTION
First chunk of #150 — a clear visual indicator when a message didn't actually send.

Sends rejected by the provider (e.g. Cloudflare over quota) are already persisted with `status='failed'` (`send-router.ts`), but that status was never exposed by the API or rendered, so a failed send looked identical to a sent one.

**Changes**
- Surface `status` on the emails API: added to `EmailSchema`, the `by-person` conversation endpoint (sent rows carry their status, received are null), and the single-email endpoint.
- Render a **"Failed to send"** badge + subtle red tint on the message in `MessageBubble` (covers both chat and thread modes) and flip the `ThreadMessage` context-card badge to a red "Failed to send".

Scoped deliberately small: just the indicator, **no filter / list view** — that belongs with the broader outbox/retry work (#151), which will also move failed sends into a dedicated surface. This is the interim visibility fix.

**Test plan**
- `yarn tsc --noEmit` clean; `yarn test` 394 passing (added a case asserting the conversation endpoint returns `status:"failed"` for a failed sent message, null for received).