### PR TITLE
fix: send manually composed emails as transactional

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -347,7 +347,10 @@ export async function sendEmail(data: {
 }): Promise<{ id: string; attachmentIds: string[]; status: string }> {
   const { files = [], ...payload } = data;
   const fd = new FormData();
-  fd.append("payload", JSON.stringify(payload));
+  // Manually composed emails are 1:1 transactional messages: no unsubscribe
+  // footer or List-Unsubscribe headers, and they bypass the suppression list
+  // (mirrors replies, which are always transactional).
+  fd.append("payload", JSON.stringify({ ...payload, transactional: true }));
   for (const af of files) fd.append("files", af.file, af.file.name);
   return apiFetch("/api/send", {
     method: "POST",


### PR DESCRIPTION
## Problem

Emails composed in the app's compose box are 1:1, human-written messages, but they were being sent as **marketing** email. The frontend `sendEmail()` posted to `/api/send` without a `transactional` flag, which defaults to `false`, so composed emails received:

- `List-Unsubscribe` and `List-Unsubscribe-Post` headers
- an auto-appended "Unsubscribe" footer in the HTML/text body

Replies (`POST /api/send/reply/{emailId}`) were already always transactional; only the compose path was affected.

## Fix

`sendEmail()` in `src/lib/api.ts` now opts into `transactional: true`. The backend `/api/send` route already accepts and honors this flag, so no backend change is needed. Transactional sends skip the unsubscribe headers/footer and bypass the suppression list — consistent with how replies already behave.

The `/api/send` HTTP API **default is unchanged** (`false`), so programmatic/marketing callers are unaffected. Sequence and template sends correctly remain marketing.

## Note

Composed emails now bypass the suppression list (the standard transactional semantic, matching replies). If someone previously unsubscribed, you can still send them a manually-composed 1:1 email.

## Verification

- `yarn tsc --noEmit` passes
- Existing `send-helper` tests already cover the transactional-vs-marketing branching in `send.ts`; no backend logic changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)