### PR TITLE
fix: align composed email font size with replies in chat feed

### DIFF
--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -79,6 +79,9 @@ export default function ReplyComposer({
   const [fromAddress, setFromAddress] = useState(recipients[0] ?? "");
   const [cc, setCc] = useState<CcEntry[]>([]);
   const [bodyHtml, setBodyHtml] = useState("");
+  // Plain-text mirror of the editor, kept in lockstep with bodyHtml so the
+  // reply ships a `text/plain` part and renders as a normal chat bubble.
+  const [bodyText, setBodyText] = useState("");
   // Stored separately from the body so swapping `From` mid-reply replaces
   // the trailing signature without touching what the user has typed.
   const [signatureHtml, setSignatureHtml] = useState<string | null>(null);
@@ -217,6 +220,7 @@ export default function ReplyComposer({
           : bodyHtml;
         await replyToEmail(emailId, {
           bodyHtml: finalBody,
+          ...(bodyText.trim() ? { bodyText } : {}),
           fromAddress,
           ...(ccPayload ? { cc: ccPayload } : {}),
           ...(files.length > 0
@@ -376,7 +380,10 @@ export default function ReplyComposer({
                   >
                     <TiptapEditor
                       content={bodyHtml}
-                      onUpdate={setBodyHtml}
+                      onUpdate={(html, text) => {
+                        setBodyHtml(html);
+                        setBodyText(text);
+                      }}
                       placeholder="Write your reply…"
                     />
                     <AttachmentChips

--- a/src/components/TiptapEditor.tsx
+++ b/src/components/TiptapEditor.tsx
@@ -6,7 +6,13 @@ import { useEffect, useRef, useState } from "react";
 
 interface TiptapEditorProps {
   content: string;
-  onUpdate: (html: string) => void;
+  /**
+   * Fires on every edit with both the serialized HTML and a plain-text
+   * rendering (blocks separated by newlines). The text feeds the outgoing
+   * `text/plain` MIME part so composed mail ships multipart — matching the
+   * reply composer's format.
+   */
+  onUpdate: (html: string, text: string) => void;
   placeholder?: string;
   className?: string;
   /** Override the default 2 MB per-image cap. */
@@ -103,7 +109,7 @@ export default function TiptapEditor({
       editorRef.current = editor as Editor;
     },
     onUpdate: ({ editor }) => {
-      onUpdate(editor.getHTML());
+      onUpdate(editor.getHTML(), editor.getText());
     },
     editorProps: {
       attributes: {

--- a/src/pages/ComposeModal.tsx
+++ b/src/pages/ComposeModal.tsx
@@ -66,6 +66,11 @@ export default function ComposeModal({
   >([]);
   const [subject, setSubject] = useState("");
   const [bodyHtml, setBodyHtml] = useState("");
+  // Plain-text rendering of the editor, kept in lockstep with bodyHtml so the
+  // outgoing mail ships a `text/plain` part — same shape the reply composers
+  // send. Also what the chat feed keys off to render a normal bubble rather
+  // than the HTML preview card.
+  const [bodyText, setBodyText] = useState("");
   // Tracked separately from the body so swapping `From` mid-compose can swap
   // the signature without stomping on what the user has typed.
   const [signatureHtml, setSignatureHtml] = useState<string | null>(null);
@@ -120,11 +125,13 @@ export default function ComposeModal({
       setCc(prefill?.cc ?? []);
       setSubject(prefill?.subject ?? "");
       setBodyHtml(prefill?.bodyHtml ?? "");
+      setBodyText("");
     } else {
       setTo("");
       setCc([]);
       setSubject("");
       setBodyHtml("");
+      setBodyText("");
       setSignatureHtml(null);
       setError("");
       setFullscreen(false);
@@ -166,6 +173,7 @@ export default function ComposeModal({
         ...(cc.length > 0 ? { cc } : {}),
         subject,
         bodyHtml: finalBody,
+        ...(bodyText.trim() ? { bodyText } : {}),
         ...(files.length > 0 ? { files: files.map((file) => ({ file })) } : {}),
       });
       dispatchEmailSent({ fromAddress, to, origin: "compose" });
@@ -296,7 +304,13 @@ export default function ComposeModal({
               buttonClassName="hidden"
               onFilesAdded={(added) => setFiles((prev) => [...prev, ...added])}
             >
-              <TiptapEditor content={bodyHtml} onUpdate={setBodyHtml} />
+              <TiptapEditor
+                content={bodyHtml}
+                onUpdate={(html, text) => {
+                  setBodyHtml(html);
+                  setBodyText(text);
+                }}
+              />
               <AttachmentChips
                 files={files}
                 capBytes={ATTACHMENT_CAP_BYTES}


### PR DESCRIPTION
## Problem

An email composed **from scratch** rendered at a different font size (12px) than a **reply** (14px) in saasmail's own chat feed.

## Root cause

In `ChatInboxSection`, each bubble renders one of two ways at different sizes:

- **HTML preview card** → `text-xs` (12px), white card
- **Plain-text bubble** → `text-sm` (14px), colored chat bubble

`shouldShowHtmlPreview()` returns `true` (→ card) whenever an email has **no `text/plain` part** — it assumes "HTML with no text part = HTML-only marketing mail." But the compose/reply *trays* sent HTML-only (no `bodyText`), so they hit the 12px card, while the inline chat reply (`ChatQuickReply`) sends `bodyText` too and got the 14px bubble.

## Fix

Align the trays to the reply's format — send a `text/plain` part alongside the HTML:

- **`TiptapEditor`** — `onUpdate` now surfaces the editor's plain text (`getText()`) alongside HTML. Backward-compatible for single-arg callers (`AdminInboxTable`).
- **`ComposeModal`** and **`ReplyComposer`** — track `bodyText` in lockstep with the body and send it (when non-empty).

Net effect: new emails and both reply paths now all send `bodyHtml` + `bodyText`, so they render at a consistent 14px in the feed. Also gives outgoing mail a proper `text/plain` part (small deliverability win). Image-only sends attach no text and correctly keep the preview card; received marketing mail is unaffected.

## Notes

- Already-sent from-scratch emails (with `bodyText: null`) still render as the 12px card since this only affects new sends — a render-side tweak or backfill would be needed to fix those retroactively.

## Testing

- `yarn tsc --noEmit` clean
- `yarn test` — 421 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)