### PR TITLE
ci: add release-drafter and PR label check

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,63 @@
+autolabeler:
+  - label: "patch"
+    body:
+      - '/\[x] Patch/gm'
+  - label: "minor"
+    body:
+      - '/\[x] Minor/gm'
+  - label: "major"
+    body:
+      - '/\[x] Major/gm'
+  - label: "feature"
+    body:
+      - '/\[x] Feature/gm'
+  - label: "bug"
+    body:
+      - '/\[x] Bug Fix/gm'
+  - label: "refactor"
+    body:
+      - '/\[x] Refactor/gm'
+  - label: "documentation"
+    body:
+      - '/\[x] Documentation/gm'
+  - label: "chore"
+    body:
+      - '/\[x] Chore/gm'
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "fix"
+      - "bug"
+      - "bugfix"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "refactor"
+      - "documentation"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  Full Changelog: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,15 @@
+name: Check PR labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "major, minor, patch"
+          invalid-labels: "hold"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,3 +13,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: "major, minor, patch"
           invalid-labels: "hold"
+          disable-reviews: "true"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- **`.github/release-drafter.yml`** — release-drafter config: autolabeler, `version-resolver`, categories (Features / Bug Fixes / Maintenance), and release template. `name-template`/`tag-template` set to `v$RESOLVED_VERSION` to match the existing `v0.x.0` tag convention.
- **`.github/workflows/release-drafter.yml`** — runs `release-drafter@v6` on push/PR to `main`, keeping a rolling draft GitHub release up to date.
- **`.github/workflows/pr-labels.yml`** — requires each PR to carry a `major`/`minor`/`patch` label (blocks on `hold`).

Also created the repo labels the workflows depend on: `major`, `minor`, `patch`, `feature`, `refactor`, `chore` (`bug`, `documentation`, `enhancement` already existed).

## Notes for reviewers

- The PR template is intentionally left unchanged, so version labels are applied manually per PR; `version-resolver` computes the next version from them.
- No npm-publish workflow was ported (saasmail is not published as a package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)