### PR TITLE
feat(api): document auth model in OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OpenAPI `/doc`: global auth documentation, `BearerAuth` security scheme, and `security` requirements on integrator-facing routes (`/api/send`, template send, sequence enroll, API keys).
+
+### Fixed
+
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - OpenAPI `/doc`: global auth documentation, `BearerAuth` security scheme, and `security` requirements on integrator-facing routes (`/api/send`, template send, sequence enroll, API keys).
-
-### Fixed
-
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-doc.test.ts
+++ b/worker/src/__tests__/openapi-doc.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+import { BEARER_AUTH_SCHEME } from "../lib/openapi-auth";
+
+describe("OpenAPI /doc", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc is public and documents Bearer auth", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      info: { description?: string };
+      components: { securitySchemes?: Record<string, unknown> };
+      paths: Record<
+        string,
+        { post?: { security?: Array<Record<string, unknown>> } }
+      >;
+    };
+
+    expect(doc.info.description).toContain("Authorization: Bearer sk_");
+    expect(doc.info.description).toContain("PASSKEY_REQUIRED");
+    expect(doc.components.securitySchemes?.[BEARER_AUTH_SCHEME]).toMatchObject(
+      { type: "http", scheme: "bearer" },
+    );
+    expect(doc.paths["/api/send"]?.post?.security).toEqual([
+      { [BEARER_AUTH_SCHEME]: [] },
+    ]);
+  });
+});

--- a/worker/src/__tests__/openapi-doc.test.ts
+++ b/worker/src/__tests__/openapi-doc.test.ts
@@ -22,9 +22,10 @@ describe("OpenAPI /doc", () => {
 
     expect(doc.info.description).toContain("Authorization: Bearer sk_");
     expect(doc.info.description).toContain("PASSKEY_REQUIRED");
-    expect(doc.components.securitySchemes?.[BEARER_AUTH_SCHEME]).toMatchObject(
-      { type: "http", scheme: "bearer" },
-    );
+    expect(doc.components.securitySchemes?.[BEARER_AUTH_SCHEME]).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+    });
     expect(doc.paths["/api/send"]?.post?.security).toEqual([
       { [BEARER_AUTH_SCHEME]: [] },
     ]);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -40,11 +40,22 @@ import { requirePasskey } from "./middleware/require-passkey";
 import { passkeys } from "./db/auth.schema";
 import { appSettings } from "./db/app-settings.schema";
 import { isDevEnvironment } from "./lib/is-dev";
+import {
+  BEARER_AUTH_SCHEME,
+  bearerAuthSecurityScheme,
+  openapiInfoDescription,
+} from "./lib/openapi-auth";
 
 const app = new OpenAPIHono<{
   Bindings: CloudflareBindings;
   Variables: Variables;
 }>();
+
+app.openAPIRegistry.registerComponent(
+  "securitySchemes",
+  BEARER_AUTH_SCHEME,
+  bearerAuthSecurityScheme,
+);
 
 // Middleware
 app.use("*", injectDb);
@@ -261,7 +272,11 @@ app.get("/api/config", async (c) => {
 app.get("/swagger-ui", swaggerUI({ url: "/doc" }));
 app.doc("/doc", {
   openapi: "3.0.0",
-  info: { title: "saasmail API", version: "1.0.0" },
+  info: {
+    title: "saasmail API",
+    version: "1.0.0",
+    description: openapiInfoDescription,
+  },
 });
 
 // SPA fallback

--- a/worker/src/lib/openapi-auth.ts
+++ b/worker/src/lib/openapi-auth.ts
@@ -1,0 +1,48 @@
+/** Shared OpenAPI auth documentation for `/doc` and route-level `security`. */
+
+export const BEARER_AUTH_SCHEME = "BearerAuth";
+
+export const openapiInfoDescription = `Self-hosted email API for a single saasmail Worker deployment.
+
+## Authentication
+
+Most routes require authentication via one of:
+
+- **API key (recommended for integrations):** \`Authorization: Bearer sk_…\`
+  Keys are issued per user at \`POST /api/api-keys\` (shown once at creation).
+- **Session cookie:** BetterAuth session from the web UI (used by the SPA).
+
+Unauthenticated requests to protected routes receive \`401 Unauthorized\`.
+
+## Passkey gate
+
+In non-development deployments, **session-cookie** users must register a passkey
+before accessing data routes. Until then, responses are \`403\` with
+\`{ "error": "Passkey registration required", "code": "PASSKEY_REQUIRED" }\`.
+API-key requests bypass this gate.
+
+## Inbox scoping
+
+Users with the \`member\` role only see data and may only send from inboxes
+assigned to them. \`admin\` users have full access. Sending from or accessing
+an unassigned inbox returns \`403\`.
+
+## Public routes (no auth)
+
+\`/api/setup/*\`, \`/api/invites/*\`, \`/api/unsubscribe/*\`, \`/unsubscribe/*\`,
+\`/api/health\`, \`/api/config\`, and \`/doc\` / \`/swagger-ui\`.
+
+## Admin-only routes
+
+\`/api/admin/*\`, \`/api/suppressions/*\`, and \`/api/webhook/*\` require the
+\`admin\` role in addition to authentication.`;
+
+export const bearerAuthSecurityScheme = {
+  type: "http" as const,
+  scheme: "bearer",
+  description:
+    "Per-user API key. Format: `sk_…`. Create or rotate at POST /api/api-keys.",
+};
+
+/** Apply to integrator-facing routes in route definitions. */
+export const bearerSecurity = [{ [BEARER_AUTH_SCHEME]: [] }];

--- a/worker/src/routers/api-keys-router.ts
+++ b/worker/src/routers/api-keys-router.ts
@@ -7,6 +7,7 @@ import { json200Response, json201Response } from "../lib/helpers";
 import { hashKey } from "../lib/crypto";
 import { isDevEnvironment } from "../lib/is-dev";
 import type { Variables } from "../variables";
+import { bearerSecurity } from "../lib/openapi-auth";
 
 export const apiKeysRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -27,6 +28,7 @@ const getKeyRoute = createRoute({
   method: "get",
   path: "/",
   tags: ["API Keys"],
+  security: bearerSecurity,
   description:
     "Get the current user's API key info (prefix and creation date), or null if none exists.",
   responses: {
@@ -60,6 +62,7 @@ const createKeyRoute = createRoute({
   method: "post",
   path: "/",
   tags: ["API Keys"],
+  security: bearerSecurity,
   description: "Generate a new API key. If one already exists, it is replaced.",
   responses: {
     ...json201Response(
@@ -122,6 +125,7 @@ const deleteKeyRoute = createRoute({
   method: "delete",
   path: "/",
   tags: ["API Keys"],
+  security: bearerSecurity,
   description: "Revoke the current user's API key.",
   responses: {
     ...json200Response(z.object({ success: z.boolean() }), "Key revoked"),

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -12,6 +12,7 @@ import { sendViaOutbox } from "../lib/outbox";
 import { generateMessageId } from "../lib/message-id";
 import { formatFromAddress } from "../lib/format-from-address";
 import type { Variables } from "../variables";
+import { bearerSecurity } from "../lib/openapi-auth";
 
 export const emailTemplatesRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -287,6 +288,7 @@ const sendTemplateRoute = createRoute({
   method: "post",
   path: "/{slug}/send",
   tags: ["Email Templates"],
+  security: bearerSecurity,
   description: "Send an email using a template.",
   request: {
     params: z.object({ slug: z.string() }),

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -18,6 +18,7 @@ import { computeConversationId, externalsOnly } from "../lib/conversation-id";
 import { parseSendBody, sendParseErrorResponse } from "../lib/multipart-send";
 import { attachments } from "../db/attachments.schema";
 import { sendViaOutbox } from "../lib/outbox";
+import { bearerSecurity } from "../lib/openapi-auth";
 
 /**
  * Fetch the set of "internal" domains (domains owned by our
@@ -141,6 +142,7 @@ const sendEmailRoute = createRoute({
   method: "post",
   path: "/",
   tags: ["Send"],
+  security: bearerSecurity,
   description:
     "Compose and send a new email. The request body is multipart/form-data with a JSON `payload` field containing a SendEmailSchema object, and zero or more `files` fields for attachments.",
   request: {
@@ -364,6 +366,7 @@ const replyEmailRoute = createRoute({
   method: "post",
   path: "/reply/{emailId}",
   tags: ["Send"],
+  security: bearerSecurity,
   description:
     "Reply to a received email. multipart/form-data body with 'payload' JSON and optional 'files'.",
   request: {

--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -11,6 +11,7 @@ import { json200Response, json201Response } from "../lib/helpers";
 import type { SequenceEmailMessage } from "../lib/sequence-processor";
 import type { Variables } from "../variables";
 import { isDemoMode } from "../lib/is-dev";
+import { bearerSecurity } from "../lib/openapi-auth";
 
 export const sequencesRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -304,6 +305,7 @@ const enrollRoute = createRoute({
   method: "post",
   path: "/{id}/enroll",
   tags: ["Sequences"],
+  security: bearerSecurity,
   description:
     "Enroll a person into a sequence. Computes all scheduled send times upfront.",
   request: {


### PR DESCRIPTION
## Summary
- Add global auth documentation to the OpenAPI `info.description` (Bearer `sk_…` keys, session cookies, passkey gate, inbox scoping, public routes, admin-only routes).
- Register `BearerAuth` via `openAPIRegistry.registerComponent` (components in `app.doc()` alone are not merged into the generated spec).
- Mark `security: [{ BearerAuth: [] }]` on integrator-facing routes: `/api/send`, `/api/send/reply/{emailId}`, template send, sequence enroll, and all API key routes.

## Test plan
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-doc.test.ts`
- [ ] `curl -s '$URL/doc?cb=1' | jq '.info.description, .components.securitySchemes.BearerAuth, .paths["/api/send"].post.security'`


Made with [Cursor](https://cursor.com)