### PR TITLE
feat: block email addresses and domains

### DIFF
--- a/migrations/0029_lumpy_pyro.sql
+++ b/migrations/0029_lumpy_pyro.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `blocklist` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`value` text NOT NULL,
+	`note` text,
+	`created_by` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `blocklist_created_at_idx` ON `blocklist` (`created_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `blocklist_type_value_unique` ON `blocklist` (`type`,`value`);

--- a/migrations/meta/0029_snapshot.json
+++ b/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2516 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c0837b98-c105-4979-9b52-ebf2d6cba7ee",
+  "prevId": "49a9b5d3-58df-44f1-8145-1c8b71afa1b4",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwkss": {
+      "name": "jwkss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_userId_idx": {
+          "name": "passkeys_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkeys_credentialID_idx": {
+          "name": "passkeys_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_email_at": {
+          "name": "last_email_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "people_last_email_at_idx": {
+          "name": "people_last_email_at_idx",
+          "columns": [
+            "last_email_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emails": {
+      "name": "emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spf": {
+          "name": "spf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dkim": {
+          "name": "dkim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dmarc": {
+          "name": "dmarc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "emails_message_id_unique": {
+          "name": "emails_message_id_unique",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "emails_person_received_idx": {
+          "name": "emails_person_received_idx",
+          "columns": [
+            "person_id",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_recipient_received_idx": {
+          "name": "emails_recipient_received_idx",
+          "columns": [
+            "recipient",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_conversation_idx": {
+          "name": "emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sent_emails": {
+      "name": "sent_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sent'"
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sent_emails_person_sent_idx": {
+          "name": "sent_emails_person_sent_idx",
+          "columns": [
+            "person_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_conversation_idx": {
+          "name": "sent_emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_from_sent_idx": {
+          "name": "sent_emails_from_sent_idx",
+          "columns": [
+            "from_address",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inbound'"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachments_email_id_idx": {
+          "name": "attachments_email_id_idx",
+          "columns": [
+            "email_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_templates_slug_unique": {
+          "name": "email_templates_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_used_by_users_id_fk": {
+          "name": "invitations_used_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_unique": {
+          "name": "api_keys_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequences": {
+      "name": "sequences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_enrollments": {
+      "name": "sequence_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrollments_person_status_idx": {
+          "name": "enrollments_person_status_idx",
+          "columns": [
+            "person_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "enrollments_sequence_status_idx": {
+          "name": "enrollments_sequence_status_idx",
+          "columns": [
+            "sequence_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_emails": {
+      "name": "sequence_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seq_emails_status_scheduled_idx": {
+          "name": "seq_emails_status_scheduled_idx",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "seq_emails_enrollment_id_idx": {
+          "name": "seq_emails_enrollment_id_idx",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sender_identities": {
+      "name": "sender_identities",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'thread'"
+        },
+        "signature_html": {
+          "name": "signature_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_permissions": {
+      "name": "inbox_permissions",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inbox_permissions_email_idx": {
+          "name": "inbox_permissions_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_permissions_user_id_users_id_fk": {
+          "name": "inbox_permissions_user_id_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_permissions_created_by_users_id_fk": {
+          "name": "inbox_permissions_created_by_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "inbox_permissions_user_id_email_pk": {
+          "columns": [
+            "user_id",
+            "email"
+          ],
+          "name": "inbox_permissions_user_id_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suppressions": {
+      "name": "suppressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "suppressions_email_unique": {
+          "name": "suppressions_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "suppressions_created_at_idx": {
+          "name": "suppressions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocklist": {
+      "name": "blocklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blocklist_created_at_idx": {
+          "name": "blocklist_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "blocklist_type_value_unique": {
+          "name": "blocklist_type_value_unique",
+          "columns": [
+            "type",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1781583896710,
       "tag": "0028_supreme_mockingbird",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1783486611938,
+      "tag": "0029_lumpy_pyro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import InboxesPage from "./pages/InboxesPage";
 import SettingsPage from "@/pages/SettingsPage";
 import MessageLinkPage from "@/pages/MessageLinkPage";
 import UnsubscribePage from "@/pages/UnsubscribePage";
+import BlocklistPage from "@/pages/BlocklistPage";
 
 const queryClient = new QueryClient();
 
@@ -159,6 +160,7 @@ function App() {
                 <Route path="/api-keys" element={<ApiKeysPage />} />
                 <Route path="/inboxes" element={<InboxesPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
+                <Route path="/blocklist" element={<BlocklistPage />} />
                 {/* Deep link from Web Push notifications — see
                     worker/src/do/notifications.ts where data.url is set. */}
                 <Route path="/inbox/:inbox/:personId" element={<InboxPage />} />

--- a/src/components/SelectionBar.tsx
+++ b/src/components/SelectionBar.tsx
@@ -1,10 +1,11 @@
-import { CheckCheck, X, Loader2 } from "lucide-react";
+import { CheckCheck, X, Loader2, ShieldBan } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface SelectionBarProps {
   count: number;
   busy?: boolean;
   onMarkRead: () => void;
+  onBlock?: () => void;
   onClear: () => void;
   className?: string;
 }
@@ -18,6 +19,7 @@ export default function SelectionBar({
   count,
   busy,
   onMarkRead,
+  onBlock,
   onClear,
   className,
 }: SelectionBarProps) {
@@ -50,6 +52,18 @@ export default function SelectionBar({
         )}
         Mark as read
       </button>
+
+      {onBlock && (
+        <button
+          type="button"
+          onClick={onBlock}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-[6px] bg-white/[0.08] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-white/[0.14] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ShieldBan size={12} />
+          Block
+        </button>
+      )}
 
       <button
         type="button"

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -10,6 +10,7 @@ import {
   Shield,
   Users,
   Ban,
+  ShieldBan,
   Menu,
   User,
   LogOut,
@@ -173,6 +174,13 @@ export default function TopNav() {
                     </DropdownMenuItem>
                   </>
                 )}
+                <DropdownMenuItem
+                  onClick={() => navigate("/blocklist")}
+                  className="cursor-pointer"
+                >
+                  <ShieldBan className="h-4 w-4" />
+                  Blocklist
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => navigate("/settings")}
@@ -282,6 +290,13 @@ export default function TopNav() {
                   </button>
                 </>
               )}
+              <button
+                onClick={() => navigate("/blocklist")}
+                className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"
+              >
+                <ShieldBan className="h-4 w-4" />
+                Blocklist
+              </button>
               <button
                 onClick={() => navigate("/settings")}
                 className="flex items-center gap-2 px-4 py-2.5 text-sm text-white/60 hover:text-white"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -826,3 +826,50 @@ export async function deleteSuppression(
 ): Promise<{ deleted: true }> {
   return apiFetch(`/api/suppressions/${id}`, { method: "DELETE" });
 }
+
+// --- Blocklist ---
+
+export type BlockRuleType = "email" | "domain";
+
+export interface BlockRule {
+  id: string;
+  type: BlockRuleType;
+  value: string;
+  note: string | null;
+  createdBy: string | null;
+  createdAt: number;
+}
+
+export interface BlocklistPageResult {
+  items: BlockRule[];
+  nextCursor: string | null;
+}
+
+export async function fetchBlocklist(
+  cursor?: string,
+): Promise<BlocklistPageResult> {
+  const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}` : "";
+  return apiFetch(`/api/blocklist${qs}`);
+}
+
+export async function addBlock(input: {
+  type: BlockRuleType;
+  value: string;
+  note?: string;
+}): Promise<BlockRule> {
+  return apiFetch("/api/blocklist", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function removeBlock(id: string): Promise<{ deleted: true }> {
+  return apiFetch(`/api/blocklist/${id}`, { method: "DELETE" });
+}
+
+export async function purgeBlockedMail(): Promise<{
+  emailsDeleted: number;
+  peopleDeleted: number;
+}> {
+  return apiFetch("/api/blocklist/mail", { method: "DELETE" });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -859,6 +859,7 @@ export async function addBlock(input: {
 }): Promise<BlockRule> {
   return apiFetch("/api/blocklist", {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
 }

--- a/src/pages/BlocklistPage.tsx
+++ b/src/pages/BlocklistPage.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useState } from "react";
+import { ShieldBan, Plus, Trash2 } from "lucide-react";
+import {
+  fetchBlocklist,
+  addBlock,
+  removeBlock,
+  purgeBlockedMail,
+} from "@/lib/api";
+import type { BlockRule, BlockRuleType } from "@/lib/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import PageHeader, { PageContainer } from "@/components/PageHeader";
+import { SectionHeader } from "@/components/PageForm";
+import { cn } from "@/lib/utils";
+
+function relativeTime(ts: number): string {
+  const diff = ts - Date.now() / 1000;
+  const abs = Math.abs(diff);
+  if (abs < 3600) return "just now";
+  if (abs < 86400) return `${Math.floor(abs / 3600)}h ago`;
+  return `${Math.floor(abs / 86400)}d ago`;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DOMAIN_RE = /^[^\s@]+\.[^\s@]+$/;
+
+export default function BlocklistPage() {
+  const [items, setItems] = useState<BlockRule[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [addType, setAddType] = useState<BlockRuleType>("email");
+  const [addValue, setAddValue] = useState("");
+  const [addSubmitting, setAddSubmitting] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [confirmDelete, setConfirmDelete] = useState<BlockRule | null>(null);
+  const [purgeOpen, setPurgeOpen] = useState(false);
+  const [purgeSubmitting, setPurgeSubmitting] = useState(false);
+  const [purgeResult, setPurgeResult] = useState<string | null>(null);
+
+  async function loadInitial() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchBlocklist();
+      setItems(res.items);
+      setNextCursor(res.nextCursor);
+    } catch {
+      setError("Failed to load blocklist.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadMore() {
+    if (!nextCursor) return;
+    try {
+      const res = await fetchBlocklist(nextCursor);
+      setItems((prev) => [...prev, ...res.items]);
+      setNextCursor(res.nextCursor);
+    } catch {
+      setError("Failed to load more.");
+    }
+  }
+
+  useEffect(() => {
+    loadInitial();
+  }, []);
+
+  function resetAdd() {
+    setAddType("email");
+    setAddValue("");
+    setAddError(null);
+    setAddSubmitting(false);
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    const value = addValue.trim().toLowerCase();
+    if (addType === "email" && !EMAIL_RE.test(value)) {
+      setAddError("Enter a valid email address.");
+      return;
+    }
+    if (addType === "domain" && !DOMAIN_RE.test(value)) {
+      setAddError("Enter a bare domain, e.g. spammer.com.");
+      return;
+    }
+    setAddSubmitting(true);
+    setAddError(null);
+    try {
+      const created = await addBlock({ type: addType, value });
+      setItems((prev) => {
+        const idx = prev.findIndex((b) => b.id === created.id);
+        if (idx >= 0) {
+          const copy = prev.slice();
+          copy[idx] = created;
+          return copy;
+        }
+        return [created, ...prev];
+      });
+      setAddOpen(false);
+      resetAdd();
+    } catch {
+      setAddError("Failed to add. It may be one of your own addresses.");
+    } finally {
+      setAddSubmitting(false);
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!confirmDelete) return;
+    try {
+      await removeBlock(confirmDelete.id);
+      setItems((prev) => prev.filter((b) => b.id !== confirmDelete.id));
+      setConfirmDelete(null);
+    } catch {
+      setError("Failed to remove.");
+    }
+  }
+
+  async function handlePurge() {
+    setPurgeSubmitting(true);
+    try {
+      const res = await purgeBlockedMail();
+      setPurgeResult(
+        `Deleted ${res.emailsDeleted} email(s) from ${res.peopleDeleted} blocked sender(s).`,
+      );
+    } catch {
+      setPurgeResult("Failed to delete blocked mail.");
+    } finally {
+      setPurgeSubmitting(false);
+      setPurgeOpen(false);
+    }
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Blocklist"
+        subtitle="Blocked addresses and domains are hidden from the inbox, and future mail from them is dropped."
+        action={
+          <button
+            onClick={() => {
+              resetAdd();
+              setAddOpen(true);
+            }}
+            className="inline-flex items-center gap-1.5 rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-text-primary/90"
+          >
+            <Plus size={14} />
+            Add block
+          </button>
+        }
+      />
+
+      <div className="max-w-4xl space-y-6">
+        <section className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+          <div className="flex items-center justify-between border-b border-border px-5 py-4">
+            <SectionHeader
+              icon={ShieldBan}
+              title={`Blocked (${items.length}${nextCursor ? "+" : ""})`}
+              subtitle="Inbound mail from these senders is dropped."
+            />
+            <button
+              onClick={() => {
+                setPurgeResult(null);
+                setPurgeOpen(true);
+              }}
+              className="inline-flex h-8 shrink-0 items-center gap-1 rounded-[6px] px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-rose-50 hover:text-rose-600"
+            >
+              <Trash2 size={12} />
+              Delete blocked mail
+            </button>
+          </div>
+
+          {error && (
+            <div className="border-b border-border bg-rose-50/60 px-5 py-2 text-xs font-medium text-rose-700">
+              {error}
+            </div>
+          )}
+          {purgeResult && (
+            <div className="border-b border-border bg-bg-muted px-5 py-2 text-xs font-medium text-text-secondary">
+              {purgeResult}
+            </div>
+          )}
+
+          {loading ? (
+            <p className="px-5 py-6 text-xs font-light text-text-tertiary">
+              Loading…
+            </p>
+          ) : items.length === 0 ? (
+            <p className="px-5 py-10 text-center text-sm text-text-tertiary">
+              Nothing blocked yet.
+            </p>
+          ) : (
+            <>
+              <ul className="divide-y divide-border/60">
+                {items.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex items-center gap-3 px-5 py-3"
+                  >
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-bg-muted">
+                      <ShieldBan size={14} className="text-text-tertiary" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium text-text-primary">
+                          {item.value}
+                        </p>
+                        <span
+                          className={cn(
+                            "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ring-1",
+                            item.type === "domain"
+                              ? "bg-amber-50 text-amber-700 ring-amber-200"
+                              : "bg-bg-muted text-text-secondary ring-border",
+                          )}
+                        >
+                          {item.type === "domain" ? "Domain" : "Email"}
+                        </span>
+                      </div>
+                      <p className="truncate text-xs font-light text-text-tertiary">
+                        {item.createdBy ?? "—"} · added{" "}
+                        {relativeTime(item.createdAt)}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => setConfirmDelete(item)}
+                      aria-label={`Unblock ${item.value}`}
+                      className="inline-flex h-8 shrink-0 items-center gap-1 rounded-[6px] px-2 text-xs font-medium text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                    >
+                      Unblock
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {nextCursor && (
+                <div className="border-t border-border px-5 py-3">
+                  <button
+                    onClick={loadMore}
+                    className="w-full rounded-[6px] border border-border bg-card py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+                  >
+                    Load more
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </section>
+      </div>
+
+      {/* Add dialog */}
+      <Dialog
+        open={addOpen}
+        onOpenChange={(o) => {
+          setAddOpen(o);
+          if (!o) resetAdd();
+        }}
+      >
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">Add block</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleAdd} className="space-y-4">
+            <div className="flex gap-2">
+              {(["email", "domain"] as BlockRuleType[]).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setAddType(t)}
+                  className={cn(
+                    "flex-1 rounded-[6px] border px-3 py-2 text-sm font-medium transition-colors",
+                    addType === t
+                      ? "border-text-primary bg-text-primary/5 text-text-primary"
+                      : "border-border text-text-secondary hover:bg-bg-muted",
+                  )}
+                >
+                  {t === "email" ? "Email address" : "Domain"}
+                </button>
+              ))}
+            </div>
+            <input
+              autoFocus
+              value={addValue}
+              onChange={(e) => setAddValue(e.target.value)}
+              placeholder={
+                addType === "email" ? "user@example.com" : "example.com"
+              }
+              className="h-10 w-full rounded-[6px] border border-border bg-bg-subtle px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-text-primary/20"
+            />
+            {addError && (
+              <p className="text-xs font-medium text-rose-600">{addError}</p>
+            )}
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setAddOpen(false)}
+                className="rounded-[8px] border border-border bg-card px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={addSubmitting}
+                className="rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90 disabled:opacity-60"
+              >
+                {addSubmitting ? "Adding…" : "Block"}
+              </button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Unblock confirm */}
+      <Dialog
+        open={confirmDelete !== null}
+        onOpenChange={(o) => {
+          if (!o) setConfirmDelete(null);
+        }}
+      >
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">Unblock?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-light text-text-secondary">
+            <span className="font-medium text-text-primary">
+              {confirmDelete?.value}
+            </span>{" "}
+            will be able to reach the inbox again, and any hidden mail will
+            reappear.
+          </p>
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              className="rounded-[8px] border border-border bg-card px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              className="rounded-[8px] bg-text-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-text-primary/90"
+            >
+              Unblock
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Purge confirm */}
+      <Dialog open={purgeOpen} onOpenChange={setPurgeOpen}>
+        <DialogContent className="border-border bg-card text-text-primary ring-1 ring-border">
+          <DialogHeader>
+            <DialogTitle className="text-text-primary">
+              Delete all blocked mail?
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-sm font-light text-text-secondary">
+            This permanently deletes every hidden email from blocked senders.
+            This cannot be undone.
+          </p>
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setPurgeOpen(false)}
+              className="rounded-[8px] border border-border bg-card px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handlePurge}
+              disabled={purgeSubmitting}
+              className="rounded-[8px] bg-rose-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-rose-700 disabled:opacity-60"
+            >
+              {purgeSubmitting ? "Deleting…" : "Delete"}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </PageContainer>
+  );
+}

--- a/src/pages/BlocklistPage.tsx
+++ b/src/pages/BlocklistPage.tsx
@@ -133,7 +133,7 @@ export default function BlocklistPage() {
         `Deleted ${res.emailsDeleted} email(s) from ${res.peopleDeleted} blocked sender(s).`,
       );
     } catch {
-      setPurgeResult("Failed to delete blocked mail.");
+      setError("Failed to delete blocked mail.");
     } finally {
       setPurgeSubmitting(false);
       setPurgeOpen(false);

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -16,6 +16,7 @@ import InboxToolbar, {
 import PeopleTable from "@/components/PeopleTable";
 import SelectionBar from "@/components/SelectionBar";
 import {
+  addBlock,
   defaultDirectionFor,
   fetchPerson,
   fetchStats,
@@ -300,6 +301,19 @@ export default function InboxPage() {
     applyMarkRead(Array.from(selectedIds), Array.from(selectedConversationIds));
     clearSelection();
   }
+
+  const handleBlockSelected = useCallback(async () => {
+    const emails = items
+      .filter((it) => it.type === "person" && selectedIds.has(it.id))
+      .map((it) => (it as GroupedPerson).email.toLowerCase());
+    if (emails.length === 0) return;
+    await Promise.all(
+      emails.map((value) => addBlock({ type: "email", value }).catch(() => {})),
+    );
+    clearSelection();
+    await refreshPeople();
+  }, [items, selectedIds, clearSelection, refreshPeople]);
+
   const [refreshKey, setRefreshKey] = useState(0);
   const [showBanner, setShowBanner] = useState(false);
   const { data: session } = useSession();
@@ -464,6 +478,7 @@ export default function InboxPage() {
                 count={selectedIds.size + selectedConversationIds.size}
                 busy={bulkBusy}
                 onMarkRead={handleBulkMarkRead}
+                onBlock={handleBlockSelected}
                 onClear={clearSelection}
               />
             </div>
@@ -475,6 +490,7 @@ export default function InboxPage() {
                 count={selectedIds.size + selectedConversationIds.size}
                 busy={bulkBusy}
                 onMarkRead={handleBulkMarkRead}
+                onBlock={handleBlockSelected}
                 onClear={clearSelection}
               />
             </div>

--- a/src/pages/PersonDetail.tsx
+++ b/src/pages/PersonDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { useLocation } from "react-router-dom";
-import { CheckCheck } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { CheckCheck, ShieldBan } from "lucide-react";
 import {
   fetchPersonEmails,
   markEmailRead,
@@ -8,12 +8,19 @@ import {
   deleteEmail,
   fetchPersonEnrollment,
   fetchStats,
+  addBlock,
   type GroupedPerson,
   type Email,
   type PersonEnrollmentInfo,
   type InboxDisplayMode,
   type ReassignPersonResult,
 } from "@/lib/api";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { messageDomId, readMessageHash } from "@/lib/message-link";
 import EnrollSequenceModal from "@/components/EnrollSequenceModal";
 import ReassignPersonModal from "@/components/ReassignPersonModal";
@@ -108,6 +115,7 @@ export default function PersonDetail({
   refreshKey,
   onOpenCompose,
 }: PersonDetailProps) {
+  const navigate = useNavigate();
   const [emails, setEmails] = useState<Email[]>([]);
   const [loading, setLoading] = useState(true);
   const [enrollModalOpen, setEnrollModalOpen] = useState(false);
@@ -126,6 +134,19 @@ export default function PersonDetail({
     Array<{ email: string; displayName: string | null }>
   >([]);
   const [activeInbox, setActiveInbox] = useState<string | null>(null);
+
+  async function handleBlock(type: "email" | "domain") {
+    const email = person.email.toLowerCase();
+    const value =
+      type === "email" ? email : email.slice(email.lastIndexOf("@") + 1);
+    if (!value) return;
+    try {
+      await addBlock({ type, value });
+      navigate("/"); // thread is now hidden; return to the inbox
+    } catch {
+      // Most likely a self-block guard rejection; leave the user on the thread.
+    }
+  }
 
   function refetchEmails() {
     fetchPersonEmails(person.id).then((res) => {
@@ -379,7 +400,7 @@ export default function PersonDetail({
             </span>
           </div>
 
-          <div className="shrink-0">
+          <div className="flex shrink-0 items-center gap-2">
             {enrollmentInfo?.enrollment ? (
               <SequenceStatus
                 personId={person.id}
@@ -393,6 +414,31 @@ export default function PersonDetail({
                 Add to sequence
               </button>
             )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  aria-label="Block sender"
+                  className="inline-flex items-center gap-1.5 rounded-[6px] border border-border bg-card px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-rose-50 hover:text-rose-600"
+                >
+                  <ShieldBan size={13} />
+                  Block
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => handleBlock("email")}
+                >
+                  Block {person.email}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => handleBlock("domain")}
+                >
+                  Block entire domain
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/worker/src/__tests__/blocklist-lib.test.ts
+++ b/worker/src/__tests__/blocklist-lib.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { applyMigrations, cleanDb, getDb } from "./helpers";
+import { blocklist } from "../db/blocklist.schema";
+import { isBlocked, domainOf } from "../lib/blocklist";
+
+async function addRule(type: "email" | "domain", value: string) {
+  await getDb()
+    .insert(blocklist)
+    .values({
+      id: `blk-${type}-${value}`,
+      type,
+      value: value.toLowerCase(),
+      createdAt: Math.floor(Date.now() / 1000),
+    });
+}
+
+beforeAll(applyMigrations);
+beforeEach(cleanDb);
+
+describe("domainOf", () => {
+  it("extracts the lowercased domain", () => {
+    expect(domainOf("Alice@Example.COM")).toBe("example.com");
+  });
+});
+
+describe("isBlocked", () => {
+  it("returns false when nothing matches", async () => {
+    expect(await isBlocked(getDb(), "alice@example.com")).toBe(false);
+  });
+
+  it("matches an exact email rule case-insensitively", async () => {
+    await addRule("email", "alice@example.com");
+    expect(await isBlocked(getDb(), "ALICE@example.com")).toBe(true);
+  });
+
+  it("matches a domain rule for any address at that domain", async () => {
+    await addRule("domain", "spammer.com");
+    expect(await isBlocked(getDb(), "anyone@spammer.com")).toBe(true);
+  });
+
+  it("does not match a lookalike domain", async () => {
+    await addRule("domain", "spammer.com");
+    expect(await isBlocked(getDb(), "x@notspammer.com")).toBe(false);
+  });
+
+  it("does not treat an email rule as a domain rule", async () => {
+    await addRule("email", "alice@example.com");
+    expect(await isBlocked(getDb(), "bob@example.com")).toBe(false);
+  });
+});

--- a/worker/src/__tests__/blocklist-router.test.ts
+++ b/worker/src/__tests__/blocklist-router.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  authFetch,
+  createTestUser,
+  getDb,
+  applyMigrations,
+  cleanDb,
+} from "./helpers";
+import { blocklist } from "../db/blocklist.schema";
+import { senderIdentities } from "../db/sender-identities.schema";
+
+beforeAll(applyMigrations);
+beforeEach(cleanDb);
+
+describe("blocklist router", () => {
+  it("POST creates an email rule (lowercased)", async () => {
+    const { apiKey } = await createTestUser();
+    const r = await authFetch("/api/blocklist", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ type: "email", value: "SPAM@Evil.com" }),
+    });
+    expect(r.status).toBe(201);
+    const body = (await r.json()) as {
+      type: string;
+      value: string;
+      createdBy: string;
+    };
+    expect(body).toMatchObject({ type: "email", value: "spam@evil.com" });
+    expect(body.createdBy).toBe("test@example.com");
+  });
+
+  it("POST is idempotent on (type, value)", async () => {
+    const { apiKey } = await createTestUser();
+    const payload = JSON.stringify({ type: "domain", value: "evil.com" });
+    await authFetch("/api/blocklist", {
+      apiKey,
+      method: "POST",
+      body: payload,
+    });
+    const r = await authFetch("/api/blocklist", {
+      apiKey,
+      method: "POST",
+      body: payload,
+    });
+    expect([200, 201]).toContain(r.status);
+    const rows = await getDb().query.blocklist.findMany();
+    expect(rows.filter((x) => x.value === "evil.com")).toHaveLength(1);
+  });
+
+  it("POST rejects blocking our own sending domain (self-lockout guard)", async () => {
+    const { apiKey } = await createTestUser();
+    await getDb().insert(senderIdentities).values({
+      email: "me@ourdomain.com",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const r = await authFetch("/api/blocklist", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ type: "domain", value: "ourdomain.com" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("POST rejects blocking our own address", async () => {
+    const { apiKey } = await createTestUser();
+    await getDb().insert(senderIdentities).values({
+      email: "me@ourdomain.com",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const r = await authFetch("/api/blocklist", {
+      apiKey,
+      method: "POST",
+      body: JSON.stringify({ type: "email", value: "me@ourdomain.com" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("GET lists rules newest first; DELETE removes one", async () => {
+    const { apiKey } = await createTestUser();
+    await getDb().insert(blocklist).values({
+      id: "blk-1",
+      type: "email",
+      value: "a@evil.com",
+      createdAt: 100,
+    });
+    const list = await authFetch("/api/blocklist", { apiKey });
+    const body = (await list.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toContain("blk-1");
+
+    const del = await authFetch("/api/blocklist/blk-1", {
+      apiKey,
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+    expect(await getDb().query.blocklist.findMany()).toHaveLength(0);
+  });
+});

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -74,6 +74,8 @@ export async function applyMigrations() {
     `CREATE INDEX IF NOT EXISTS push_subscriptions_user_idx ON push_subscriptions(user_id)`,
     `CREATE TABLE IF NOT EXISTS suppressions (id TEXT PRIMARY KEY, email TEXT NOT NULL, reason TEXT NOT NULL, source TEXT, note TEXT, created_at INTEGER NOT NULL)`,
     `CREATE UNIQUE INDEX IF NOT EXISTS suppressions_email_unique ON suppressions(email)`,
+    `CREATE TABLE IF NOT EXISTS blocklist (id TEXT PRIMARY KEY, type TEXT NOT NULL, value TEXT NOT NULL, note TEXT, created_by TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS blocklist_type_value_unique ON blocklist(type, value)`,
   ];
 
   for (const sql of statements) {
@@ -261,6 +263,7 @@ export function buildSendForm(
 export async function cleanDb() {
   const db = env.DB;
   await db.exec(`
+    DELETE FROM blocklist;
     DELETE FROM suppressions;
     DELETE FROM push_subscriptions;
     DELETE FROM inbox_permissions;

--- a/worker/src/__tests__/people-router.test.ts
+++ b/worker/src/__tests__/people-router.test.ts
@@ -6,7 +6,9 @@ import {
   createTestPerson,
   createTestEmail,
   authFetch,
+  getDb,
 } from "./helpers";
+import { blocklist } from "../db/blocklist.schema";
 
 describe("people router", () => {
   let apiKey: string;
@@ -245,6 +247,59 @@ describe("people router", () => {
       const body = await res.json();
       expect(body.data[0].recipients?.[0]).toBe("support@saasmail.test");
       expect(body.data[1].recipients?.[0]).toBe("alpha@saasmail.test");
+    });
+
+    it("excludes blocked senders (email + domain) from grouped results and aggregates", async () => {
+      await createTestPerson({
+        id: "p-block-email",
+        email: "spam@evil.com",
+        unreadCount: 1,
+      });
+      await createTestEmail({
+        id: "e-be",
+        personId: "p-block-email",
+        messageId: "m-be@evil.com",
+      });
+
+      await createTestPerson({
+        id: "p-block-domain",
+        email: "x@bad.com",
+        unreadCount: 1,
+      });
+      await createTestEmail({
+        id: "e-bd",
+        personId: "p-block-domain",
+        messageId: "m-bd@bad.com",
+      });
+
+      await createTestPerson({
+        id: "p-keep",
+        email: "ok@nice.com",
+        unreadCount: 1,
+      });
+      await createTestEmail({
+        id: "e-keep",
+        personId: "p-keep",
+        messageId: "m-keep@nice.com",
+      });
+
+      await getDb()
+        .insert(blocklist)
+        .values([
+          { id: "b1", type: "email", value: "spam@evil.com", createdAt: 1 },
+          { id: "b2", type: "domain", value: "bad.com", createdAt: 2 },
+        ]);
+
+      const r = await authFetch("/api/people/grouped", { apiKey });
+      const body = (await r.json()) as {
+        data: Array<{ id: string; email: string }>;
+        aggregates: { unreadRowCount: number };
+      };
+      const ids = body.data.map((d) => d.id);
+      expect(ids).toContain("p-keep");
+      expect(ids).not.toContain("p-block-email");
+      expect(ids).not.toContain("p-block-domain");
+      expect(body.aggregates.unreadRowCount).toBe(1); // only p-keep counts
     });
 
     it("flips recency to ascending (oldest first) when direction=asc", async () => {

--- a/worker/src/__tests__/purge-blocked.test.ts
+++ b/worker/src/__tests__/purge-blocked.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  authFetch,
+  createTestUser,
+  createTestPerson,
+  createTestEmail,
+  getDb,
+  applyMigrations,
+  cleanDb,
+} from "./helpers";
+import { blocklist } from "../db/blocklist.schema";
+
+beforeAll(applyMigrations);
+beforeEach(cleanDb);
+
+describe("DELETE /api/blocklist/mail (purge)", () => {
+  it("deletes emails + people matching a domain rule, leaves others", async () => {
+    const { apiKey } = await createTestUser();
+
+    // Blocked sender (domain rule below).
+    await createTestPerson({ id: "p-spam", email: "bad@evil.com" });
+    await createTestEmail({
+      id: "e-spam",
+      personId: "p-spam",
+      messageId: "m-spam@evil.com",
+    });
+
+    // Innocent sender — must survive.
+    await createTestPerson({ id: "p-ok", email: "good@nice.com" });
+    await createTestEmail({
+      id: "e-ok",
+      personId: "p-ok",
+      messageId: "m-ok@nice.com",
+    });
+
+    await getDb().insert(blocklist).values({
+      id: "blk-dom",
+      type: "domain",
+      value: "evil.com",
+      createdAt: 1,
+    });
+
+    const r = await authFetch("/api/blocklist/mail", {
+      apiKey,
+      method: "DELETE",
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as {
+      emailsDeleted: number;
+      peopleDeleted: number;
+    };
+    expect(body.emailsDeleted).toBe(1);
+    expect(body.peopleDeleted).toBe(1);
+
+    const people = await getDb().query.people.findMany();
+    expect(people.map((p) => p.id)).toEqual(["p-ok"]);
+    const emails = await getDb().query.emails.findMany();
+    expect(emails.map((e) => e.id)).toEqual(["e-ok"]);
+  });
+
+  it("matches exact email rules too", async () => {
+    const { apiKey } = await createTestUser();
+    await createTestPerson({ id: "p-x", email: "x@mixed.com" });
+    await createTestEmail({
+      id: "e-x",
+      personId: "p-x",
+      messageId: "m-x@mixed.com",
+    });
+    await createTestPerson({ id: "p-y", email: "y@mixed.com" });
+    await createTestEmail({
+      id: "e-y",
+      personId: "p-y",
+      messageId: "m-y@mixed.com",
+    });
+
+    await getDb().insert(blocklist).values({
+      id: "blk-email",
+      type: "email",
+      value: "x@mixed.com",
+      createdAt: 1,
+    });
+
+    await authFetch("/api/blocklist/mail", { apiKey, method: "DELETE" });
+    const people = await getDb().query.people.findMany();
+    expect(people.map((p) => p.id).sort()).toEqual(["p-y"]);
+  });
+});

--- a/worker/src/db/blocklist.schema.ts
+++ b/worker/src/db/blocklist.schema.ts
@@ -1,0 +1,28 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  unique,
+  index,
+} from "drizzle-orm/sqlite-core";
+
+export const blocklist = sqliteTable(
+  "blocklist",
+  {
+    id: text("id").primaryKey(),
+    // "email" blocks a single address; "domain" blocks every address at a domain.
+    type: text("type", { enum: ["email", "domain"] }).notNull(),
+    // Lowercased + trimmed. For "domain" this is the bare domain (e.g. "spammer.com").
+    value: text("value").notNull(),
+    note: text("note"),
+    createdBy: text("created_by"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    unique("blocklist_type_value_unique").on(table.type, table.value),
+    index("blocklist_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export type BlockRule = typeof blocklist.$inferSelect;
+export type NewBlockRule = typeof blocklist.$inferInsert;

--- a/worker/src/db/index.ts
+++ b/worker/src/db/index.ts
@@ -15,4 +15,5 @@ export * from "./inbox-permissions.schema";
 export * from "./push-subscriptions.schema";
 export * from "./app-settings.schema";
 export * from "./suppressions.schema";
+export * from "./blocklist.schema";
 export * from "./schema";

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -14,6 +14,7 @@ import { inboxPermissions } from "./inbox-permissions.schema";
 import { pushSubscriptions } from "./push-subscriptions.schema";
 import { appSettings } from "./app-settings.schema";
 import { suppressions } from "./suppressions.schema";
+import { blocklist } from "./blocklist.schema";
 
 export const schema = {
   ...authSchema,
@@ -32,4 +33,5 @@ export const schema = {
   pushSubscriptions,
   appSettings,
   suppressions,
+  blocklist,
 } as const;

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -9,6 +9,7 @@ import { inboxPermissions } from "./db/inbox-permissions.schema";
 import { senderIdentities } from "./db/sender-identities.schema";
 import { users } from "./db/auth.schema";
 import { parseEmail } from "./lib/email-parser";
+import { isBlocked } from "./lib/blocklist";
 import { computeConversationId, externalsOnly } from "./lib/conversation-id";
 import { cancelSequencesForPerson } from "./lib/cancel-sequence";
 import {
@@ -37,6 +38,12 @@ export async function handleEmail(
   // need the stored column to match).
   const recipientCanonical = parsed.to.trim().toLowerCase();
   const fromAddressCanonical = parsed.from.address.trim().toLowerCase();
+
+  // Drop mail from blocked senders/domains before any storage or side effects.
+  if (await isBlocked(db, fromAddressCanonical)) {
+    console.log(`Dropped blocked email from ${fromAddressCanonical}`);
+    return;
+  }
 
   // Deduplicate by Message-ID
   if (parsed.messageId) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ import { sequencesRouter } from "./routers/sequences-router";
 import { handleScheduled, handleQueueBatch } from "./lib/sequence-processor";
 import type { SequenceEmailMessage } from "./lib/sequence-processor";
 import { notificationsRouter } from "./routers/notifications-router";
+import { blocklistRouter } from "./routers/blocklist-router";
 import { suppressionsRouter } from "./routers/suppressions-router";
 import { webhooksRouter } from "./routers/webhooks-router";
 import { unsubscribeRouter } from "./routers/unsubscribe-router";
@@ -204,6 +205,7 @@ app.route("/api/api-keys", apiKeysRouter);
 app.route("/api/invites", invitesRouter);
 app.route("/api/sequences", sequencesRouter);
 app.route("/api/notifications", notificationsRouter);
+app.route("/api/blocklist", blocklistRouter);
 
 // Admin routes (require admin role)
 app.use("/api/admin/*", requireAdmin);

--- a/worker/src/lib/blocklist.ts
+++ b/worker/src/lib/blocklist.ts
@@ -1,0 +1,26 @@
+import { and, eq, or } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { schema } from "../db/schema";
+import { blocklist } from "../db/blocklist.schema";
+
+export type Database = DrizzleD1Database<typeof schema>;
+
+/** Lowercased domain part of an email address (everything after the last "@"). */
+export function domainOf(email: string): string {
+  const at = email.lastIndexOf("@");
+  return at === -1 ? "" : email.slice(at + 1).toLowerCase();
+}
+
+/** True if the sender email (exact) or its domain is on the blocklist. */
+export async function isBlocked(db: Database, email: string): Promise<boolean> {
+  const addr = email.trim().toLowerCase();
+  const domain = domainOf(addr);
+  const row = await db.query.blocklist.findFirst({
+    where: or(
+      and(eq(blocklist.type, "email"), eq(blocklist.value, addr)),
+      and(eq(blocklist.type, "domain"), eq(blocklist.value, domain)),
+    ),
+    columns: { id: true },
+  });
+  return !!row;
+}

--- a/worker/src/lib/blocklist.ts
+++ b/worker/src/lib/blocklist.ts
@@ -5,7 +5,12 @@ import { blocklist } from "../db/blocklist.schema";
 
 export type Database = DrizzleD1Database<typeof schema>;
 
-/** Lowercased domain part of an email address (everything after the last "@"). */
+/**
+ * Lowercased domain part of an email address (everything after the last "@").
+ * Well-formed stored addresses have exactly one "@", so this agrees with the
+ * first-"@" `substr(..., instr(..., '@')+1)` expression used in the SQL paths
+ * (people-router hiding, purge selection).
+ */
 export function domainOf(email: string): string {
   const at = email.lastIndexOf("@");
   return at === -1 ? "" : email.slice(at + 1).toLowerCase();

--- a/worker/src/lib/purge-blocked.ts
+++ b/worker/src/lib/purge-blocked.ts
@@ -1,0 +1,45 @@
+import { eq, sql } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { emails } from "../db/emails.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { people } from "../db/people.schema";
+import { deleteEmailWithAttachments } from "./delete-email";
+
+/**
+ * Hard-delete every email + person whose address matches any block rule, and
+ * clean up R2 attachments. Matches exact-email rules and domain rules (via the
+ * computed domain of people.email). Returns counts for the caller/UI.
+ */
+export async function purgeBlockedMail(
+  db: DrizzleD1Database<any>,
+  r2: R2Bucket,
+): Promise<{ emailsDeleted: number; peopleDeleted: number }> {
+  // People whose address is blocked (exact email OR domain match).
+  const blockedPeople = await db.all<{ id: string }>(sql`
+    SELECT p.id FROM people p
+    WHERE EXISTS (
+      SELECT 1 FROM blocklist b
+      WHERE (b.type = 'email'  AND b.value = p.email)
+         OR (b.type = 'domain' AND b.value = lower(substr(p.email, instr(p.email, '@') + 1)))
+    )
+  `);
+
+  let emailsDeleted = 0;
+  for (const { id: personId } of blockedPeople) {
+    // Received emails (with R2 attachment cleanup).
+    const received = await db
+      .select({ id: emails.id })
+      .from(emails)
+      .where(eq(emails.personId, personId));
+    for (const e of received) {
+      const res = await deleteEmailWithAttachments(db, r2, e.id);
+      if (res) emailsDeleted++;
+    }
+    // Any sent emails attributed to this person.
+    await db.delete(sentEmails).where(eq(sentEmails.personId, personId));
+    // Finally the person row.
+    await db.delete(people).where(eq(people.id, personId));
+  }
+
+  return { emailsDeleted, peopleDeleted: blockedPeople.length };
+}

--- a/worker/src/routers/blocklist-router.ts
+++ b/worker/src/routers/blocklist-router.ts
@@ -5,6 +5,7 @@ import { blocklist } from "../db/blocklist.schema";
 import { senderIdentities } from "../db/sender-identities.schema";
 import { domainOf } from "../lib/blocklist";
 import { json200Response, json201Response } from "../lib/helpers";
+import { purgeBlockedMail } from "../lib/purge-blocked";
 import type { Variables } from "../variables";
 
 export const blocklistRouter = new OpenAPIHono<{
@@ -184,6 +185,27 @@ blocklistRouter.openapi(createRouteDef, async (c) => {
   )[0];
 
   return c.json(toDTO(row), row.id === id ? 201 : 200);
+});
+
+// --- DELETE /api/blocklist/mail (purge hidden mail) ---
+const PurgeResponseSchema = z.object({
+  emailsDeleted: z.number(),
+  peopleDeleted: z.number(),
+});
+
+const purgeRouteDef = createRoute({
+  method: "delete",
+  path: "/mail",
+  tags: ["Blocklist"],
+  description:
+    "Permanently delete all currently-hidden emails from blocked senders/domains.",
+  responses: { ...json200Response(PurgeResponseSchema, "Purge result") },
+});
+
+blocklistRouter.openapi(purgeRouteDef, async (c) => {
+  const db = c.get("db");
+  const result = await purgeBlockedMail(db, c.env.R2);
+  return c.json(result, 200);
 });
 
 // --- DELETE /api/blocklist/:id ---

--- a/worker/src/routers/blocklist-router.ts
+++ b/worker/src/routers/blocklist-router.ts
@@ -1,0 +1,206 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { desc, eq, lt, and } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { blocklist } from "../db/blocklist.schema";
+import { senderIdentities } from "../db/sender-identities.schema";
+import { domainOf } from "../lib/blocklist";
+import { json200Response, json201Response } from "../lib/helpers";
+import type { Variables } from "../variables";
+
+export const blocklistRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+const BlockRuleSchema = z.object({
+  id: z.string(),
+  type: z.enum(["email", "domain"]),
+  value: z.string(),
+  note: z.string().nullable(),
+  createdBy: z.string().nullable(),
+  createdAt: z.number(),
+});
+
+const ListResponseSchema = z.object({
+  items: z.array(BlockRuleSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const CreateSchema = z.object({
+  type: z.enum(["email", "domain"]),
+  value: z.string().min(1),
+  note: z.string().optional(),
+});
+
+const DeleteResponseSchema = z.object({ deleted: z.literal(true) });
+const ErrorSchema = z.object({ error: z.string() });
+
+function toDTO(r: {
+  id: string;
+  type: "email" | "domain";
+  value: string;
+  note: string | null;
+  createdBy: string | null;
+  createdAt: number;
+}) {
+  return {
+    id: r.id,
+    type: r.type,
+    value: r.value,
+    note: r.note,
+    createdBy: r.createdBy,
+    createdAt: r.createdAt,
+  };
+}
+
+// --- GET /api/blocklist ---
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Blocklist"],
+  description:
+    "List block rules, newest first. Cursor is the createdAt of the last item.",
+  request: {
+    query: z.object({
+      cursor: z.string().optional(),
+      limit: z.string().optional(),
+    }),
+  },
+  responses: { ...json200Response(ListResponseSchema, "List of block rules") },
+});
+
+blocklistRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const { cursor, limit: limitRaw } = c.req.valid("query");
+
+  let limit = DEFAULT_LIMIT;
+  if (limitRaw) {
+    const parsed = Number.parseInt(limitRaw, 10);
+    if (Number.isFinite(parsed) && parsed > 0)
+      limit = Math.min(parsed, MAX_LIMIT);
+  }
+
+  const whereClause = cursor
+    ? lt(blocklist.createdAt, Number.parseInt(cursor, 10))
+    : undefined;
+  const rows = await db
+    .select()
+    .from(blocklist)
+    .where(whereClause)
+    .orderBy(desc(blocklist.createdAt))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor =
+    hasMore && items.length > 0
+      ? String(items[items.length - 1].createdAt)
+      : null;
+
+  return c.json({ items: items.map(toDTO), nextCursor }, 200);
+});
+
+// --- POST /api/blocklist ---
+const createRouteDef = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Blocklist"],
+  description:
+    "Add a block rule. Idempotent on (type, value). Rejects rules that would block our own sending identities.",
+  request: {
+    body: { content: { "application/json": { schema: CreateSchema } } },
+  },
+  responses: {
+    ...json200Response(BlockRuleSchema, "Existing rule returned"),
+    ...json201Response(BlockRuleSchema, "Rule created"),
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+blocklistRouter.openapi(createRouteDef, async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const { type, value: rawValue, note } = c.req.valid("json");
+
+  const value = rawValue.trim().toLowerCase();
+  if (!value) return c.json({ error: "Value is required." }, 400);
+  if (type === "email" && !value.includes("@")) {
+    return c.json({ error: "Enter a valid email address." }, 400);
+  }
+  if (type === "domain" && (value.includes("@") || !value.includes("."))) {
+    return c.json({ error: "Enter a bare domain, e.g. spammer.com." }, 400);
+  }
+
+  // Self-lockout guard: never let a rule block one of our own sender identities.
+  const identities = await db
+    .select({ email: senderIdentities.email })
+    .from(senderIdentities);
+  const ownEmails = new Set(identities.map((i) => i.email.toLowerCase()));
+  const ownDomains = new Set(
+    Array.from(ownEmails)
+      .map((e) => domainOf(e))
+      .filter(Boolean),
+  );
+  if (type === "email" && ownEmails.has(value)) {
+    return c.json({ error: "You can't block one of your own addresses." }, 400);
+  }
+  if (type === "domain" && ownDomains.has(value)) {
+    return c.json({ error: "You can't block your own sending domain." }, 400);
+  }
+
+  const existing = await db
+    .select()
+    .from(blocklist)
+    .where(and(eq(blocklist.type, type), eq(blocklist.value, value)))
+    .limit(1);
+  if (existing.length > 0) return c.json(toDTO(existing[0]), 200);
+
+  const id = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .insert(blocklist)
+    .values({
+      id,
+      type,
+      value,
+      note: note ?? null,
+      createdBy: user.email,
+      createdAt: now,
+    })
+    .onConflictDoNothing();
+
+  const row = (
+    await db
+      .select()
+      .from(blocklist)
+      .where(and(eq(blocklist.type, type), eq(blocklist.value, value)))
+      .limit(1)
+  )[0];
+
+  return c.json(toDTO(row), row.id === id ? 201 : 200);
+});
+
+// --- DELETE /api/blocklist/:id ---
+const deleteRouteDef = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Blocklist"],
+  description: "Remove a block rule (unblock). Idempotent.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    ...json200Response(DeleteResponseSchema, "Rule deleted (or absent)"),
+  },
+});
+
+blocklistRouter.openapi(deleteRouteDef, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  await db.delete(blocklist).where(eq(blocklist.id, id));
+  return c.json({ deleted: true as const }, 200);
+});

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -197,6 +197,15 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
         ))`,
     );
   }
+  // Hide senders that are on the global blocklist (exact email or domain).
+  // The blocklist is the source of truth; unblocking makes rows reappear.
+  personConditions.push(
+    sql`NOT EXISTS (
+      SELECT 1 FROM blocklist b
+      WHERE (b.type = 'email'  AND b.value = s.email)
+         OR (b.type = 'domain' AND b.value = lower(substr(s.email, instr(s.email, '@') + 1)))
+    )`,
+  );
   const scopeClause = peopleScopeClause(allowed);
   const personExtraConditions =
     personConditions.length > 0


### PR DESCRIPTION
## Summary

Adds the ability to block individual email addresses and entire sending domains. Blocking **hides** existing mail from the inbox (reversible) and **drops** future inbound mail at ingress. Any authenticated inbox user can manage the blocklist; a settings page lists rules, unblocks, and purges hidden mail.

## How it works

- **Source of truth:** new global `blocklist` table (`type` = `email` | `domain`, unique on `(type, value)`). Blocking sets no destructive state, so **unblock is fully reversible** — deleting a rule makes hidden threads reappear.
- **Ingress drop** (`worker/src/email-handler.ts`): `isBlocked()` runs right after sender canonicalization and returns early *before* any DB write, notification, webhook, or sequence side effect.
- **Hiding** (`people-router.ts`): a `NOT EXISTS` filter on the grouped inbox query excludes blocked senders from both the rows **and** the aggregate counts.
- **API** (`/api/blocklist`, not admin-gated): list, create (idempotent, with a self-lockout guard that refuses to block your own `sender_identities`), delete, and `DELETE /mail` to purge hidden mail (reuses `deleteEmailWithAttachments` for R2 cleanup, spares innocent senders).
- **Frontend:** Blocklist settings page (+ nav links), a Block menu in the thread header (block sender / block domain), and a Block action in the inbox selection bar.
- Domain matching is **exact** everywhere (a rule for `evil.com` won't match `x@notevil.com` or subdomains).

## Testing

- New tests: `blocklist-lib`, `blocklist-router`, `purge-blocked`, plus a grouped-inbox hiding assertion in `people-router`.
- `yarn tsc --noEmit`: clean.
- Full suite (serialized): **419 passed, 1 skipped, 0 failed**. Note: the default *parallel* `yarn test` has pre-existing cross-file D1 state contamination (present on `main` too) — run with `--no-file-parallelism` for a clean result.

## Migration

`0029_*` — additive `CREATE TABLE blocklist` + indexes. No backfill, no backward-compat risk.

## Documented follow-ups (out of scope)

- `stats-router` global counts don't exclude blocked senders (spec scoped hiding to the grouped query).
- Multi-participant group conversations aren't hidden (only 1-on-1 person threads); future group mail from blocked senders is still dropped at ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)