### PR TITLE
feat(api): document sequence enrollment schema and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OpenAPI sequences: `fromAddress` and typed `variables` on `EnrollmentSchema`; document enroll and delete error responses (400/404).
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-sequence-enrollment.test.ts
+++ b/worker/src/__tests__/openapi-sequence-enrollment.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+describe("OpenAPI sequence enrollment", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc documents EnrollmentSchema and enroll errors", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      paths: Record<
+        string,
+        {
+          post?: { responses?: Record<string, { description?: string }> };
+          delete?: { responses?: Record<string, { description?: string }> };
+        }
+      >;
+      components?: {
+        schemas?: Record<string, { properties?: Record<string, unknown> }>;
+      };
+    };
+
+    const enroll = doc.paths["/api/sequences/{id}/enroll"]?.post?.responses;
+    expect(enroll?.["201"]).toBeDefined();
+    expect(enroll?.["400"]?.description).toContain("active sequence");
+    expect(enroll?.["404"]?.description).toContain("not found");
+
+    const del = doc.paths["/api/sequences/{id}"]?.delete?.responses;
+    expect(del?.["400"]?.description).toContain("active enrollments");
+
+    const enrollBody =
+      doc.paths["/api/sequences/{id}/enroll"]?.post?.responses?.["201"]
+        ?.content?.["application/json"]?.schema;
+    const enrollment = (
+      enrollBody as {
+        properties?: {
+          enrollment?: { properties?: Record<string, unknown> };
+        };
+      }
+    )?.properties?.enrollment?.properties;
+    expect(enrollment).toMatchObject({
+      fromAddress: expect.any(Object),
+      variables: expect.any(Object),
+    });
+  });
+});

--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -19,6 +19,8 @@ export const sequencesRouter = new OpenAPIHono<{
 
 // --- Zod Schemas ---
 
+const ErrorSchema = z.object({ error: z.string() });
+
 const SequenceStepSchema = z.object({
   order: z.number().int().min(1),
   templateSlug: z.string(),
@@ -58,8 +60,14 @@ const EnrollmentSchema = z.object({
   id: z.string(),
   sequenceId: z.string(),
   personId: z.string(),
+  fromAddress: z.string().email().openapi({
+    description: "Sender identity used for all steps in this enrollment.",
+  }),
   status: z.string(),
-  variables: z.any(),
+  variables: z.record(z.string(), z.string()).openapi({
+    description:
+      "Template variables for this enrollment. API responses return a parsed object (stored as JSON in the database).",
+  }),
   enrolledAt: z.number(),
   cancelledAt: z.number().nullable(),
 });
@@ -269,6 +277,10 @@ const deleteRoute = createRoute({
   },
   responses: {
     ...json200Response(z.object({ success: z.boolean() }), "Sequence deleted"),
+    400: {
+      description: "Sequence has active enrollments",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 
@@ -322,6 +334,15 @@ const enrollRoute = createRoute({
       }),
       "Person enrolled",
     ),
+    400: {
+      description:
+        "Person already in an active sequence, or all steps were skipped",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Sequence or person not found",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Add `fromAddress` and typed `variables` (`Record<string, string>`) to `EnrollmentSchema` so `/doc` matches enroll, get-enrollment, and list-enrollments responses.
- Document enroll error responses: `400` (active sequence conflict, all steps skipped), `404` (sequence/person not found).
- Document delete sequence `400` when active enrollments exist.

## Test plan
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-sequence-enrollment.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/sequences-router.test.ts`
- [x] Prettier on changed files


Made with [Cursor](https://cursor.com)