### PR TITLE
docs: fix OpenAPI doc URLs and version in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).
+
 ### Added
 
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ function verify(rawBody, header, secret) {
 | **Receive email**   | Cloudflare Email Workers                                                  |
 | **Send email**      | Cloudflare Email Sending, Resend, Bavimail, or Postmark                   |
 | **Runtime**         | Cloudflare Workers + Hono                                                 |
-| **API**             | Zod + `@hono/zod-openapi` (OpenAPI 3.1)                                   |
+| **API**             | Zod + `@hono/zod-openapi` (OpenAPI 3.0)                                   |
 | **Database**        | Cloudflare D1 (SQLite)                                                    |
 | **File storage**    | Cloudflare R2 (attachments)                                               |
 | **Queue**           | Cloudflare Queues (sequence processing)                                   |
@@ -381,7 +381,7 @@ yarn db:studio:dev
 
 Since Cloudflare Email Routing can't deliver to `wrangler dev`, the seed script populates `seeds/demo.sql` so you can exercise the inbox UI without real inbound email.
 
-The API is generated from Zod schemas in `worker/src/routers/` and exposes an OpenAPI 3.1 spec at `/api/doc` in the running worker.
+The API is generated from Zod schemas in `worker/src/routers/`. Each running worker exposes an OpenAPI 3.0 spec at `/doc` (JSON) and an interactive explorer at `/swagger-ui`. Both are public — no auth required to read the spec.
 
 ### End-to-end tests
 


### PR DESCRIPTION
## Summary
- Correct the documented OpenAPI endpoint from `/api/doc` to `/doc` (JSON spec) and `/swagger-ui` (interactive explorer).
- Align the architecture table to OpenAPI 3.0, matching what `app.doc()` emits today.

## Test plan
- [x] `rg '/api/doc' README.md` — no stale references (only the changelog note describing the fix)
- [x] Verified live tenant serves spec at `/doc` and UI at `/swagger-ui`


Made with [Cursor](https://cursor.com)