### PR TITLE
feat(api): add health and config routes to OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI `/doc`: global auth documentation, `BearerAuth` security scheme, and `security` requirements on integrator-facing routes (`/api/send`, template send, sequence enroll, API keys).
 - OpenAPI sequences: `fromAddress` and typed `variables` on `EnrollmentSchema`; document enroll and delete error responses (400/404).
 - OpenAPI send paths: document multipart parse errors (400/413), inbox permission 403, and reply/template-not-found 404 on `/api/send`, `/api/send/reply/{emailId}`, and `/api/email-templates/{slug}/send`.
+- OpenAPI bootstrap: add unauthenticated `GET /api/health` and `GET /api/config` to the generated spec.
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-bootstrap.test.ts
+++ b/worker/src/__tests__/openapi-bootstrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+describe("OpenAPI bootstrap routes", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc documents /api/health and /api/config without security", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      paths: Record<
+        string,
+        {
+          get?: {
+            tags?: string[];
+            security?: unknown;
+            responses?: Record<string, unknown>;
+          };
+        }
+      >;
+    };
+
+    const health = doc.paths["/api/health"]?.get;
+    expect(health?.tags).toContain("Bootstrap");
+    expect(health?.security).toBeUndefined();
+    expect(health?.responses?.["200"]).toBeDefined();
+
+    const config = doc.paths["/api/config"]?.get;
+    expect(config?.tags).toContain("Bootstrap");
+    expect(config?.security).toBeUndefined();
+    expect(config?.responses?.["200"]).toBeDefined();
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -37,13 +37,13 @@ import { suppressionsRouter } from "./routers/suppressions-router";
 import { webhooksRouter } from "./routers/webhooks-router";
 import { unsubscribeRouter } from "./routers/unsubscribe-router";
 import { outboxRouter } from "./routers/outbox-router";
+import { bootstrapRouter } from "./routers/bootstrap-router";
 export { NotificationsHub } from "./do/notifications";
 import type { Variables } from "./variables";
 import type { MiddlewareHandler } from "hono";
 import { injectAllowedInboxes } from "./middleware/inject-allowed-inboxes";
 import { requirePasskey } from "./middleware/require-passkey";
 import { passkeys } from "./db/auth.schema";
-import { appSettings } from "./db/app-settings.schema";
 import { isDevEnvironment } from "./lib/is-dev";
 import {
   BEARER_AUTH_SCHEME,
@@ -256,26 +256,8 @@ app.route("/api/unsubscribe", unsubscribeRouter);
 // GET requests don't match the router and fall through to the SPA assets handler.
 app.route("/unsubscribe", unsubscribeRouter);
 
-// Health check (no auth)
-app.get("/api/health", (c) => c.json({ status: "ok" }));
-
-// Public runtime config (no auth) — consumed by the SPA
-app.get("/api/config", async (c) => {
-  const db = c.get("db");
-  const row = await db
-    .select({ value: appSettings.value })
-    .from(appSettings)
-    .where(eq(appSettings.key, "brand_name"))
-    .limit(1);
-  const brandName =
-    row.length > 0 && row[0].value && row[0].value.length > 0
-      ? row[0].value
-      : "saasmail";
-  return c.json({
-    passkeyRequired: !isDevEnvironment(c.env),
-    brandName,
-  });
-});
+// Public bootstrap routes (no auth) — documented in OpenAPI under Bootstrap tag
+app.route("/api", bootstrapRouter);
 
 // Swagger UI
 app.get("/swagger-ui", swaggerUI({ url: "/doc" }));

--- a/worker/src/routers/bootstrap-router.ts
+++ b/worker/src/routers/bootstrap-router.ts
@@ -1,0 +1,68 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { eq } from "drizzle-orm";
+import { appSettings } from "../db/app-settings.schema";
+import { json200Response } from "../lib/helpers";
+import { isDevEnvironment } from "../lib/is-dev";
+import type { Variables } from "../variables";
+
+export const bootstrapRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const HealthSchema = z.object({
+  status: z.literal("ok").openapi({ example: "ok" }),
+});
+
+const healthRoute = createRoute({
+  method: "get",
+  path: "/health",
+  tags: ["Bootstrap"],
+  description:
+    "Liveness probe. No authentication required — safe for load balancers and uptime checks.",
+  responses: {
+    ...json200Response(HealthSchema, "Service is healthy"),
+  },
+});
+
+bootstrapRouter.openapi(healthRoute, (c) => c.json({ status: "ok" as const }));
+
+const ConfigSchema = z.object({
+  passkeyRequired: z.boolean().openapi({
+    description:
+      "Whether session users must register a WebAuthn passkey before using the API. Always false in local dev.",
+  }),
+  brandName: z.string().openapi({
+    description:
+      'Instance display name from app settings. Defaults to "saasmail" when unset.',
+    example: "saasmail",
+  }),
+});
+
+const configRoute = createRoute({
+  method: "get",
+  path: "/config",
+  tags: ["Bootstrap"],
+  description:
+    "Public runtime configuration consumed by the web UI on startup. No authentication required.",
+  responses: {
+    ...json200Response(ConfigSchema, "Runtime configuration"),
+  },
+});
+
+bootstrapRouter.openapi(configRoute, async (c) => {
+  const db = c.get("db");
+  const row = await db
+    .select({ value: appSettings.value })
+    .from(appSettings)
+    .where(eq(appSettings.key, "brand_name"))
+    .limit(1);
+  const brandName =
+    row.length > 0 && row[0].value && row[0].value.length > 0
+      ? row[0].value
+      : "saasmail";
+  return c.json({
+    passkeyRequired: !isDevEnvironment(c.env),
+    brandName,
+  });
+});


### PR DESCRIPTION
## Summary

- Add `bootstrap-router.ts` with documented `GET /api/health` and `GET /api/config` (Bootstrap tag, no auth)
- Remove inline handlers from `index.ts`; behavior unchanged
- OpenAPI test asserts both paths appear in `/doc` without `security`

## Test plan

- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-bootstrap.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/health-and-auth.test.ts`
- [ ] After deploy: `curl -s 'https://<host>/doc?cb=…' | jq '.paths | keys | map(select(test("health|config")))'`


Made with [Cursor](https://cursor.com)