### PR TITLE
fix: clear stale Reply-To when reassigning a message to a new person

### DIFF
--- a/src/components/ReassignPersonModal.tsx
+++ b/src/components/ReassignPersonModal.tsx
@@ -29,9 +29,10 @@ export default function ReassignPersonModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // On open, prefill the address from the message's inbound Reply-To when
-  // present. The thread list doesn't carry replyTo, so fetch the single
-  // email (which surfaces it) unless the object already has it.
+  // On open, prefill the correspondent address. Prefer inbound Reply-To
+  // (contact-form pattern) when it differs from the attributed sender;
+  // otherwise fall back to fromAddress. The thread list doesn't carry
+  // replyTo, so fetch the single email when needed.
   useEffect(() => {
     if (!open || !email) return;
     setName("");
@@ -44,15 +45,23 @@ export default function ReassignPersonModal({
       setPrefilledFromReplyTo(true);
       return;
     }
+    if (email.fromAddress) {
+      setToEmail(email.fromAddress);
+      return;
+    }
     let cancelled = false;
     fetchEmail(email.id)
       .then((full) => {
-        if (cancelled || !full.replyTo) return;
-        setToEmail(full.replyTo);
-        setPrefilledFromReplyTo(true);
+        if (cancelled) return;
+        if (full.replyTo) {
+          setToEmail(full.replyTo);
+          setPrefilledFromReplyTo(true);
+          return;
+        }
+        if (full.fromAddress) setToEmail(full.fromAddress);
       })
       .catch(() => {
-        /* no Reply-To to prefill — leave blank */
+        /* no address to prefill — leave blank */
       });
     return () => {
       cancelled = true;

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -281,6 +281,22 @@ describe("emails router", () => {
       expect(data.replyTo).toBeNull();
     });
 
+    it("returns replyTo null when Reply-To matches the attributed sender", async () => {
+      await createTestPerson({ id: "s1", email: "alice@example.com" });
+      await createTestEmail({
+        id: "e-same-rt",
+        personId: "s1",
+        rawHeaders: JSON.stringify({
+          "reply-to": "Alice <alice@example.com>",
+        }),
+      });
+
+      const res = await authFetch("/api/emails/e-same-rt", { apiKey });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.replyTo).toBeNull();
+    });
+
     it("returns 404 for missing email", async () => {
       const res = await authFetch("/api/emails/nonexistent", { apiKey });
       expect(res.status).toBe(404);

--- a/worker/src/__tests__/reassign-person.test.ts
+++ b/worker/src/__tests__/reassign-person.test.ts
@@ -310,6 +310,35 @@ describe("reassign email to person", () => {
     const res = await reassign("nope", apiKey, { email: "real@example.com" });
     expect(res.status).toBe(404);
   });
+
+  it("clears a stale inbound Reply-To when re-attributing to a different person", async () => {
+    await createTestPerson({ id: "p-old", email: "forms@site.test" });
+    await createTestEmail({
+      id: "e1",
+      personId: "p-old",
+      rawHeaders: JSON.stringify({
+        "reply-to": "Submitter <submitter@example.com>",
+      }),
+    });
+
+    const res = await reassign("e1", apiKey, { email: "charlie@example.com" });
+    expect(res.status).toBe(200);
+
+    const db = getDb();
+    const email = await db
+      .select()
+      .from(emails)
+      .where(eq(emails.id, "e1"))
+      .get();
+    const headers = JSON.parse(email?.rawHeaders ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(headers["reply-to"]).toBeUndefined();
+    expect(
+      Object.keys(headers).some((k) => k.toLowerCase() === "reply-to"),
+    ).toBe(false);
+  });
 });
 
 async function createSent(opts: {

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -95,6 +95,43 @@ function extractReplyTo(rawHeaders: string | null): string | null {
   return null;
 }
 
+/**
+ * Strip Reply-To from stored raw headers after re-attribution. Once a message
+ * is attributed to a person, `people.email` is the canonical reply target —
+ * leaving the original inbound Reply-To in place would mislead the reassign
+ * UI and any code that surfaces `replyTo` alongside the new person.
+ */
+function clearReplyToInRawHeaders(rawHeaders: string | null): string | null {
+  if (!rawHeaders) return rawHeaders;
+  try {
+    const headers = JSON.parse(rawHeaders) as Record<string, unknown>;
+    const next: Record<string, unknown> = {};
+    let changed = false;
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === "reply-to") {
+        changed = true;
+        continue;
+      }
+      next[key] = value;
+    }
+    return changed ? JSON.stringify(next) : rawHeaders;
+  } catch {
+    return rawHeaders;
+  }
+}
+
+/** Reply-To is only meaningful when it differs from the attributed sender. */
+function surfaceReplyTo(
+  rawHeaders: string | null,
+  personEmail: string | null,
+): string | null {
+  const replyTo = extractReplyTo(rawHeaders);
+  if (!replyTo) return null;
+  const person = personEmail?.trim().toLowerCase();
+  if (person && replyTo === person) return null;
+  return replyTo;
+}
+
 const InboxMetaSchema = z.object({
   email: z.string(),
   displayName: z.string().nullable(),
@@ -397,7 +434,7 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
         timestamp: row[0].receivedAt,
         fromAddress: senderRow[0]?.email ?? null,
         toAddress: null,
-        replyTo: extractReplyTo(row[0].rawHeaders),
+        replyTo: surfaceReplyTo(row[0].rawHeaders, senderRow[0]?.email ?? null),
         cc: parseCc(row[0].cc),
         attachments: atts,
       },
@@ -790,6 +827,7 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
       id: emails.id,
       personId: emails.personId,
       recipient: emails.recipient,
+      rawHeaders: emails.rawHeaders,
     })
     .from(emails)
     .where(eq(emails.id, id))
@@ -808,9 +846,13 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
     const person = await resolvePerson();
     if (person.id !== target.personId) {
       // conversation_id is orthogonal and intentionally left unchanged.
+      const rawHeaders = clearReplyToInRawHeaders(target.rawHeaders);
       await db
         .update(emails)
-        .set({ personId: person.id })
+        .set({
+          personId: person.id,
+          ...(rawHeaders !== target.rawHeaders ? { rawHeaders } : {}),
+        })
         .where(eq(emails.id, target.id));
       await recompute(target.personId);
       await recompute(person.id);


### PR DESCRIPTION
## Summary
- Strip the inbound `Reply-To` from `raw_headers` when a received message is re-attributed to a different person, so `people.email` stays the canonical reply target
- Return `replyTo: null` from the single-email endpoint when the stored `Reply-To` matches the attributed sender (covers messages reassigned before this fix)
- Improve the reassign modal prefill to fall back to `fromAddress` when there is no distinct `Reply-To`

## Test plan
- [x] `npm test -- --run reassign-person.test.ts emails-router.test.ts`
- [ ] Reassign a contact-form message (with `Reply-To`) to a different person; confirm the modal no longer pre-fills the old address
- [ ] Reply after reassignment still routes to the new person's email

Made with [Cursor](https://cursor.com)