### PR TITLE
feat(api): document attachments on EmailSchema responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OpenAPI email responses: document `attachments` on `EmailSchema`, clarify `replyTo` is only populated on `GET /api/emails/{id}` for received messages.
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-email-schemas.test.ts
+++ b/worker/src/__tests__/openapi-email-schemas.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+function emailItemSchema(doc: {
+  paths: Record<
+    string,
+    {
+      get?: {
+        responses?: Record<
+          string,
+          { content?: { "application/json"?: { schema?: unknown } } }
+        >;
+      };
+    }
+  >;
+}) {
+  const byPerson =
+    doc.paths["/api/emails/by-person/{personId}"]?.get?.responses?.["200"]
+      ?.content?.["application/json"]?.schema;
+  const byPersonProps = (
+    byPerson as { properties?: { emails?: { items?: unknown } } }
+  )?.properties?.emails?.items;
+  return byPersonProps as { properties?: Record<string, unknown> } | undefined;
+}
+
+describe("OpenAPI EmailSchema", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc documents attachments on email responses", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = await res.json();
+
+    const emailItem = emailItemSchema(doc);
+    expect(emailItem?.properties).toMatchObject({
+      attachments: expect.any(Object),
+      attachmentCount: expect.any(Object),
+      replyTo: expect.any(Object),
+    });
+
+    const attachments = emailItem?.properties?.attachments as {
+      type?: string;
+      items?: { properties?: Record<string, unknown> };
+    };
+    expect(attachments?.type).toBe("array");
+    expect(attachments?.items?.properties).toMatchObject({
+      id: expect.any(Object),
+      filename: expect.any(Object),
+      contentType: expect.any(Object),
+      size: expect.any(Object),
+    });
+
+    const replyTo = emailItem?.properties?.replyTo as { description?: string };
+    expect(replyTo?.description).toContain("GET /api/emails/{id}");
+  });
+});

--- a/worker/src/routers/conversations-router.ts
+++ b/worker/src/routers/conversations-router.ts
@@ -34,7 +34,7 @@ const listConversationEmailsRoute = createRoute({
   path: "/{id}/emails",
   tags: ["Conversations"],
   description:
-    "List all emails in a group conversation, oldest first, with participants metadata.",
+    "List all emails in a group conversation, oldest first, with participants metadata. Each email includes attachment metadata when present.",
   request: {
     params: z.object({ id: z.string() }),
   },

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -21,6 +21,25 @@ export const CcEntrySchema = z.object({
   name: z.string().nullable().optional(),
 });
 
+/** Attachment row returned on email list/detail/conversation endpoints. */
+export const AttachmentSchema = z.object({
+  id: z.string(),
+  emailId: z.string(),
+  kind: z.string().openapi({
+    description:
+      '"inbound" for received email attachments, "sent" for outbound.',
+  }),
+  filename: z.string(),
+  contentType: z.string(),
+  size: z.number().openapi({ description: "Size in bytes." }),
+  r2Key: z.string().openapi({
+    description:
+      "Internal R2 object key. Download via GET /api/attachments/{id}.",
+  }),
+  contentId: z.string().nullable(),
+  createdAt: z.number(),
+});
+
 /** Parse a stored cc TEXT column (JSON) into a typed array, falling back to
  *  [] for NULL or any malformed/corrupt JSON so a bad row never breaks reads. */
 export function parseCc(
@@ -58,7 +77,14 @@ export const EmailSchema = z.object({
         "provider failure, will be retried), or 'failed' (the provider " +
         "rejected it). Null for received messages.",
     }),
-  attachmentCount: z.number().optional(),
+  attachmentCount: z.number().optional().openapi({
+    description:
+      "Number of attachments on this message. Set on list endpoints; may be omitted on GET /api/emails/{id}.",
+  }),
+  attachments: z.array(AttachmentSchema).optional().openapi({
+    description:
+      "Attachment metadata. Included on GET /api/emails/by-person/{personId}, GET /api/emails/{id}, and GET /api/conversations/{id}/emails. Download bytes via GET /api/attachments/{id}.",
+  }),
   replyTo: z
     .string()
     .nullable()
@@ -66,9 +92,9 @@ export const EmailSchema = z.object({
     .openapi({
       description:
         "Address from the inbound Reply-To header, when present (e.g. a " +
-        "contact form's actual submitter behind a noreply@ sender). Parsed " +
-        "from stored raw headers and returned by the single-email endpoint; " +
-        "null when there is no Reply-To.",
+        "contact form's actual submitter behind a noreply@ sender). Populated " +
+        "only on GET /api/emails/{id} for received messages; omitted or null " +
+        "on list/conversation endpoints and on sent messages.",
     }),
 });
 
@@ -112,7 +138,7 @@ const listPersonEmailsRoute = createRoute({
   path: "/by-person/{personId}",
   tags: ["Emails"],
   description:
-    "List all emails for a person (received and sent, interleaved chronologically).",
+    "List all emails for a person (received and sent, interleaved chronologically). Each email includes attachment metadata when present.",
   request: {
     params: z.object({ personId: z.string() }),
     query: z.object({
@@ -360,7 +386,8 @@ const getEmailRoute = createRoute({
   method: "get",
   path: "/{id}",
   tags: ["Emails"],
-  description: "Get a single email with full details.",
+  description:
+    "Get a single email with full details, including attachments. replyTo is set for received messages when a Reply-To header was present.",
   request: {
     params: z.object({ id: z.string() }),
   },


### PR DESCRIPTION
## Summary
- Add `AttachmentSchema` and optional `attachments` array to `EmailSchema` so `/doc` matches runtime responses on by-person, single-email, and conversation endpoints.
- Clarify `replyTo` is only populated on `GET /api/emails/{id}` for received messages (not on list/conversation endpoints).
- Document `attachmentCount` scope on list vs detail endpoints.

## Test plan
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-email-schemas.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/emails-router.test.ts`
- [x] Prettier check on changed files


Made with [Cursor](https://cursor.com)