### PR TITLE
feat(api): register send payload schemas in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OpenAPI `/doc`: register `SendEmailSchema`, `CcEntry`, and `ReplyEmailSchema` under `components.schemas` (including `transactional` and reply payload fields).
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-send-schemas.test.ts
+++ b/worker/src/__tests__/openapi-send-schemas.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+describe("OpenAPI send schemas", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc registers SendEmailSchema, CcEntry, and ReplyEmailSchema", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      components: {
+        schemas?: Record<
+          string,
+          { properties?: Record<string, unknown>; type?: string }
+        >;
+      };
+    };
+
+    const schemas = doc.components.schemas ?? {};
+    expect(Object.keys(schemas).sort()).toEqual(
+      ["CcEntry", "ReplyEmailSchema", "SendEmailSchema"].sort(),
+    );
+
+    const send = schemas.SendEmailSchema;
+    expect(send?.properties).toMatchObject({
+      to: expect.any(Object),
+      fromAddress: expect.any(Object),
+      subject: expect.any(Object),
+      bodyHtml: expect.any(Object),
+      transactional: expect.any(Object),
+    });
+
+    const reply = schemas.ReplyEmailSchema;
+    expect(reply?.properties).toMatchObject({
+      fromAddress: expect.any(Object),
+      bodyHtml: expect.any(Object),
+      templateSlug: expect.any(Object),
+    });
+
+    const cc = schemas.CcEntry;
+    expect(cc?.properties).toMatchObject({
+      email: expect.any(Object),
+    });
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,7 +12,12 @@ import { handleEmail } from "./email-handler";
 import { peopleRouter } from "./routers/people-router";
 import { emailsRouter } from "./routers/emails-router";
 import { conversationsRouter } from "./routers/conversations-router";
-import { sendRouter } from "./routers/send-router";
+import {
+  sendRouter,
+  CcEntrySchema,
+  ReplyEmailSchema,
+  SendEmailSchema,
+} from "./routers/send-router";
 import { attachmentsRouter } from "./routers/attachments-router";
 import { statsRouter } from "./routers/stats-router";
 import { setupRouter } from "./routers/setup-router";
@@ -45,6 +50,10 @@ const app = new OpenAPIHono<{
   Bindings: CloudflareBindings;
   Variables: Variables;
 }>();
+
+app.openAPIRegistry.register("CcEntry", CcEntrySchema);
+app.openAPIRegistry.register("SendEmailSchema", SendEmailSchema);
+app.openAPIRegistry.register("ReplyEmailSchema", ReplyEmailSchema);
 
 // Middleware
 app.use("*", injectDb);

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -52,7 +52,7 @@ export const sendRouter = new OpenAPIHono<{
   Variables: Variables;
 }>();
 
-const CcEntrySchema = z
+export const CcEntrySchema = z
   .object({
     email: z.string().email().openapi({ example: "cc@example.com" }),
     // Constrain the rendered "Name <addr>" header — long display names
@@ -76,7 +76,7 @@ function formatCc(c: CcEntry): string {
   return c.name ? `${c.name} <${c.email}>` : c.email;
 }
 
-const SendEmailSchema = z
+export const SendEmailSchema = z
   .object({
     to: z.string().email().openapi({
       description: "Recipient email address.",
@@ -158,6 +158,7 @@ const sendEmailRoute = createRoute({
                   subject: "Welcome to our service",
                   bodyHtml: "<p>Hello!</p>",
                   bodyText: "Hello!",
+                  transactional: false,
                 },
                 null,
                 2,
@@ -349,15 +350,40 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
   );
 });
 
-const ReplyEmailSchema = z.object({
-  bodyHtml: z.string().optional(),
-  bodyText: z.string().optional(),
-  fromAddress: z.string().email(),
-  cc: z.array(CcEntrySchema).max(MAX_CC_ENTRIES).optional(),
-  templateSlug: z.string().optional(),
-  variables: z.record(z.string(), z.string()).optional(),
-  replyTo: z.string().email().optional(),
-});
+export const ReplyEmailSchema = z
+  .object({
+    fromAddress: z.string().email().openapi({
+      description:
+        "Sending identity for the reply. Must be one of your configured inboxes.",
+      example: "support@yourdomain.com",
+    }),
+    bodyHtml: z.string().optional().openapi({
+      description:
+        "HTML reply body. Provide bodyHtml and/or bodyText unless templateSlug is set.",
+    }),
+    bodyText: z.string().optional().openapi({
+      description: "Plain-text reply body.",
+    }),
+    cc: z
+      .array(CcEntrySchema)
+      .max(MAX_CC_ENTRIES)
+      .optional()
+      .openapi({
+        description: `CC recipients. Maximum ${MAX_CC_ENTRIES} entries.`,
+      }),
+    templateSlug: z.string().optional().openapi({
+      description:
+        "Optional template slug to render as the reply body instead of bodyHtml/bodyText.",
+    }),
+    variables: z.record(z.string(), z.string()).optional().openapi({
+      description: "Template variables when templateSlug is set.",
+    }),
+    replyTo: z.string().email().optional().openapi({
+      description: "Override Reply-To header for this reply.",
+      example: "submitter@example.com",
+    }),
+  })
+  .openapi("ReplyEmailSchema");
 
 // Reply to an existing email
 const replyEmailRoute = createRoute({
@@ -372,7 +398,19 @@ const replyEmailRoute = createRoute({
       content: {
         "multipart/form-data": {
           schema: z.object({
-            payload: z.string().describe("JSON-encoded reply body"),
+            payload: z.string().openapi({
+              description:
+                "JSON-encoded ReplyEmailSchema. Required: `fromAddress`. Provide bodyHtml/bodyText or templateSlug. See the ReplyEmailSchema component for the full field reference.",
+              example: JSON.stringify(
+                {
+                  fromAddress: "support@yourdomain.com",
+                  bodyHtml: "<p>Thanks for reaching out — we're on it.</p>",
+                  bodyText: "Thanks for reaching out — we're on it.",
+                },
+                null,
+                2,
+              ),
+            }),
             files: z.union([z.array(z.any()), z.any()]).optional(),
           }),
         },


### PR DESCRIPTION
## Summary
- Register `SendEmailSchema`, `CcEntry`, and `ReplyEmailSchema` under `components.schemas` via `openAPIRegistry.register` (the batch `registerComponent('schemas', {...})` form does not register Zod schemas).
- Document `ReplyEmailSchema` fields on the reply route payload description with an example.
- Include `transactional` in the send payload example; field was already in the Zod schema but absent from `/doc`.

## Test plan
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-send-schemas.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/send-router.test.ts`
- [x] `npx prettier --check` on changed files
- [ ] `curl -s '$URL/doc?cb=1' | jq '.components.schemas | keys'`


Made with [Cursor](https://cursor.com)