### PR TITLE
fix(security): enforce inbox scoping on email delete and reply paths

### DIFF
--- a/worker/src/__tests__/inbox-permission-enforcement.test.ts
+++ b/worker/src/__tests__/inbox-permission-enforcement.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import {
+  applyMigrations,
+  authFetch,
+  cleanDb,
+  createTestEmail,
+  createTestPerson,
+  createTestUser,
+  getDb,
+  buildSendForm,
+} from "./helpers";
+import { inboxPermissions } from "../db/inbox-permissions.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { emails } from "../db/emails.schema";
+
+const MINE = "mine@x.com";
+const OTHER = "other@x.com";
+
+/** Insert a sent email attributable to a given inbox. */
+async function insertSentEmail(id: string, fromAddress: string) {
+  const now = Math.floor(Date.now() / 1000);
+  await getDb()
+    .insert(sentEmails)
+    .values({
+      id,
+      personId: "sender-1",
+      fromAddress,
+      toAddress: "alice@example.com",
+      subject: "Outgoing",
+      bodyHtml: "<p>Outgoing</p>",
+      bodyText: "Outgoing",
+      messageId: `${id}@saasmail.test`,
+      status: "sent",
+      sentAt: now,
+      createdAt: now,
+    });
+}
+
+/**
+ * A member scoped to a single inbox. Inbox-permission enforcement is only
+ * meaningful for non-admins — `allowed.isAdmin` short-circuits every check.
+ */
+async function createScopedMember() {
+  const { apiKey } = await createTestUser({
+    id: "u-member",
+    role: "member",
+    email: "member@x.com",
+  });
+  await getDb()
+    .insert(inboxPermissions)
+    .values({
+      userId: "u-member",
+      email: MINE,
+      createdAt: Math.floor(Date.now() / 1000),
+      createdBy: null,
+    });
+  return apiKey;
+}
+
+describe("inbox permission enforcement", () => {
+  let apiKey: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    apiKey = await createScopedMember();
+    await createTestPerson();
+    // DemoSender so the reply path completes without hitting Resend.
+    (env as any).DEMO_MODE = "1";
+  });
+
+  afterEach(() => {
+    (env as any).DEMO_MODE = "0";
+  });
+
+  describe("DELETE /api/emails/{id}", () => {
+    it("refuses to delete a sent email belonging to another inbox", async () => {
+      await insertSentEmail("sent-other", OTHER);
+
+      const res = await authFetch("/api/emails/sent-other", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+
+      // The row must survive — this delete is irreversible.
+      const rows = await getDb()
+        .select()
+        .from(sentEmails)
+        .where(eq(sentEmails.id, "sent-other"));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("deletes a sent email belonging to an allowed inbox", async () => {
+      await insertSentEmail("sent-mine", MINE);
+
+      const res = await authFetch("/api/emails/sent-mine", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+
+      const rows = await getDb()
+        .select()
+        .from(sentEmails)
+        .where(eq(sentEmails.id, "sent-mine"));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("refuses to delete a received email addressed to another inbox", async () => {
+      await createTestEmail({ id: "rcv-other", recipient: OTHER });
+
+      const res = await authFetch("/api/emails/rcv-other", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+
+      const rows = await getDb()
+        .select()
+        .from(emails)
+        .where(eq(emails.id, "rcv-other"));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("deletes a received email addressed to an allowed inbox", async () => {
+      await createTestEmail({ id: "rcv-mine", recipient: MINE });
+
+      const res = await authFetch("/api/emails/rcv-mine", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+
+      const rows = await getDb()
+        .select()
+        .from(emails)
+        .where(eq(emails.id, "rcv-mine"));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("still 404s for an id that matches nothing", async () => {
+      const res = await authFetch("/api/emails/does-not-exist", {
+        apiKey,
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/send/reply/{emailId}", () => {
+    it("refuses to reply to an email received at another inbox", async () => {
+      await createTestEmail({ id: "rcv-other", recipient: OTHER });
+
+      const res = await authFetch("/api/send/reply/rcv-other", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: MINE,
+          bodyHtml: "<p>reply</p>",
+        }),
+      });
+      expect(res.status).toBe(403);
+
+      // Nothing may be queued for delivery.
+      const rows = await getDb().select().from(sentEmails);
+      expect(rows).toHaveLength(0);
+    });
+
+    it("allows a reply to an email received at an allowed inbox", async () => {
+      await createTestEmail({ id: "rcv-mine", recipient: MINE });
+
+      const res = await authFetch("/api/send/reply/rcv-mine", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: MINE,
+          bodyHtml: "<p>reply</p>",
+        }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it("refuses to reply to a sent email belonging to another inbox", async () => {
+      await insertSentEmail("sent-other", OTHER);
+
+      const res = await authFetch("/api/send/reply/sent-other", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: MINE,
+          bodyHtml: "<p>reply</p>",
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/worker/src/lib/delete-email.ts
+++ b/worker/src/lib/delete-email.ts
@@ -4,16 +4,31 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { attachments } from "../db/attachments.schema";
 import { people } from "../db/people.schema";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { AllowedInboxes } from "./inbox-permissions";
+
+/** Grants deletion of any email. For system callers (e.g. blocklist purge). */
+export const SYSTEM_INBOX_ACCESS: AllowedInboxes = { isAdmin: true };
+
+function isInboxAllowed(allowed: AllowedInboxes, inbox: string): boolean {
+  return allowed.isAdmin || allowed.inboxes.includes(inbox.toLowerCase());
+}
 
 /**
  * Hard delete an email (received or sent) and all associated R2 attachments.
  * Updates person counts when deleting a received email.
  * Returns null if the email was not found.
+ *
+ * `allowed` scopes the delete to inboxes the caller may act on: a received
+ * email is keyed by `recipient`, a sent one by `fromAddress`. A denied delete
+ * is reported as not-found so callers cannot probe for ids they can't see.
+ * The check lives here rather than at the call site because doing it in the
+ * router meant the sent-email branch below could be reached unguarded.
  */
 export async function deleteEmailWithAttachments(
   db: DrizzleD1Database<any>,
   r2: R2Bucket,
   emailId: string,
+  allowed: AllowedInboxes,
 ): Promise<{ success: boolean; attachmentsDeleted: number } | null> {
   // Try received email first
   const received = await db
@@ -21,6 +36,7 @@ export async function deleteEmailWithAttachments(
       id: emails.id,
       personId: emails.personId,
       isRead: emails.isRead,
+      recipient: emails.recipient,
     })
     .from(emails)
     .where(eq(emails.id, emailId))
@@ -28,6 +44,7 @@ export async function deleteEmailWithAttachments(
 
   if (received.length > 0) {
     const email = received[0];
+    if (!isInboxAllowed(allowed, email.recipient)) return null;
 
     // Delete R2 attachments
     const atts = await db
@@ -62,12 +79,13 @@ export async function deleteEmailWithAttachments(
 
   // Try sent email
   const sent = await db
-    .select({ id: sentEmails.id })
+    .select({ id: sentEmails.id, fromAddress: sentEmails.fromAddress })
     .from(sentEmails)
     .where(eq(sentEmails.id, emailId))
     .limit(1);
 
   if (sent.length > 0) {
+    if (!isInboxAllowed(allowed, sent[0].fromAddress)) return null;
     // Sent emails don't have attachments in the current schema
     await db.delete(sentEmails).where(eq(sentEmails.id, emailId));
     return { success: true, attachmentsDeleted: 0 };

--- a/worker/src/lib/purge-blocked.ts
+++ b/worker/src/lib/purge-blocked.ts
@@ -3,7 +3,10 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { emails } from "../db/emails.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { people } from "../db/people.schema";
-import { deleteEmailWithAttachments } from "./delete-email";
+import {
+  deleteEmailWithAttachments,
+  SYSTEM_INBOX_ACCESS,
+} from "./delete-email";
 
 /**
  * Hard-delete every email + person whose address matches any block rule, and
@@ -32,7 +35,14 @@ export async function purgeBlockedMail(
       .from(emails)
       .where(eq(emails.personId, personId));
     for (const e of received) {
-      const res = await deleteEmailWithAttachments(db, r2, e.id);
+      // Purging a blocked sender is a system action, not a user-scoped one:
+      // every matching email must go regardless of who triggered the purge.
+      const res = await deleteEmailWithAttachments(
+        db,
+        r2,
+        e.id,
+        SYSTEM_INBOX_ACCESS,
+      );
       if (res) emailsDeleted++;
     }
     // Any sent emails attributed to this person.

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -671,18 +671,9 @@ emailsRouter.openapi(deleteEmailRoute, async (c) => {
   const { id } = c.req.valid("param");
 
   const allowed = c.get("allowedInboxes")!;
-  if (!allowed.isAdmin) {
-    const row = await db
-      .select({ recipient: emails.recipient })
-      .from(emails)
-      .where(eq(emails.id, id))
-      .limit(1);
-    if (row.length > 0 && !allowed.inboxes.includes(row[0].recipient)) {
-      return c.json({ error: "Email not found" }, 404);
-    }
-  }
-
-  const result = await deleteEmailWithAttachments(db, r2, id);
+  // Scoping is enforced inside deleteEmailWithAttachments so that received and
+  // sent emails are both covered; a denied delete comes back as null → 404.
+  const result = await deleteEmailWithAttachments(db, r2, id, allowed);
   if (!result) {
     return c.json({ error: "Email not found" }, 404);
   }

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -480,6 +480,10 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
 
   if (receivedRow.length > 0) {
     const orig = receivedRow[0];
+    // Mirror of the sent-row check below: only allow replies to messages
+    // delivered to an inbox the caller still owns. Without this a scoped user
+    // could thread a reply into a conversation they cannot read.
+    assertInboxAllowed(allowed, orig.recipient);
     const person = await db
       .select({ email: people.email })
       .from(people)


### PR DESCRIPTION
Inbox permission checks covered received email but not their sent counterparts, so a member scoped to one inbox could act on another inbox's messages. Both paths now enforce the same rule.

## Delete

`DELETE /api/emails/{id}` pre-checked `emails.recipient` in the route. For an id matching a *sent* email that lookup returns no rows, so the guard was skipped and `deleteEmailWithAttachments` removed the `sent_emails` row unchecked.

The check now lives inside `deleteEmailWithAttachments`, which takes an `AllowedInboxes` and keys received email on `recipient`, sent on `fromAddress`:

- A denied delete returns `null`, so the route's existing not-found branch handles it and callers can't probe for ids they can't see.
- Making the argument **required** means no call site can reach the delete unguarded — the previous shape allowed it by omission.
- `purge-blocked` passes `SYSTEM_INBOX_ACCESS`, since a blocklist purge is a system action that must remove every matching email.

The route drops its own partial pre-check (−11 lines) now that scoping is enforced one layer down.

## Reply

`POST /api/send/reply/{emailId}` already asserted on the sent branch that the caller owns the original's `fromAddress` (with a comment explaining why), but the received branch asserted nothing about `orig.recipient`. A scoped user could thread a reply into a conversation they cannot read. Adds the mirroring assertion.

## Also

Both checks lowercase before comparing, matching `assertInboxAllowed`'s existing behavior. This also fixes a false *denial* on mixed-case stored rows, where a rightful owner was previously refused.

## Tests

New `worker/src/__tests__/inbox-permission-enforcement.test.ts` — 8 tests covering allowed and denied deletes and replies across both tables. The denied cases assert the row still exists after a refused delete, and that nothing is queued after a refused reply, rather than only asserting the status code.

Verified these fail against the previous behavior (`expected 200 to be 404`, `expected 201 to be 403`) and pass after the change.

- `yarn tsc --noEmit` clean
- `yarn test` — 62 files, 481 passed, 1 skipped

## Notes for review

- Denied delete returns 404 (not-found semantics, avoids id probing); denied reply returns 403, matching the `assertInboxAllowed` already used by the adjacent sent branch. The asymmetry is deliberate but worth a second opinion.
- Deployments where all users are admin are unaffected either way — `allowed.isAdmin` short-circuits both checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)