### PR TITLE
chore: release 0.10.1 — email-sender provider refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-01
+
+### Changed
+
+- Refactored `email-sender.ts` into a `email-sender/` folder with a dedicated `providers/` sub-directory, splitting each provider (Bavimail, Cloudflare, Resend, demo, noop) into its own module alongside shared types and utilities.
+
 ## [0.10.0] - 2026-06-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saasmail",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the package version to `0.10.1` and records the changes shipped on 2026-06-30 in `CHANGELOG.md`.

## Changes

- Added `[0.10.1] - 2026-07-01` section to `CHANGELOG.md` documenting the email-sender provider refactor.
- Bumped `version` in `package.json` from `0.10.0` → `0.10.1`.

## Test plan

- [ ] `yarn tsc --noEmit`
- [ ] `yarn test`
- [ ] `yarn test:e2e` (if the change touches UI or API surface)
- [ ] Manual verification: n/a — changelog and version bump only

## Notes for reviewers

Covers commit `e5a72d2` (refactor(email): split email-sender into providers folder): `email-sender.ts` was split into `email-sender/index.ts`, `email-sender/types.ts`, `email-sender/shared.ts`, and five provider modules under `email-sender/providers/`. No public API or behaviour change.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed
- [x] Updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [ ] Updated docs (`README.md`, `docs/`) if behavior or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1QcGsLKYoHzm2fUhtLH1)_