### PR TITLE
fix: show real From address in view-original for received emails

### DIFF
--- a/worker/src/__tests__/conversations-router.test.ts
+++ b/worker/src/__tests__/conversations-router.test.ts
@@ -90,9 +90,6 @@ describe("conversations router", () => {
     });
 
     it("resolves fromAddress to the sender person for received emails", async () => {
-      // Regression: the view-original modal showed "—" for From on received
-      // emails because the timeline returned fromAddress: null. Received mail
-      // has no sender column — it's the linked person (personId → people.email).
       const db = getDb();
       const now = Math.floor(Date.now() / 1000);
       await createTestPerson({ id: "p1", email: "external@example.com" });

--- a/worker/src/__tests__/conversations-router.test.ts
+++ b/worker/src/__tests__/conversations-router.test.ts
@@ -5,11 +5,13 @@ import {
   applyMigrations,
   cleanDb,
   createTestUser,
+  createTestPerson,
   authFetch,
   getDb,
   buildSendForm,
 } from "./helpers";
 import { sentEmails } from "../db/sent-emails.schema";
+import { emails } from "../db/emails.schema";
 
 describe("conversations router", () => {
   let apiKey: string;
@@ -85,6 +87,41 @@ describe("conversations router", () => {
       expect(sentRow!.attachments).toHaveLength(1);
       expect(sentRow!.attachments[0].filename).toBe("doc.txt");
       expect(sentRow!.attachmentCount).toBe(1);
+    });
+
+    it("resolves fromAddress to the sender person for received emails", async () => {
+      // Regression: the view-original modal showed "—" for From on received
+      // emails because the timeline returned fromAddress: null. Received mail
+      // has no sender column — it's the linked person (personId → people.email).
+      const db = getDb();
+      const now = Math.floor(Date.now() / 1000);
+      await createTestPerson({ id: "p1", email: "external@example.com" });
+      await db.insert(emails).values({
+        id: "recv-1",
+        personId: "p1",
+        recipient: "me@saasmail.test",
+        subject: "Inbound",
+        bodyHtml: "<p>hi</p>",
+        bodyText: "hi",
+        rawHeaders: "{}",
+        messageId: "inbound-1@example.com",
+        isRead: 0,
+        conversationId: "conv-xyz",
+        receivedAt: now,
+        createdAt: now,
+      });
+
+      const res = await authFetch("/api/conversations/conv-xyz/emails", {
+        apiKey,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        emails: Array<{ id: string; type: string; fromAddress: string | null }>;
+      };
+      const received = body.emails.find((e) => e.id === "recv-1");
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("received");
+      expect(received!.fromAddress).toBe("external@example.com");
     });
   });
 });

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -70,8 +70,6 @@ describe("emails router", () => {
       // Most recent first — sent email has higher timestamp
       expect(data[0].type).toBe("sent");
       expect(data[1].type).toBe("received");
-      // Received email's From resolves to the sender person (regression:
-      // used to be null, rendering "—" in the view-original modal).
       expect(data[1].fromAddress).toBe("a@test.com");
     });
 
@@ -247,8 +245,6 @@ describe("emails router", () => {
     });
 
     it("resolves fromAddress to the sender person for received email", async () => {
-      // Regression: the view-original modal showed "—" for From because
-      // received emails have no sender column — it's the linked person.
       await createTestPerson({ id: "s1", email: "sender@example.com" });
       await createTestEmail({ id: "e1", personId: "s1" });
 

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -70,6 +70,9 @@ describe("emails router", () => {
       // Most recent first — sent email has higher timestamp
       expect(data[0].type).toBe("sent");
       expect(data[1].type).toBe("received");
+      // Received email's From resolves to the sender person (regression:
+      // used to be null, rendering "—" in the view-original modal).
+      expect(data[1].fromAddress).toBe("a@test.com");
     });
 
     it("surfaces delivery status: 'failed' on sent, null on received", async () => {
@@ -241,6 +244,18 @@ describe("emails router", () => {
       expect(data.id).toBe("e1");
       expect(data.type).toBe("received");
       expect(data.attachments).toEqual([]);
+    });
+
+    it("resolves fromAddress to the sender person for received email", async () => {
+      // Regression: the view-original modal showed "—" for From because
+      // received emails have no sender column — it's the linked person.
+      await createTestPerson({ id: "s1", email: "sender@example.com" });
+      await createTestEmail({ id: "e1", personId: "s1" });
+
+      const res = await authFetch("/api/emails/e1", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.fromAddress).toBe("sender@example.com");
     });
 
     it("surfaces replyTo from the inbound Reply-To header", async () => {

--- a/worker/src/routers/conversations-router.ts
+++ b/worker/src/routers/conversations-router.ts
@@ -186,6 +186,11 @@ conversationsRouter.openapi(listConversationEmailsRoute, async (c) => {
     }
   }
 
+  // Received emails don't store a sender column — the sender is the person
+  // (personId → people.email). Resolve it from the participants we already
+  // loaded so "From" renders correctly in the timeline / view-original modal.
+  const personEmailById = new Map(participants.map((p) => [p.id, p.email]));
+
   // Merge into the same email shape as listPersonEmailsRoute, oldest first.
   const merged = [
     ...received.map((e) => ({
@@ -193,7 +198,9 @@ conversationsRouter.openapi(listConversationEmailsRoute, async (c) => {
       type: "received" as const,
       personId: e.personId ?? null,
       recipient: e.recipient,
-      fromAddress: null,
+      fromAddress: e.personId
+        ? (personEmailById.get(e.personId) ?? null)
+        : null,
       toAddress: null,
       subject: e.subject,
       bodyHtml: e.bodyHtml,

--- a/worker/src/routers/conversations-router.ts
+++ b/worker/src/routers/conversations-router.ts
@@ -186,9 +186,6 @@ conversationsRouter.openapi(listConversationEmailsRoute, async (c) => {
     }
   }
 
-  // Received emails don't store a sender column — the sender is the person
-  // (personId → people.email). Resolve it from the participants we already
-  // loaded so "From" renders correctly in the timeline / view-original modal.
   const personEmailById = new Map(participants.map((p) => [p.id, p.email]));
 
   // Merge into the same email shape as listPersonEmailsRoute, oldest first.

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -193,6 +193,16 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
     .where(and(...sentConditions))
     .orderBy(desc(sentEmails.sentAt));
 
+  // Received emails don't store a sender column — the sender is this person
+  // (personId → people.email). Resolve it once so "From" renders in the
+  // view-original modal instead of an em-dash placeholder.
+  const personRow = await db
+    .select({ email: people.email })
+    .from(people)
+    .where(eq(people.id, personId))
+    .limit(1);
+  const personEmail = personRow[0]?.email ?? null;
+
   // Merge and sort
   const merged = [
     ...received.map((e) => ({
@@ -200,7 +210,7 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
       type: "received" as const,
       personId,
       recipient: e.recipient,
-      fromAddress: null,
+      fromAddress: personEmail,
       toAddress: null,
       subject: e.subject,
       bodyHtml: e.bodyHtml,
@@ -377,12 +387,19 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
       .select()
       .from(attachments)
       .where(eq(attachments.emailId, id));
+    // The sender of a received email is the linked person (personId →
+    // people.email); the `emails` table has no sender column of its own.
+    const senderRow = await db
+      .select({ email: people.email })
+      .from(people)
+      .where(eq(people.id, row[0].personId))
+      .limit(1);
     return c.json(
       {
         ...row[0],
         type: "received",
         timestamp: row[0].receivedAt,
-        fromAddress: null,
+        fromAddress: senderRow[0]?.email ?? null,
         toAddress: null,
         replyTo: extractReplyTo(row[0].rawHeaders),
         cc: parseCc(row[0].cc),
@@ -810,7 +827,9 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
           id: target.id,
           personId: person.id,
           toAddress: null,
-          fromAddress: null,
+          // Received sender is the (now reassigned) person — mirror the read
+          // endpoints so consumers get a real From, not an em-dash placeholder.
+          fromAddress: person.email,
         },
         person,
       },

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -193,9 +193,6 @@ emailsRouter.openapi(listPersonEmailsRoute, async (c) => {
     .where(and(...sentConditions))
     .orderBy(desc(sentEmails.sentAt));
 
-  // Received emails don't store a sender column — the sender is this person
-  // (personId → people.email). Resolve it once so "From" renders in the
-  // view-original modal instead of an em-dash placeholder.
   const personRow = await db
     .select({ email: people.email })
     .from(people)
@@ -387,8 +384,6 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
       .select()
       .from(attachments)
       .where(eq(attachments.emailId, id));
-    // The sender of a received email is the linked person (personId →
-    // people.email); the `emails` table has no sender column of its own.
     const senderRow = await db
       .select({ email: people.email })
       .from(people)
@@ -827,8 +822,6 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
           id: target.id,
           personId: person.id,
           toAddress: null,
-          // Received sender is the (now reassigned) person — mirror the read
-          // endpoints so consumers get a real From, not an em-dash placeholder.
           fromAddress: person.email,
         },
         person,


### PR DESCRIPTION
## Problem

When clicking **View Original** on a received email, the popup's **From** field always showed `—` (em-dash placeholder), which is incorrect.

## Root cause

Received emails have no sender column in the `emails` table — the sender is the linked person (`personId → people.email`). But every read endpoint that feeds the view-original modal hard-coded `fromAddress: null` for received mail, so the frontend (`EmailHtmlModal.tsx`, which correctly reads `email.fromAddress`) always fell back to the `—` placeholder.

## Fix

Resolve the real sender from the `people` table in all affected handlers:

- **`conversations-router` `listConversationEmails`** — the endpoint the popup actually uses; reuses the already-loaded `participants` as a `personId → email` map (no extra query).
- **`emails-router` `listPersonEmails`** — looks up the person's email once (single `personId` route param).
- **`emails-router` `getEmail`** — looks up the sender for a received row.
- **`emails-router` `reassignPerson`** (received branch) — returns the reassigned person's email instead of `null`, so consumers get a real From after re-attribution.

No frontend changes were needed — the modal was already reading the right field; it was just always empty.

## Tests

- Added regression tests for the conversation-timeline and single-email endpoints asserting `fromAddress` resolves to the sender.
- Strengthened the existing by-person test with the same assertion.
- Full suite: **421 passed / 1 skipped**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)