### PR TITLE
fix: make mobile pull-to-refresh work

### DIFF
--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,9 +1,10 @@
-import { useCallback, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UsePullToRefreshOptions {
   /** Called when the user pulls past the threshold and releases. May be async;
-   *  the spinner stays until the returned promise settles. */
-  onRefresh: () => Promise<unknown> | void;
+   *  the spinner stays until the returned promise settles. When omitted, the
+   *  gesture is disabled entirely (no listeners are attached). */
+  onRefresh?: () => Promise<unknown> | void;
   /** Pull distance (px) required to trigger a refresh. */
   threshold?: number;
   /** Max distance the indicator travels — pulling further has no extra effect. */
@@ -12,9 +13,15 @@ interface UsePullToRefreshOptions {
 
 /**
  * Touch-driven pull-to-refresh for a scrollable container. Attach `ref` to the
- * element that scrolls and spread `handlers` onto the same element. The pull is
- * only armed when the container is already scrolled to the top, so it never
- * fights an in-progress scroll.
+ * element that scrolls. The pull is only armed when the container is already
+ * scrolled to the top, so it never fights an in-progress scroll.
+ *
+ * The touch listeners are attached natively (not via React's onTouch* props)
+ * because React registers touchmove as a *passive* listener — passive listeners
+ * can't call preventDefault(), which we need to suppress the browser's own
+ * overscroll / pull-to-refresh so ours can take over. Without this the native
+ * gesture wins on mobile (Android Chrome reloads the page) and the custom pull
+ * appears to do nothing.
  *
  * Touch-only by design — desktop never fires these events, so it's inert there.
  */
@@ -24,68 +31,90 @@ export function usePullToRefresh<T extends HTMLElement>({
   maxPull = 110,
 }: UsePullToRefreshOptions) {
   const ref = useRef<T | null>(null);
-  const startY = useRef<number | null>(null);
   const [pullDistance, setPullDistance] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
 
-  const onTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      const el = ref.current;
+  // Hold the latest callback so we can re-bind listeners only when the gesture
+  // is enabled/disabled, not on every render where onRefresh's identity changes.
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  const enabled = typeof onRefresh === "function";
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled) return;
+
+    // Gesture state kept in closures (not React state) so the move handler can
+    // read/write it synchronously without stale-closure surprises.
+    let startY: number | null = null;
+    let distance = 0;
+    let busy = false;
+
+    const onTouchStart = (e: TouchEvent) => {
       // Only arm when resting at the top and not mid-refresh.
-      if (!el || el.scrollTop > 0 || refreshing) {
-        startY.current = null;
+      if (el.scrollTop > 0 || busy) {
+        startY = null;
         return;
       }
-      startY.current = e.touches[0].clientY;
-    },
-    [refreshing],
-  );
+      startY = e.touches[0].clientY;
+    };
 
-  const onTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      if (startY.current === null || refreshing) return;
-      const el = ref.current;
-      if (!el) return;
+    const onTouchMove = (e: TouchEvent) => {
+      if (startY === null || busy) return;
       // If the container scrolled away from the top mid-gesture, bail out so a
       // normal scroll wins.
       if (el.scrollTop > 0) {
-        startY.current = null;
+        startY = null;
+        distance = 0;
         setPullDistance(0);
         return;
       }
-      const delta = e.touches[0].clientY - startY.current;
+      const delta = e.touches[0].clientY - startY;
       if (delta <= 0) {
+        distance = 0;
         setPullDistance(0);
         return;
       }
+      // We're actively pulling the list down past its top edge — stop the
+      // browser's native overscroll/refresh from stealing the gesture.
+      e.preventDefault();
       // Rubber-band resistance so the pull feels heavier the further it goes.
-      setPullDistance(Math.min(maxPull, delta * 0.5));
-    },
-    [maxPull, refreshing],
-  );
+      distance = Math.min(maxPull, delta * 0.5);
+      setPullDistance(distance);
+    };
 
-  const onTouchEnd = useCallback(() => {
-    if (startY.current === null) return;
-    startY.current = null;
-    if (pullDistance >= threshold) {
-      setRefreshing(true);
-      // Hold the indicator at the threshold while the refresh runs.
-      setPullDistance(threshold);
-      Promise.resolve(onRefresh()).finally(() => {
-        setRefreshing(false);
+    const onTouchEnd = () => {
+      if (startY === null) return;
+      startY = null;
+      if (distance >= threshold) {
+        busy = true;
+        setRefreshing(true);
+        // Hold the indicator at the threshold while the refresh runs.
+        setPullDistance(threshold);
+        Promise.resolve(onRefreshRef.current?.()).finally(() => {
+          busy = false;
+          distance = 0;
+          setRefreshing(false);
+          setPullDistance(0);
+        });
+      } else {
+        distance = 0;
         setPullDistance(0);
-      });
-    } else {
-      setPullDistance(0);
-    }
-  }, [pullDistance, threshold, onRefresh]);
+      }
+    };
 
-  return {
-    ref,
-    pullDistance,
-    refreshing,
-    threshold,
-    /** Spread onto the same element that `ref` is attached to. */
-    handlers: { onTouchStart, onTouchMove, onTouchEnd },
-  };
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd);
+    el.addEventListener("touchcancel", onTouchEnd);
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [enabled, threshold, maxPull]);
+
+  return { ref, pullDistance, refreshing, threshold };
 }

--- a/src/pages/PersonList.tsx
+++ b/src/pages/PersonList.tsx
@@ -132,10 +132,7 @@ export default function PersonList({
     pullDistance,
     refreshing,
     threshold,
-    handlers: pullHandlers,
-  } = usePullToRefresh<HTMLDivElement>({
-    onRefresh: onRefresh ?? (() => {}),
-  });
+  } = usePullToRefresh<HTMLDivElement>({ onRefresh });
   const pullActive = pullDistance > 0 || refreshing;
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -202,7 +199,6 @@ export default function PersonList({
       {/* Scrollable list — independent of the right pane */}
       <div
         ref={scrollRef}
-        {...(onRefresh ? pullHandlers : {})}
         className="smooth-scroll relative min-h-0 flex-1 overflow-y-auto"
         style={onRefresh ? { overscrollBehaviorY: "contain" } : undefined}
       >


### PR DESCRIPTION
## Problem

Mobile pull-to-refresh on the People list did nothing. The logic was sound, but the hook wired its touch handlers via React's `onTouch*` **props**, which React registers as **passive** listeners. Passive listeners can't call `e.preventDefault()`, so nothing suppressed the browser's own native overscroll / pull-to-refresh gesture. That native gesture competes with — and on Android Chrome overrides (pulls down to reload the page) — the custom one.

## Fix

- `usePullToRefresh.ts`: attach touch listeners **natively via the ref** instead of React props; bind `touchmove` as non-passive (`{ passive: false }`) and `preventDefault()` while actively pulling from the top edge so the custom refresh takes over.
- Only bind when `onRefresh` is provided (preserves the previous no-op behavior when absent); gesture state lives in effect-scoped closures.
- `PersonList.tsx`: drop the now-removed `handlers` spread; just attach `ref` and pass `onRefresh` through.

## Testing

- `yarn tsc --noEmit` — clean
- `yarn test` — 419 passed, 1 skipped (49 files)

Note: diagnosed by reading the code, not on a physical device — passive touch listeners are the textbook cause of this exact symptom and the applied fix is the standard remedy. Worth a real-device confirm on the mobile inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)