### PR TITLE
feat(email): add Postmark send provider

### DIFF
--- a/.claude/skills/saasmail-onboarding/SKILL.md
+++ b/.claude/skills/saasmail-onboarding/SKILL.md
@@ -16,7 +16,7 @@ Read `wrangler.jsonc.example` in the project root so you know the exact shape of
 Set expectations up front, so the user knows what they're committing to:
 
 - **~30–40 minutes** total; most of the wait is DNS propagation, not typing.
-- **Two decisions**: which domains will be used, and which outbound email provider (Cloudflare Email Sending, Resend, or Bavimail).
+- **Two decisions**: which domains will be used, and which outbound email provider (Cloudflare Email Sending, Resend, Bavimail, or Postmark).
 - **Three manual Cloudflare-dashboard steps** (Email Routing per inbound domain, Email Service per send-from domain, and checking the deployed worker).
 - **Cost**: a Cloudflare **Workers Paid plan (~$5/mo)** is required. saasmail uses Queues, which aren't on the free plan. Email Routing is free; Cloudflare Email Sending is usage-based.
 
@@ -81,8 +81,9 @@ Most single-domain setups use the same domain for all three, with the UI on a su
 - **Option A — Cloudflare Email Sending** (default; recommended for a pure-Cloudflare setup). Uses the `send_email` binding. Each send-from domain must be onboarded in Cloudflare Email Service (Step 8 below).
 - **Option B — Resend**. Set `RESEND_API_KEY` as a secret. Each send-from domain must be verified in the Resend dashboard instead.
 - **Option C — Bavimail**. Set both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` as secrets. The alias ID identifies the sending alias configured in the Bavimail dashboard, which is also where each send-from domain is verified.
+- **Option D — Postmark**. Set `POSTMARK_API_KEY` (your Postmark server's API token) as a secret. Each send-from domain must be verified in the Postmark dashboard.
 
-Runtime precedence: **Bavimail** wins when both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` are set; otherwise **Resend** wins when `RESEND_API_KEY` is set; otherwise the `send_email` binding is used. Default the user to Option A unless they already have a Resend or Bavimail account and prefer it.
+Runtime precedence: **Bavimail** wins when both `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` are set; otherwise **Postmark** wins when `POSTMARK_API_KEY` is set; otherwise **Resend** wins when `RESEND_API_KEY` is set; otherwise the `send_email` binding is used. Default the user to Option A unless they already have a Resend, Bavimail, or Postmark account and prefer it.
 
 ## Deployment Steps
 
@@ -192,9 +193,17 @@ wrangler secret put BAVIMAIL_API_KEY
 wrangler secret put BAVIMAIL_ALIAS_ID
 ```
 
-Paste the Bavimail API bearer token and alias UUID (from the Bavimail dashboard) when prompted. Both must be set — if only one is present, saasmail falls through to Resend or the `send_email` binding.
+Paste the Bavimail API bearer token and alias UUID (from the Bavimail dashboard) when prompted. Both must be set — if only one is present, saasmail falls through to Postmark, Resend, or the `send_email` binding.
 
-Do **not** set `RESEND_API_KEY` for Option A or C — its mere presence tells saasmail to use Resend, overriding the `send_email` binding. Likewise, do **not** set the Bavimail secrets for Option A or B — Bavimail wins over both when both Bavimail vars are present.
+If Decision 2 is **Option D (Postmark)**, run:
+
+```bash
+wrangler secret put POSTMARK_API_KEY
+```
+
+Paste the Postmark server API token (from the Postmark dashboard → your server → **API Tokens**) when prompted.
+
+Set the secret(s) for **only** the provider you chose. A provider's secrets being present is what selects it, in precedence order Bavimail > Postmark > Resend > the `send_email` binding — so a stray `RESEND_API_KEY` or `POSTMARK_API_KEY` will override the `send_email` binding for Option A.
 
 ### Step 6: Apply Database Migrations
 
@@ -281,6 +290,8 @@ If the worker isn't in the dropdown, Step 7 didn't actually succeed — go back 
 
 **Option C (Bavimail)**: verify each send-from domain in the Bavimail dashboard, add the DKIM/SPF records it provides, and confirm the sending alias (whose ID you set as `BAVIMAIL_ALIAS_ID`) is attached to the verified domain. Then skip the rest of this step.
 
+**Option D (Postmark)**: verify each send-from domain in the Postmark dashboard → **Sender Signatures / Domains**, and add the DKIM/SPF (Return-Path) records Postmark provides. Then skip the rest of this step.
+
 **Option A (Cloudflare Email Sending)**: repeat for each send-from domain from Decision 1:
 
 1. Open [Email Service](https://dash.cloudflare.com/?to=/:account/email-service) — **account-level**, not a per-zone setting.
@@ -303,7 +314,7 @@ Show the user exactly what was set up, substituting their real values:
 
 - Worker deployed at `<BASE_URL>`
 - Inbound: Cloudflare Email Routing → worker, on `<inbound domain(s)>`
-- Outbound: `<Cloudflare Email Sending | Resend | Bavimail>`, from `<send-from domain(s)>`
+- Outbound: `<Cloudflare Email Sending | Resend | Bavimail | Postmark>`, from `<send-from domain(s)>`
 - D1 database `saasmail-db` (binding `DB`)
 - R2 bucket `saasmail-attachments` (binding `R2`)
 - Queue `saasmail-sequence-emails` (binding `EMAIL_QUEUE`)
@@ -314,6 +325,6 @@ Show the user exactly what was set up, substituting their real values:
 - **`wrangler queues create` fails with a plan error** — Workers Paid plan isn't actually active. Recheck at https://dash.cloudflare.com/?to=/:account/workers/plans.
 - **Worker missing from Email Routing "Send to a Worker" dropdown** — Step 7 didn't succeed, or the dashboard is cached. Run `wrangler deployments list` to confirm, then refresh the dashboard.
 - **Inbound test email never arrives** — MX records haven't propagated, or the catch-all isn't saved. Email Routing **Overview** should say status **Active**; `dig MX <inbound domain>` should return `*.mx.cloudflare.net` hosts.
-- **Outbound email looks sent but never arrives** — the send-from domain isn't verified. Check Email Service (Option A), Resend → Domains (Option B), or the Bavimail dashboard (Option C); status must read **Verified**.
+- **Outbound email looks sent but never arrives** — the send-from domain isn't verified. Check Email Service (Option A), Resend → Domains (Option B), the Bavimail dashboard (Option C), or the Postmark dashboard (Option D); status must read **Verified**.
 - **Locked out after sign-up** — passkey enrollment wasn't completed. Sign in again and finish the prompt; the server requires a passkey for `/api/*` in production.
 - **`BASE_URL` serves a blank Cloudflare page instead of saasmail** — the `routes` block in `wrangler.jsonc` wasn't uncommented, or `custom_domain: true` is missing. Fix and redeploy.

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,7 +1,11 @@
-# Outbound provider — Bavimail takes precedence over Resend and Cloudflare
-# Email Sending when BOTH BAVIMAIL_API_KEY and BAVIMAIL_ALIAS_ID are set.
+# Outbound provider precedence: Bavimail (BAVIMAIL_API_KEY + BAVIMAIL_ALIAS_ID)
+# > Postmark (POSTMARK_API_KEY) > Resend (RESEND_API_KEY) > Cloudflare Email
+# Sending (EMAIL binding). Set only the one you use.
 BAVIMAIL_API_KEY=
 BAVIMAIL_ALIAS_ID=
+
+# Postmark server API token.
+POSTMARK_API_KEY=
 
 RESEND_API_KEY=re_xxxx
 BETTER_AUTH_SECRET=generate-a-random-secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
+
 ## [0.10.0] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Every interaction with a customer matters, and context compounds. saasmail pulls the promo blast, the billing receipt, and the support thread into the same conversation, so anyone on your team can respond with the full history already in hand.
 
-Self-hosted on Cloudflare Workers. Receive with **Cloudflare Email Workers**. Send with **Cloudflare Email Sending**, **Resend**, or **Bavimail**.
+Self-hosted on Cloudflare Workers. Receive with **Cloudflare Email Workers**. Send with **Cloudflare Email Sending**, **Resend**, **Bavimail**, or **Postmark**.
 
 <img width="5088" height="3106" alt="saasmail-new" src="https://github.com/user-attachments/assets/407a8b4e-3ba0-4ed9-ae8a-f39dee861e56" />
 
@@ -30,18 +30,19 @@ https://github.com/user-attachments/assets/fe3a3811-1902-4b0b-8b94-f8c72f1afab4
 
 ## Provider Matrix
 
-|               | Cloudflare | Resend | Bavimail |
-| ------------- | ---------- | ------ | -------- |
-| **Sending**   | ✅         | ✅     | ✅       |
-| **Receiving** | ✅         | ❌     | ❌       |
+|               | Cloudflare | Resend | Bavimail | Postmark |
+| ------------- | ---------- | ------ | -------- | -------- |
+| **Sending**   | ✅         | ✅     | ✅       | ✅       |
+| **Receiving** | ✅         | ❌     | ❌       | ❌       |
 
 Pick one outbound provider at deploy time:
 
 - **Cloudflare Email Sending** — add a `send_email` binding (`EMAIL`) in `wrangler.jsonc` and onboard your domain at [Email Service](https://dash.cloudflare.com/?to=/:account/email-service).
 - **Resend** — set `RESEND_API_KEY` as a secret.
 - **Bavimail** — set `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` as secrets. The alias ID identifies the sending alias configured in your Bavimail dashboard.
+- **Postmark** — set `POSTMARK_API_KEY` as a secret (your Postmark server's API token). Verify each send-from domain in the Postmark dashboard.
 
-Selection precedence at runtime: **Bavimail** (when both env vars are set) > **Resend** (when `RESEND_API_KEY` is set) > **Cloudflare Email Sending** (when the `EMAIL` binding exists). If none are configured, send attempts return a "No email provider configured" error.
+Selection precedence at runtime: **Bavimail** (when both env vars are set) > **Postmark** (when `POSTMARK_API_KEY` is set) > **Resend** (when `RESEND_API_KEY` is set) > **Cloudflare Email Sending** (when the `EMAIL` binding exists). If none are configured, send attempts return a "No email provider configured" error.
 
 ## How much does it cost?
 
@@ -144,7 +145,7 @@ function verify(rawBody, header, secret) {
 | Layer               | Technology                                                                |
 | ------------------- | ------------------------------------------------------------------------- |
 | **Receive email**   | Cloudflare Email Workers                                                  |
-| **Send email**      | Cloudflare Email Sending, Resend, or Bavimail                             |
+| **Send email**      | Cloudflare Email Sending, Resend, Bavimail, or Postmark                   |
 | **Runtime**         | Cloudflare Workers + Hono                                                 |
 | **API**             | Zod + `@hono/zod-openapi` (OpenAPI 3.1)                                   |
 | **Database**        | Cloudflare D1 (SQLite)                                                    |
@@ -212,6 +213,7 @@ Don't have Claude Code? The manual steps below cover the same ground.
 - A [Cloudflare](https://dash.cloudflare.com/) account with Email Routing available for your domain
 - _Optional:_ a [Resend](https://resend.com/) account and API key (only if you prefer Resend over Cloudflare Email Sending)
 - _Optional:_ a [Bavimail](https://bavimail.com/) account, API key, and alias ID (only if you prefer Bavimail)
+- _Optional:_ a [Postmark](https://postmarkapp.com/) account and server API token (only if you prefer Postmark)
 
 ### 1. Clone and install
 
@@ -267,7 +269,8 @@ cp .dev.vars.example .dev.vars
 Edit `.dev.vars`:
 
 - `BAVIMAIL_API_KEY` and `BAVIMAIL_ALIAS_ID` — your Bavimail bearer token and alias UUID (only if using Bavimail; both must be set)
-- `RESEND_API_KEY` — your Resend API key (omit if using Cloudflare Email Sending or Bavimail)
+- `POSTMARK_API_KEY` — your Postmark server API token (only if using Postmark)
+- `RESEND_API_KEY` — your Resend API key (omit if using Cloudflare Email Sending, Bavimail, or Postmark)
 - `BETTER_AUTH_SECRET` — generate a random string (`openssl rand -hex 32`)
 - `UNSUBSCRIBE_SECRET` — generate a random string (`openssl rand -hex 32`); used to sign one-click unsubscribe tokens
 
@@ -279,6 +282,7 @@ wrangler secret put UNSUBSCRIBE_SECRET
 wrangler secret put RESEND_API_KEY      # only if using Resend
 wrangler secret put BAVIMAIL_API_KEY    # only if using Bavimail
 wrangler secret put BAVIMAIL_ALIAS_ID   # only if using Bavimail
+wrangler secret put POSTMARK_API_KEY    # only if using Postmark
 ```
 
 ### 6. Run migrations
@@ -399,6 +403,7 @@ Local development secrets. Created from `.dev.vars.example`. This file is gitign
 
 - `BAVIMAIL_API_KEY` — Bavimail API bearer token (required for Bavimail, must be paired with `BAVIMAIL_ALIAS_ID`)
 - `BAVIMAIL_ALIAS_ID` — Bavimail alias UUID identifying the sending alias (required for Bavimail)
+- `POSTMARK_API_KEY` — Postmark server API token (if using Postmark)
 - `RESEND_API_KEY` — Resend API key (if using Resend)
 - `BETTER_AUTH_SECRET` — Secret for session signing
 - `UNSUBSCRIBE_SECRET` — Secret used to HMAC-sign one-click unsubscribe tokens. Generate with `openssl rand -hex 32`. Set in prod via `wrangler secret put UNSUBSCRIBE_SECRET`. Required for the suppressions/unsubscribe feature.

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { createEmailSender, BavimailSender } from "../lib/email-sender";
+import {
+  createEmailSender,
+  BavimailSender,
+  PostmarkSender,
+} from "../lib/email-sender";
 
 describe("createEmailSender", () => {
   it("picks Resend when RESEND_API_KEY is set", () => {
@@ -61,6 +65,24 @@ describe("createEmailSender", () => {
       RESEND_API_KEY: "re_test",
     } as unknown as CloudflareBindings);
     expect(sender.provider).toBe("resend");
+  });
+
+  it("picks Postmark when POSTMARK_API_KEY is set, even over Resend and Cloudflare", () => {
+    const sender = createEmailSender({
+      POSTMARK_API_KEY: "pm_test",
+      RESEND_API_KEY: "re_test",
+      EMAIL: { send: vi.fn() },
+    } as unknown as CloudflareBindings);
+    expect(sender.provider).toBe("postmark");
+  });
+
+  it("prefers Bavimail over Postmark when both are configured", () => {
+    const sender = createEmailSender({
+      BAVIMAIL_API_KEY: "bm_test",
+      BAVIMAIL_ALIAS_ID: "alias-uuid",
+      POSTMARK_API_KEY: "pm_test",
+    } as unknown as CloudflareBindings);
+    expect(sender.provider).toBe("bavimail");
   });
 });
 
@@ -179,6 +201,16 @@ describe("maxAttachmentBytes", () => {
       BAVIMAIL_ALIAS_ID: "alias-uuid",
     } as any);
     expect(sender.maxAttachmentBytes()).toBe(25 * 1024 * 1024);
+  });
+
+  it("returns ~7MB for Postmark", () => {
+    const sender = createEmailSender({
+      POSTMARK_API_KEY: "pm_test",
+    } as any);
+    // Postmark caps total message size at 10MB; base64 inflates ~1.4x.
+    expect(sender.maxAttachmentBytes()).toBe(
+      Math.floor((10 * 1024 * 1024) / 1.4),
+    );
   });
 });
 
@@ -437,6 +469,196 @@ describe("BavimailSender", () => {
   it("normalizes thrown fetch errors", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
     const sender = makeBavimailSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("network down");
+  });
+});
+
+describe("PostmarkSender", () => {
+  function makePostmarkSender(fetchFn: typeof fetch) {
+    return new PostmarkSender("pm_test", fetchFn);
+  }
+
+  function okResponse(body: Record<string, unknown>) {
+    return new Response(JSON.stringify({ ErrorCode: 0, ...body }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("sends a basic email with the server token and correct body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okResponse({ MessageID: "pm-msg-123" }));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: '"Alice" <a@b.com>',
+      to: "c@d.com",
+      subject: "hello",
+      html: "<p>hi</p>",
+      text: "hi",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.id).toBe("pm-msg-123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.postmarkapp.com/email");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Postmark-Server-Token"]).toBe("pm_test");
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      From: '"Alice" <a@b.com>',
+      To: "c@d.com",
+      Subject: "hello",
+      HtmlBody: "<p>hi</p>",
+      TextBody: "hi",
+    });
+  });
+
+  it("joins cc into a comma-separated Cc string", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ MessageID: "x" }));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      cc: ['"Eve" <e@f.com>', "g@h.com"],
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.Cc).toBe('"Eve" <e@f.com>,g@h.com');
+  });
+
+  it("maps Reply-To to ReplyTo and routes other headers through Headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ MessageID: "x" }));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+      headers: {
+        "Reply-To": "submitter@example.com",
+        "In-Reply-To": "<orig@msg>",
+        "Message-ID": "<new@msg>",
+      },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.ReplyTo).toBe("submitter@example.com");
+    expect(body.Headers).toEqual([
+      { Name: "In-Reply-To", Value: "<orig@msg>" },
+      { Name: "Message-ID", Value: "<new@msg>" },
+    ]);
+  });
+
+  it("base64-encodes attachments into the Attachments array", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ MessageID: "x" }));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+      attachments: [
+        {
+          filename: "a.txt",
+          contentType: "text/plain",
+          content: new TextEncoder().encode("alpha"),
+        },
+      ],
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.Attachments).toEqual([
+      {
+        Name: "a.txt",
+        Content: btoa("alpha"),
+        ContentType: "text/plain",
+      },
+    ]);
+  });
+
+  it("returns error from the Message field on a non-2xx response", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ErrorCode: 300, Message: "Invalid 'From' address" }),
+          { status: 422 },
+        ),
+      );
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("Invalid 'From' address");
+  });
+
+  it("treats a 200 with a non-zero ErrorCode as a failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ErrorCode: 405, Message: "Not allowed to send" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toBe("Not allowed to send");
+  });
+
+  it("falls back to status text when the error body cannot be parsed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("not json", { status: 500 }));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
+
+    const result = await sender.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "s",
+      html: "<p>h</p>",
+    });
+
+    expect(result.id).toBeNull();
+    expect(result.error?.message).toMatch(/500/);
+  });
+
+  it("normalizes thrown fetch errors", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    const sender = makePostmarkSender(fetchMock as unknown as typeof fetch);
 
     const result = await sender.send({
       from: "a@b.com",

--- a/worker/src/__tests__/email-sender.test.ts
+++ b/worker/src/__tests__/email-sender.test.ts
@@ -494,6 +494,15 @@ describe("PostmarkSender", () => {
     });
   }
 
+  // NOTE: the production default `fetch` must be bound to globalThis — an
+  // unbound global fetch invoked as a method reference (`this.fetchFn(...)`)
+  // throws "Illegal invocation" in the Workers runtime (see the constructor).
+  // We deliberately do NOT unit-test the un-injected default path here:
+  // exercising it makes a real outbound fetch, which the vitest-pool-workers
+  // runtime blocks with a "Network connection lost" rejection that leaks across
+  // isolates and fails unrelated tests. The binding is covered by production
+  // verification instead.
+
   it("sends a basic email with the server token and correct body", async () => {
     const fetchMock = vi
       .fn()

--- a/worker/src/lib/email-sender/index.ts
+++ b/worker/src/lib/email-sender/index.ts
@@ -3,6 +3,7 @@ import type { EmailSender } from "./types";
 import { ResendSender } from "./providers/resend";
 import { CloudflareSender } from "./providers/cloudflare";
 import { BavimailSender } from "./providers/bavimail";
+import { PostmarkSender } from "./providers/postmark";
 import { NoopSender } from "./providers/noop";
 import { DemoSender } from "./providers/demo";
 
@@ -15,6 +16,7 @@ export type {
 export { ResendSender } from "./providers/resend";
 export { CloudflareSender } from "./providers/cloudflare";
 export { BavimailSender } from "./providers/bavimail";
+export { PostmarkSender } from "./providers/postmark";
 export { NoopSender } from "./providers/noop";
 export { DemoSender } from "./providers/demo";
 
@@ -24,6 +26,7 @@ export function createEmailSender(
     EMAIL?: SendEmail;
     BAVIMAIL_API_KEY?: string;
     BAVIMAIL_ALIAS_ID?: string;
+    POSTMARK_API_KEY?: string;
   },
 ): EmailSender {
   if (isDemoMode(env)) {
@@ -31,6 +34,9 @@ export function createEmailSender(
   }
   if (env.BAVIMAIL_API_KEY && env.BAVIMAIL_ALIAS_ID) {
     return new BavimailSender(env.BAVIMAIL_API_KEY, env.BAVIMAIL_ALIAS_ID);
+  }
+  if (env.POSTMARK_API_KEY) {
+    return new PostmarkSender(env.POSTMARK_API_KEY);
   }
   if (env.RESEND_API_KEY) {
     return new ResendSender(env.RESEND_API_KEY);

--- a/worker/src/lib/email-sender/providers/postmark.ts
+++ b/worker/src/lib/email-sender/providers/postmark.ts
@@ -13,10 +13,17 @@ async function extractPostmarkError(res: Response): Promise<string> {
 
 export class PostmarkSender implements EmailSender {
   readonly provider = "postmark" as const;
-  constructor(
-    private apiKey: string,
-    private fetchFn: typeof fetch = fetch,
-  ) {}
+  private apiKey: string;
+  private fetchFn: typeof fetch;
+
+  constructor(apiKey: string, fetchFn?: typeof fetch) {
+    this.apiKey = apiKey;
+    // Bind to globalThis: invoking the global `fetch` as a method reference
+    // (`this.fetchFn(...)`) throws "Illegal invocation" in the Cloudflare
+    // Workers runtime. Tests inject their own fetch, so the unbound default
+    // only ever runs in production — exactly where it would break.
+    this.fetchFn = fetchFn ?? fetch.bind(globalThis);
+  }
 
   async send(params: SendEmailParams): Promise<SendEmailResult> {
     try {
@@ -87,6 +94,11 @@ export class PostmarkSender implements EmailSender {
       return { id: data.MessageID ?? null, error: null };
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
+      console.error(
+        "[PostmarkSender] send failed:",
+        message,
+        e instanceof Error ? e.stack : "",
+      );
       return { id: null, error: { message } };
     }
   }

--- a/worker/src/lib/email-sender/providers/postmark.ts
+++ b/worker/src/lib/email-sender/providers/postmark.ts
@@ -1,0 +1,98 @@
+import type { EmailSender, SendEmailParams, SendEmailResult } from "../types";
+import { toBase64 } from "../shared";
+
+async function extractPostmarkError(res: Response): Promise<string> {
+  try {
+    const data = (await res.json()) as { Message?: string; ErrorCode?: number };
+    if (data.Message) return data.Message;
+  } catch {
+    // fall through
+  }
+  return `Postmark request failed: ${res.status} ${res.statusText}`.trim();
+}
+
+export class PostmarkSender implements EmailSender {
+  readonly provider = "postmark" as const;
+  constructor(
+    private apiKey: string,
+    private fetchFn: typeof fetch = fetch,
+  ) {}
+
+  async send(params: SendEmailParams): Promise<SendEmailResult> {
+    try {
+      const payload: Record<string, unknown> = {
+        From: params.from,
+        To: params.to,
+        Subject: params.subject,
+        HtmlBody: params.html,
+      };
+      if (params.text) {
+        payload.TextBody = params.text;
+      }
+      if (params.cc && params.cc.length > 0) {
+        payload.Cc = params.cc.join(",");
+      }
+      if (params.headers) {
+        const entries = Object.entries(params.headers);
+        // Postmark has a dedicated ReplyTo field; everything else goes through
+        // the generic Headers array.
+        const replyTo = entries.find(([k]) => k.toLowerCase() === "reply-to");
+        if (replyTo) {
+          payload.ReplyTo = replyTo[1];
+        }
+        const rest = entries.filter(([k]) => k.toLowerCase() !== "reply-to");
+        if (rest.length > 0) {
+          payload.Headers = rest.map(([Name, Value]) => ({ Name, Value }));
+        }
+      }
+      if (params.attachments && params.attachments.length > 0) {
+        payload.Attachments = params.attachments.map((a) => ({
+          Name: a.filename,
+          Content: toBase64(a.content),
+          ContentType: a.contentType,
+        }));
+      }
+
+      const res = await this.fetchFn("https://api.postmarkapp.com/email", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-Postmark-Server-Token": this.apiKey,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        return {
+          id: null,
+          error: { message: await extractPostmarkError(res) },
+        };
+      }
+
+      const data = (await res.json().catch(() => ({}))) as {
+        MessageID?: string;
+        ErrorCode?: number;
+        Message?: string;
+      };
+      // Postmark can return HTTP 200 with a non-zero ErrorCode on some failures.
+      if (data.ErrorCode && data.ErrorCode !== 0) {
+        return {
+          id: null,
+          error: {
+            message: data.Message ?? `Postmark error ${data.ErrorCode}`,
+          },
+        };
+      }
+      return { id: data.MessageID ?? null, error: null };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { id: null, error: { message } };
+    }
+  }
+
+  maxAttachmentBytes(): number {
+    // Postmark caps total message size at 10 MB; base64 inflates ~1.4x.
+    return Math.floor((10 * 1024 * 1024) / 1.4);
+  }
+}

--- a/worker/src/lib/email-sender/types.ts
+++ b/worker/src/lib/email-sender/types.ts
@@ -23,7 +23,7 @@ export interface SendEmailResult {
 }
 
 export interface EmailSender {
-  provider: "resend" | "cloudflare" | "none" | "demo" | "bavimail";
+  provider: "resend" | "cloudflare" | "none" | "demo" | "bavimail" | "postmark";
   send(params: SendEmailParams): Promise<SendEmailResult>;
   maxAttachmentBytes(): number;
 }

--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -27,9 +27,9 @@
     }
   ],
   // Optional: enable Cloudflare Email Sending as the outbound provider.
-  // If Bavimail (BAVIMAIL_API_KEY + BAVIMAIL_ALIAS_ID) or RESEND_API_KEY is
-  // set, those win instead. Requires onboarding your domain at Email Service
-  // → https://dash.cloudflare.com/?to=/:account/email-service
+  // If Bavimail (BAVIMAIL_API_KEY + BAVIMAIL_ALIAS_ID), POSTMARK_API_KEY, or
+  // RESEND_API_KEY is set, those win instead. Requires onboarding your domain
+  // at Email Service → https://dash.cloudflare.com/?to=/:account/email-service
   // "send_email": [
   //   { "name": "EMAIL" }
   // ],
@@ -79,7 +79,9 @@
   },
   // Outbound email provider selection (runtime, no explicit toggle):
   //   - Set BOTH BAVIMAIL_API_KEY and BAVIMAIL_ALIAS_ID (via `wrangler secret put`)
-  //     to use Bavimail. Takes precedence over Resend and the EMAIL binding.
+  //     to use Bavimail. Takes precedence over Postmark, Resend, and the EMAIL binding.
+  //   - Set POSTMARK_API_KEY (via `wrangler secret put POSTMARK_API_KEY`) to use Postmark.
+  //     Takes precedence over Resend and the EMAIL binding.
   //   - Set RESEND_API_KEY (via `wrangler secret put RESEND_API_KEY`) to use Resend.
   //   - Or uncomment the `send_email` binding above to use Cloudflare Email Sending.
   //   - If none are configured, send attempts return a "No email provider configured" error.


### PR DESCRIPTION
## What & why

Adds **Postmark** as an outbound email provider alongside Cloudflare Email Sending, Resend, and Bavimail.

`PostmarkSender` POSTs to `https://api.postmarkapp.com/email` with an `X-Postmark-Server-Token` header. It maps `Reply-To` to Postmark's dedicated `ReplyTo` field and routes any other headers through the `Headers` array, base64-encodes attachments into `Attachments`, and treats both non-2xx responses and `200 + non-zero ErrorCode` as failures. It's fetch-based with an injectable `fetchFn` (so tests never touch `globalThis.fetch`), mirroring `BavimailSender`.

Selected via the `POSTMARK_API_KEY` secret. Runtime precedence: **Bavimail > Postmark > Resend > Cloudflare Email Sending**.

## Stacked on #163

> ⚠️ This PR is stacked on #163 (the `email-sender/` folder refactor) and includes its commit. Please merge #163 first; I'll rebase this onto `main` so it shows only the Postmark commit.

## Changes
- `worker/src/lib/email-sender/providers/postmark.ts` — new `PostmarkSender`.
- `types.ts` union + `index.ts` factory branch & re-export.
- Tests: provider selection (+ precedence), header/cc/attachment mapping, error paths, `maxAttachmentBytes` — appended to `email-sender.test.ts`.
- Docs: README (provider matrix, prerequisites, secrets, `.dev.vars`), `wrangler.jsonc.example`, `.dev.vars.example`, the onboarding skill (Option D), and `CHANGELOG.md`.

## Checklist
- [x] `yarn tsc --noEmit` clean
- [x] `yarn test` — 405 passed / 1 skipped (+11 Postmark tests)
- [x] No schema change → no migration
- [x] CHANGELOG updated under `[Unreleased]`
- [x] Docs updated (README, examples, onboarding)
- [ ] e2e — n/a (no UI/API contract change)