### PR TITLE
feat(api): document send path error responses in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI `/doc`: register `SendEmailSchema`, `CcEntry`, and `ReplyEmailSchema` under `components.schemas` (including `transactional` and reply payload fields).
 - OpenAPI `/doc`: global auth documentation, `BearerAuth` security scheme, and `security` requirements on integrator-facing routes (`/api/send`, template send, sequence enroll, API keys).
 - OpenAPI sequences: `fromAddress` and typed `variables` on `EnrollmentSchema`; document enroll and delete error responses (400/404).
+- OpenAPI send paths: document multipart parse errors (400/413), inbox permission 403, and reply/template-not-found 404 on `/api/send`, `/api/send/reply/{emailId}`, and `/api/email-templates/{slug}/send`.
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-send-errors.test.ts
+++ b/worker/src/__tests__/openapi-send-errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+describe("OpenAPI send path errors", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc documents send, reply, and template-send error responses", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      paths: Record<
+        string,
+        { post?: { responses?: Record<string, { description?: string }> } }
+      >;
+    };
+
+    const send = doc.paths["/api/send"]?.post?.responses;
+    expect(send?.["201"]).toBeDefined();
+    expect(send?.["400"]?.description).toMatch(/payload/i);
+    expect(send?.["403"]?.description).toMatch(/inbox/i);
+    expect(send?.["413"]?.description).toMatch(/attachment/i);
+
+    const reply = doc.paths["/api/send/reply/{emailId}"]?.post?.responses;
+    expect(reply?.["201"]).toBeDefined();
+    expect(reply?.["400"]).toBeDefined();
+    expect(reply?.["403"]).toBeDefined();
+    expect(reply?.["404"]?.description).toMatch(/not found/i);
+    expect(reply?.["413"]).toBeDefined();
+
+    const templateSend =
+      doc.paths["/api/email-templates/{slug}/send"]?.post?.responses;
+    expect(templateSend?.["201"]).toBeDefined();
+    expect(templateSend?.["400"]?.description).toMatch(/variables/i);
+    expect(templateSend?.["403"]).toBeDefined();
+    expect(templateSend?.["404"]?.description).toMatch(/not found/i);
+  });
+});

--- a/worker/src/lib/openapi-send-errors.ts
+++ b/worker/src/lib/openapi-send-errors.ts
@@ -1,0 +1,66 @@
+import { z } from "@hono/zod-openapi";
+
+export const ErrorSchema = z.object({
+  error: z.string(),
+});
+
+/**
+ * JSON error bodies on multipart send paths (parseSendBody / sendParseErrorResponse)
+ * and reply/template validation failures that share the same `{ error }` shape.
+ */
+export const SendPathErrorSchema = z.object({
+  error: z.string(),
+  detail: z.string().optional(),
+  limit: z.number().int().optional(),
+  provided: z.number().int().optional(),
+  limitBytes: z.number().int().optional(),
+  providedBytes: z.number().int().optional(),
+  missingVariables: z.array(z.string()).optional(),
+  requiredVariables: z.array(z.string()).optional(),
+});
+
+export const multipartParseErrorResponses = {
+  400: {
+    description:
+      "Missing or invalid `payload` JSON, or too many attachment files (max 50).",
+    content: {
+      "application/json": { schema: SendPathErrorSchema },
+    },
+  },
+  413: {
+    description: "Total attachment size exceeds the provider limit.",
+    content: {
+      "application/json": { schema: SendPathErrorSchema },
+    },
+  },
+};
+
+export const inboxForbiddenResponse = {
+  403: {
+    description:
+      "fromAddress is not an inbox this API key is permitted to send from.",
+    content: {
+      "application/json": { schema: ErrorSchema },
+    },
+  },
+};
+
+export const replyValidationErrorResponse = {
+  400: {
+    description:
+      "Multipart parse failure, missing bodyHtml/templateSlug, or missing required template variables.",
+    content: {
+      "application/json": { schema: SendPathErrorSchema },
+    },
+  },
+};
+
+export const replyNotFoundResponse = {
+  404: {
+    description:
+      "Original email or person not found, sent email has no associated person, or template slug not found.",
+    content: {
+      "application/json": { schema: ErrorSchema },
+    },
+  },
+};

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -13,6 +13,10 @@ import { generateMessageId } from "../lib/message-id";
 import { formatFromAddress } from "../lib/format-from-address";
 import type { Variables } from "../variables";
 import { bearerSecurity } from "../lib/openapi-auth";
+import {
+  ErrorSchema,
+  inboxForbiddenResponse,
+} from "../lib/openapi-send-errors";
 
 export const emailTemplatesRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -329,6 +333,11 @@ const sendTemplateRoute = createRoute({
           }),
         },
       },
+    },
+    ...inboxForbiddenResponse,
+    404: {
+      description: "Template slug not found",
+      content: { "application/json": { schema: ErrorSchema } },
     },
   },
 });

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -19,6 +19,12 @@ import { parseSendBody, sendParseErrorResponse } from "../lib/multipart-send";
 import { attachments } from "../db/attachments.schema";
 import { sendViaOutbox } from "../lib/outbox";
 import { bearerSecurity } from "../lib/openapi-auth";
+import {
+  inboxForbiddenResponse,
+  multipartParseErrorResponses,
+  replyNotFoundResponse,
+  replyValidationErrorResponse,
+} from "../lib/openapi-send-errors";
 
 /**
  * Fetch the set of "internal" domains (domains owned by our
@@ -177,6 +183,8 @@ const sendEmailRoute = createRoute({
   },
   responses: {
     ...json201Response(SentEmailResponseSchema, "Email sent"),
+    ...multipartParseErrorResponses,
+    ...inboxForbiddenResponse,
   },
 });
 
@@ -422,6 +430,10 @@ const replyEmailRoute = createRoute({
   },
   responses: {
     ...json201Response(SentEmailResponseSchema, "Reply sent"),
+    ...replyValidationErrorResponse,
+    413: multipartParseErrorResponses[413],
+    ...inboxForbiddenResponse,
+    ...replyNotFoundResponse,
   },
 });
 


### PR DESCRIPTION
## Summary

- Document multipart parse failures (`400` missing/invalid payload, too many files; `413` attachment size) on `POST /api/send` and `POST /api/send/reply/{emailId}`
- Document inbox permission `403` on send, reply, and template send paths
- Document reply/template `404` responses and broaden reply `400` for template validation failures
- Add `worker/src/lib/openapi-send-errors.ts` shared schemas + OpenAPI test

## Test plan

- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-send-errors.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-send-schemas.test.ts worker/src/__tests__/openapi-doc.test.ts`
- [ ] After deploy: `curl -s 'https://<host>/doc?cb=…' | jq '.paths["/api/send"].post.responses | keys'` → expect `201`, `400`, `403`, `413`


Made with [Cursor](https://cursor.com)