### PR TITLE
feat(api): document notifications routes in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI sequences: `fromAddress` and typed `variables` on `EnrollmentSchema`; document enroll and delete error responses (400/404).
 - OpenAPI send paths: document multipart parse errors (400/413), inbox permission 403, and reply/template-not-found 404 on `/api/send`, `/api/send/reply/{emailId}`, and `/api/email-templates/{slug}/send`.
 - OpenAPI bootstrap: add unauthenticated `GET /api/health` and `GET /api/config` to the generated spec.
+- OpenAPI notifications: convert `notifications-router` to zod-openapi; document config, WebSocket stream, push subscribe/unsubscribe, and subscription management routes.
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
 
 ## [0.10.0] - 2026-06-23

--- a/worker/src/__tests__/openapi-notifications.test.ts
+++ b/worker/src/__tests__/openapi-notifications.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { exports } from "cloudflare:workers";
+import { applyMigrations } from "./helpers";
+
+describe("OpenAPI notifications routes", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("GET /doc documents all /api/notifications paths", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      paths: Record<
+        string,
+        {
+          get?: { tags?: string[]; security?: unknown };
+          post?: { tags?: string[]; security?: unknown };
+          delete?: { tags?: string[]; security?: unknown };
+        }
+      >;
+    };
+
+    const paths = Object.keys(doc.paths).filter((p) =>
+      p.startsWith("/api/notifications"),
+    );
+    expect(paths.sort()).toEqual(
+      [
+        "/api/notifications/config",
+        "/api/notifications/stream",
+        "/api/notifications/subscribe",
+        "/api/notifications/subscriptions",
+        "/api/notifications/subscriptions/{id}",
+      ].sort(),
+    );
+
+    for (const path of paths) {
+      const op =
+        doc.paths[path].get ?? doc.paths[path].post ?? doc.paths[path].delete;
+      expect(op?.tags).toContain("Notifications");
+      expect(op?.security).toEqual([{ BearerAuth: [] }]);
+    }
+
+    const stream = doc.paths["/api/notifications/stream"]?.get?.responses;
+    expect(stream?.["426"]).toBeDefined();
+    expect(stream?.["403"]).toBeDefined();
+    expect(stream?.["101"]).toBeDefined();
+
+    const subscribe =
+      doc.paths["/api/notifications/subscribe"]?.post?.responses;
+    expect(subscribe?.["201"]).toBeDefined();
+    expect(subscribe?.["503"]).toBeDefined();
+  });
+});

--- a/worker/src/routers/notifications-router.ts
+++ b/worker/src/routers/notifications-router.ts
@@ -1,15 +1,88 @@
-import { Hono } from "hono";
-import { z } from "zod";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { eq, and } from "drizzle-orm";
 import type { Variables } from "../variables";
 import { pushSubscriptions } from "../db/push-subscriptions.schema";
+import { bearerSecurity } from "../lib/openapi-auth";
+import { json200Response } from "../lib/helpers";
 
-export const notificationsRouter = new Hono<{
+const ErrorSchema = z.object({
+  error: z.string(),
+});
+
+const invalidBodyHook = (
+  result: { success: boolean },
+  c: { json: (body: { error: string }, status: 400) => Response },
+) => {
+  if (!result.success) {
+    return c.json({ error: "invalid body" }, 400);
+  }
+};
+
+export const notificationsRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
   Variables: Variables;
 }>();
 
-notificationsRouter.get("/stream", async (c) => {
+const NotificationsConfigSchema = z.object({
+  vapidPublicKey: z.string().openapi({
+    description:
+      "VAPID public key for Web Push subscription (empty when unset).",
+  }),
+  pushEnabled: z.boolean().openapi({
+    description:
+      "True when both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY are configured.",
+  }),
+});
+
+const configRoute = createRoute({
+  method: "get",
+  path: "/config",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description:
+    "Push notification configuration for the authenticated user. Used by the SPA to register a Web Push subscription.",
+  responses: {
+    ...json200Response(NotificationsConfigSchema, "Push configuration"),
+  },
+});
+
+notificationsRouter.openapi(configRoute, (c) => {
+  const publicKey = c.env.VAPID_PUBLIC_KEY ?? "";
+  const privateKey = c.env.VAPID_PRIVATE_KEY ?? "";
+  return c.json({
+    vapidPublicKey: publicKey,
+    pushEnabled: Boolean(publicKey && privateKey),
+  });
+});
+
+const streamRoute = createRoute({
+  method: "get",
+  path: "/stream",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description: `Real-time in-app notification stream via WebSocket upgrade to the user's NotificationsHub Durable Object.
+
+Requires \`Upgrade: websocket\` and \`Connection: Upgrade\` headers, plus an \`Origin\` header matching one of the instance's \`TRUSTED_ORIGINS\`. Session cookie or API key authentication.`,
+  responses: {
+    101: {
+      description: "Switching Protocols — WebSocket connection established.",
+    },
+    401: {
+      description: "Missing or invalid authentication",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    403: {
+      description: "Missing or untrusted Origin header",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    426: {
+      description: "Request is not a WebSocket upgrade",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+notificationsRouter.openapi(streamRoute, async (c) => {
   if (c.req.header("Upgrade") !== "websocket") {
     return c.json({ error: "Expected WebSocket upgrade" }, 426);
   }
@@ -40,93 +113,190 @@ notificationsRouter.get("/stream", async (c) => {
   );
 });
 
-notificationsRouter.get("/config", (c) => {
-  const publicKey = c.env.VAPID_PUBLIC_KEY ?? "";
-  const privateKey = c.env.VAPID_PRIVATE_KEY ?? "";
-  return c.json({
-    vapidPublicKey: publicKey,
-    pushEnabled: Boolean(publicKey && privateKey),
-  });
-});
-
-const subscribeSchema = z.object({
-  endpoint: z.string().url(),
-  keys: z.object({
-    p256dh: z.string().min(1),
-    auth: z.string().min(1),
+export const PushSubscribeSchema = z.object({
+  endpoint: z.string().url().openapi({
+    description: "Push service endpoint URL returned by the browser.",
+    example: "https://fcm.googleapis.com/fcm/send/…",
   }),
-  userAgent: z.string().max(512).optional(),
+  keys: z.object({
+    p256dh: z.string().min(1).openapi({
+      description: "P-256 ECDH public key from the browser PushSubscription.",
+    }),
+    auth: z.string().min(1).openapi({
+      description: "Authentication secret from the browser PushSubscription.",
+    }),
+  }),
+  userAgent: z.string().max(512).optional().openapi({
+    description: "Optional browser user-agent string for debugging.",
+  }),
 });
 
-notificationsRouter.post("/subscribe", async (c) => {
-  const user = c.get("user");
-  if (!user) return c.json({ error: "Unauthorized" }, 401);
+const subscribeRoute = createRoute({
+  method: "post",
+  path: "/subscribe",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description:
+    "Register or update a Web Push subscription for the authenticated user. Upserts by endpoint.",
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: PushSubscribeSchema },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Subscription registered",
+    },
+    400: {
+      description: "Invalid JSON body or schema validation failure",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    503: {
+      description: "VAPID keys are not configured on this instance",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.literal("push_not_configured") }),
+        },
+      },
+    },
+  },
+});
 
-  const privateKey = c.env.VAPID_PRIVATE_KEY ?? "";
-  if (!privateKey) {
-    return c.json({ error: "push_not_configured" }, 503);
-  }
+notificationsRouter.openapi(
+  subscribeRoute,
+  async (c) => {
+    const user = c.get("user");
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-  let body: z.infer<typeof subscribeSchema>;
-  try {
-    body = subscribeSchema.parse(await c.req.json());
-  } catch {
-    return c.json({ error: "invalid body" }, 400);
-  }
+    const privateKey = c.env.VAPID_PRIVATE_KEY ?? "";
+    if (!privateKey) {
+      return c.json({ error: "push_not_configured" }, 503);
+    }
 
-  const db = c.get("db");
-  const now = Math.floor(Date.now() / 1000);
+    const body = c.req.valid("json");
+    const db = c.get("db");
+    const now = Math.floor(Date.now() / 1000);
 
-  await db
-    .insert(pushSubscriptions)
-    .values({
-      id: crypto.randomUUID(),
-      userId: user.id,
-      endpoint: body.endpoint,
-      p256dh: body.keys.p256dh,
-      auth: body.keys.auth,
-      userAgent: body.userAgent ?? null,
-      createdAt: now,
-      lastUsedAt: null,
-    })
-    .onConflictDoUpdate({
-      target: pushSubscriptions.endpoint,
-      set: {
+    await db
+      .insert(pushSubscriptions)
+      .values({
+        id: crypto.randomUUID(),
         userId: user.id,
+        endpoint: body.endpoint,
         p256dh: body.keys.p256dh,
         auth: body.keys.auth,
         userAgent: body.userAgent ?? null,
+        createdAt: now,
+        lastUsedAt: null,
+      })
+      .onConflictDoUpdate({
+        target: pushSubscriptions.endpoint,
+        set: {
+          userId: user.id,
+          p256dh: body.keys.p256dh,
+          auth: body.keys.auth,
+          userAgent: body.userAgent ?? null,
+        },
+      });
+
+    return c.body(null, 201);
+  },
+  invalidBodyHook,
+);
+
+const UnsubscribeBodySchema = z.object({
+  endpoint: z.string().url().openapi({
+    description: "Push subscription endpoint URL to remove.",
+  }),
+});
+
+const unsubscribeRoute = createRoute({
+  method: "delete",
+  path: "/subscribe",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description:
+    "Remove a Web Push subscription for the authenticated user by endpoint URL.",
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: UnsubscribeBodySchema },
       },
-    });
-
-  return c.body(null, 201);
+    },
+  },
+  responses: {
+    204: {
+      description: "Subscription removed (or was not registered)",
+    },
+    400: {
+      description: "Invalid JSON body or missing endpoint",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
 });
 
-notificationsRouter.delete("/subscribe", async (c) => {
-  const user = c.get("user");
-  if (!user) return c.json({ error: "Unauthorized" }, 401);
+notificationsRouter.openapi(
+  unsubscribeRoute,
+  async (c) => {
+    const user = c.get("user");
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-  let body: { endpoint?: string };
-  try {
-    body = (await c.req.json()) as { endpoint?: string };
-  } catch {
-    return c.json({ error: "invalid body" }, 400);
-  }
-  if (!body.endpoint) return c.json({ error: "endpoint required" }, 400);
+    const body = c.req.valid("json");
+    if (!body.endpoint) return c.json({ error: "endpoint required" }, 400);
 
-  const db = c.get("db");
-  await db
-    .delete(pushSubscriptions)
-    .where(
-      and(
-        eq(pushSubscriptions.userId, user.id),
-        eq(pushSubscriptions.endpoint, body.endpoint),
-      ),
-    );
-  return c.body(null, 204);
+    const db = c.get("db");
+    await db
+      .delete(pushSubscriptions)
+      .where(
+        and(
+          eq(pushSubscriptions.userId, user.id),
+          eq(pushSubscriptions.endpoint, body.endpoint),
+        ),
+      );
+    return c.body(null, 204);
+  },
+  invalidBodyHook,
+);
+
+const PushSubscriptionSummarySchema = z.object({
+  id: z.string(),
+  userAgent: z.string().nullable(),
+  createdAt: z.number().int(),
+  lastUsedAt: z.number().int().nullable(),
 });
 
-notificationsRouter.get("/subscriptions", async (c) => {
+const listSubscriptionsRoute = createRoute({
+  method: "get",
+  path: "/subscriptions",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description:
+    "List Web Push subscriptions registered for the authenticated user.",
+  responses: {
+    ...json200Response(
+      z.object({
+        subscriptions: z.array(PushSubscriptionSummarySchema),
+      }),
+      "Push subscriptions",
+    ),
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+notificationsRouter.openapi(listSubscriptionsRoute, async (c) => {
   const user = c.get("user");
   if (!user) return c.json({ error: "Unauthorized" }, 401);
 
@@ -143,10 +313,37 @@ notificationsRouter.get("/subscriptions", async (c) => {
   return c.json({ subscriptions: rows });
 });
 
-notificationsRouter.delete("/subscriptions/:id", async (c) => {
+const deleteSubscriptionRoute = createRoute({
+  method: "delete",
+  path: "/subscriptions/{id}",
+  tags: ["Notifications"],
+  security: bearerSecurity,
+  description:
+    "Delete a single push subscription by id. Scoped to the authenticated user.",
+  request: {
+    params: z.object({
+      id: z.string().openapi({ description: "Push subscription id." }),
+    }),
+  },
+  responses: {
+    204: {
+      description: "Subscription deleted",
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    404: {
+      description: "Subscription not found for this user",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+  },
+});
+
+notificationsRouter.openapi(deleteSubscriptionRoute, async (c) => {
   const user = c.get("user");
   if (!user) return c.json({ error: "Unauthorized" }, 401);
-  const id = c.req.param("id");
+  const { id } = c.req.valid("param");
 
   const db = c.get("db");
   const result = await db


### PR DESCRIPTION
## Summary

- Convert `notifications-router.ts` from plain Hono to `@hono/zod-openapi`
- Document all six notification endpoints under the **Notifications** tag with `BearerAuth`
- WebSocket stream documents `101`, `401`, `403`, and `426` responses
- Push subscribe documents `201`, `400`, `401`, `503`; preserves `{ error: "invalid body" }` via validation hook
- OpenAPI test locks down path list and key response codes

## Test plan

- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/openapi-notifications.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/notifications-router.test.ts`
- [x] `npx vitest run --config vitest.config.test.ts worker/src/__tests__/push-subscriptions-router.test.ts`
- [ ] After deploy: `curl -s 'https://<host>/doc?cb=…' | jq '.paths | keys | map(select(test("notifications")))'`

**Label:** please add `patch` (fork cannot label upstream PRs).


Made with [Cursor](https://cursor.com)