### PR TITLE
fix: quote display names containing RFC 5322 specials in From header

### DIFF
--- a/worker/src/__tests__/format-from-address.test.ts
+++ b/worker/src/__tests__/format-from-address.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { encodeDisplayName } from "../lib/format-from-address";
+
+describe("encodeDisplayName", () => {
+  it("leaves a plain display name as a bare atom sequence", () => {
+    expect(encodeDisplayName("The Support Team")).toBe("The Support Team");
+  });
+
+  it("quotes a display name containing a comma", () => {
+    // Regression: unquoted, providers split the From header on the comma and
+    // reject the send with "Illegal email address 'Ada'".
+    expect(encodeDisplayName("Ada, VP of Engineering")).toBe(
+      '"Ada, VP of Engineering"',
+    );
+  });
+
+  it("quotes other RFC 5322 specials", () => {
+    expect(encodeDisplayName("Support (Billing)")).toBe('"Support (Billing)"');
+    expect(encodeDisplayName("a@b")).toBe('"a@b"');
+    expect(encodeDisplayName("Sales: EMEA")).toBe('"Sales: EMEA"');
+  });
+
+  it("escapes embedded quotes and backslashes", () => {
+    expect(encodeDisplayName('Bob "The Builder"')).toBe(
+      '"Bob \\"The Builder\\""',
+    );
+    expect(encodeDisplayName("back\\slash, inc")).toBe('"back\\\\slash, inc"');
+  });
+});

--- a/worker/src/lib/format-from-address.ts
+++ b/worker/src/lib/format-from-address.ts
@@ -3,8 +3,28 @@ import { senderIdentities } from "../db/sender-identities.schema";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 
 /**
+ * RFC 5322 "specials" — a display-name containing any of these is not a valid
+ * bare atom sequence and must be sent as a quoted-string instead.
+ *
+ * The comma matters most in practice: providers split the From header on commas
+ * to find multiple addresses, so an unquoted `Ada, VP of Engineering` is parsed
+ * as an address list whose first entry is the bare word `Ada` — and the whole
+ * send is rejected ("Illegal email address 'Ada'").
+ */
+const RFC5322_SPECIALS = /[()<>[\]:;@\\,."]/;
+
+/**
+ * Encodes a display-name for use in a From header, quoting and escaping it
+ * when it contains characters that can't appear in a bare atom.
+ */
+export function encodeDisplayName(name: string): string {
+  if (!RFC5322_SPECIALS.test(name)) return name;
+  return `"${name.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
  * Looks up the display name for an email address and returns
- * a formatted "From" string for the Resend API.
+ * a formatted "From" string for the sending provider.
  *
  * Returns "Display Name <email>" if a display name is configured,
  * otherwise returns the bare email address.
@@ -20,7 +40,7 @@ export async function formatFromAddress(
     .limit(1);
 
   if (rows.length > 0 && rows[0].displayName) {
-    return `${rows[0].displayName} <${email}>`;
+    return `${encodeDisplayName(rows[0].displayName)} <${email}>`;
   }
   return email;
 }


### PR DESCRIPTION
A sender identity whose display name contains a comma produces an unquoted `From` header like:

```
Ada, VP of Engineering <ada@example.com>
```

Providers parse `From` as an address list and split on the comma, so the first "address" is the bare word `Ada` and the send is rejected. Postmark, for example, returns:

```
Error parsing 'From': Illegal email address 'Ada'. It must contain the '@' symbol.
```

Net effect: any inbox whose display name contains a comma (or any other RFC 5322 special) can never send, and the failure surfaces only in the outbox as a provider rejection — nothing at call time indicates the address is unusable.

## Fix

`encodeDisplayName()` now quotes the display name and escapes embedded quotes/backslashes when it contains characters that can't appear in a bare atom sequence. Plain names are left untouched, so existing `From` headers are unchanged.

## Testing

- 4 new unit tests in `worker/src/__tests__/format-from-address.test.ts` covering plain names, commas, other specials, and escaping
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)