### PR TITLE
feat(mcp): send, reply, search + review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,14 +248,24 @@ Three scopes gate what a connected client may do:
 
 **Access is scoped to the connecting user.** A client acting for a member with
 access to one inbox sees only that inbox — the same permission model as the web
-UI and the HTTP API, enforced by the same code. Admins see everything.
+UI and the HTTP API, enforced by the same code. Admins see everything. A passkey
+is required, the same as for the web API.
 
-Revoke a connection at any time; tokens stop working immediately. Note that
-`delete_email` is permanent (there is no trash), so clients are told to confirm
-before calling it.
+**Prefer `email:read` alone.** An assistant connected to a mailbox reads
+attacker-authored content by definition — anyone can email you. Granting
+`email:send` or `email:manage` alongside it means a message in your inbox can
+try to instruct the assistant to mail your data somewhere or delete it. The
+consent screen flags those two scopes for this reason, and `delete_email` is
+permanent (there is no trash). Grant them only to clients you actually trust.
 
-> Freeform composition (`send_email`, `reply_email`) and full-text `search_emails`
-> are not exposed yet. A client can still send through a saved template.
+**Revoking access.** Admins can list connected OAuth clients and cut them off at
+**Settings → OAuth apps** (`GET /api/oauth-apps`, `DELETE /api/oauth-apps/{clientId}`).
+Revocation takes effect on the client's next call: the MCP endpoint checks the
+client on every request, so a revoked connection cannot keep working until its
+token expires. Banning a user has the same immediate effect.
+
+Any client can register itself (that is how MCP connectors work), so the list is
+also where you spot one you don't recognise.
 
 ### Webhooks
 

--- a/src/pages/ConsentPage.tsx
+++ b/src/pages/ConsentPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Check, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Check, ShieldCheck } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { useBranding } from "@/lib/branding";
 
@@ -18,6 +18,14 @@ const SCOPE_DESCRIPTIONS: Record<string, string> = {
   "email:send": "Send mail and enroll contacts in sequences",
   "email:manage": "Mark mail as read and delete mail",
 };
+
+/**
+ * Scopes that let a client act, not just look. An assistant connected to a
+ * mailbox reads attacker-authored content by definition, so granting these
+ * alongside read access is what turns a prompt injection into an outbound
+ * message or a deletion. They are called out rather than listed flatly.
+ */
+const ELEVATED_SCOPES = new Set(["email:send", "email:manage"]);
 
 const CARD =
   "rounded-2xl bg-white/10 p-8 shadow-2xl ring-1 ring-white/20 backdrop-blur-xl";
@@ -147,24 +155,54 @@ export default function ConsentPage() {
         <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-white/50">
           It will be able to
         </p>
-        <ul className="mb-8 space-y-2">
-          {scopes.map((s) => (
-            <li
-              key={s}
-              className="flex items-start gap-2 rounded-md bg-white/5 px-3 py-2 ring-1 ring-white/10"
-            >
-              <Check
-                className="mt-0.5 h-3.5 w-3.5 shrink-0"
-                strokeWidth={2.5}
-                style={{ color: "#BFFF00" }}
-                aria-hidden
-              />
-              <span className="text-xs text-white/80">
-                {SCOPE_DESCRIPTIONS[s] ?? s}
-              </span>
-            </li>
-          ))}
+        <ul className="mb-4 space-y-2">
+          {scopes.map((s) => {
+            const elevated = ELEVATED_SCOPES.has(s);
+            return (
+              <li
+                key={s}
+                className={
+                  elevated
+                    ? "flex items-start gap-2 rounded-md bg-amber-500/10 px-3 py-2 ring-1 ring-amber-400/30"
+                    : "flex items-start gap-2 rounded-md bg-white/5 px-3 py-2 ring-1 ring-white/10"
+                }
+              >
+                {elevated ? (
+                  <AlertTriangle
+                    className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300"
+                    strokeWidth={2.5}
+                    aria-hidden
+                  />
+                ) : (
+                  <Check
+                    className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                    strokeWidth={2.5}
+                    style={{ color: "#BFFF00" }}
+                    aria-hidden
+                  />
+                )}
+                <span
+                  className={
+                    elevated
+                      ? "text-xs text-amber-100"
+                      : "text-xs text-white/80"
+                  }
+                >
+                  {SCOPE_DESCRIPTIONS[s] ?? s}
+                </span>
+              </li>
+            );
+          })}
         </ul>
+
+        {scopes.some((s) => ELEVATED_SCOPES.has(s)) && (
+          <p className="mb-8 rounded-md bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-100 ring-1 ring-amber-400/30">
+            This app can act on your mailbox, not just read it. Anything it
+            reads — including mail sent to you by strangers — can influence what
+            it does next. Only continue if you trust it with sending and
+            deleting.
+          </p>
+        )}
 
         <div className="space-y-3">
           <button

--- a/worker/src/__tests__/consent-tamper.test.ts
+++ b/worker/src/__tests__/consent-tamper.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { applyMigrations, cleanDb } from "./helpers";
+import {
+  BASE_URL,
+  MCP_AUDIENCE,
+  REDIRECT_URI,
+  type Credentials,
+  Jar,
+  createUserWithPassword,
+  json,
+  pkce,
+  registerClient,
+  req,
+  signIn,
+} from "./mcp-helpers";
+
+const ADMIN: Credentials = {
+  name: "Owner",
+  email: "owner@saasmail.test",
+  password: "correct-horse-battery",
+};
+
+/**
+ * The consent screen renders the scope list from the *visible* `scope` query
+ * parameter, while the grant is recorded from the signed `oauth_query` blob.
+ * If those can diverge, an attacker could show a victim "Verify your identity"
+ * and have them approve full mailbox read/send/delete.
+ *
+ * This asserts they cannot: `scope` is covered by the signature.
+ */
+describe("consent request tampering", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    await createUserWithPassword(ADMIN, "admin");
+  });
+
+  it("rejects a consent whose scope was altered after signing", async () => {
+    const jar = new Jar();
+    await signIn(jar, ADMIN);
+    const { client_id } = await registerClient(
+      "openid email:read email:send email:manage",
+    );
+    const { challenge } = await pkce();
+
+    const authorizeRes = jar.absorb(
+      await req(
+        `/api/auth/oauth2/authorize?${new URLSearchParams({
+          client_id,
+          redirect_uri: REDIRECT_URI,
+          response_type: "code",
+          scope: "openid email:read email:send email:manage",
+          resource: MCP_AUDIENCE,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        })}`,
+        { headers: { cookie: jar.header }, redirect: "manual" },
+      ),
+    );
+    const location = authorizeRes.headers.get("location") ?? "";
+    const signedQuery = location.slice(location.indexOf("?") + 1);
+
+    // Sanity: the untampered query is accepted.
+    expect(signedQuery).toContain("scope=");
+
+    // Now downgrade only the visible scope, as a phishing link would.
+    const tampered = new URLSearchParams(signedQuery);
+    tampered.set("scope", "openid");
+
+    const res = await json(
+      "/api/auth/oauth2/consent",
+      { accept: true, oauth_query: tampered.toString() },
+      { headers: { cookie: jar.header, Origin: BASE_URL } },
+    );
+
+    const body = await res.text();
+    expect(res.status, `tampered consent was accepted: ${body}`).not.toBe(200);
+    expect(body).toContain("invalid_signature");
+  });
+
+  it("covers scope with the signature", async () => {
+    const jar = new Jar();
+    await signIn(jar, ADMIN);
+    const { client_id } = await registerClient("openid email:read");
+    const { challenge } = await pkce();
+
+    const authorizeRes = jar.absorb(
+      await req(
+        `/api/auth/oauth2/authorize?${new URLSearchParams({
+          client_id,
+          redirect_uri: REDIRECT_URI,
+          response_type: "code",
+          scope: "openid email:read",
+          resource: MCP_AUDIENCE,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        })}`,
+        { headers: { cookie: jar.header }, redirect: "manual" },
+      ),
+    );
+    const location = authorizeRes.headers.get("location") ?? "";
+    const params = new URLSearchParams(
+      location.slice(location.indexOf("?") + 1),
+    );
+    // The signed-parameter allowlist must include `scope`, or the consent
+    // screen could be made to display something other than what is granted.
+    expect(params.getAll("ba_param")).toContain("scope");
+  });
+});

--- a/worker/src/__tests__/mcp-oauth.test.ts
+++ b/worker/src/__tests__/mcp-oauth.test.ts
@@ -6,6 +6,7 @@ import {
   MCP_AUDIENCE,
   REDIRECT_URI,
   type Credentials,
+  callTool,
   createUserWithPassword,
   exchangeToken,
   getAccessToken,
@@ -206,15 +207,24 @@ describe("MCP OAuth", () => {
 
   describe("scope enforcement", () => {
     it("refuses a tool whose scope the token lacks", async () => {
-      // whoami requires email:read; this token only carries openid.
+      // list_people requires email:read; this token only carries openid.
       const token = await getAccessToken(ADMIN, "openid");
       const res = await mcpRpc(token, "tools/call", {
-        name: "whoami",
+        name: "list_people",
         arguments: {},
       });
       const body = await readRpc(res);
       expect(body.result.isError).toBe(true);
       expect(body.result.content[0].text).toContain("email:read");
+    });
+
+    it("still allows whoami without a capability scope", async () => {
+      // whoami is the documented way to discover a valid fromAddress, so a
+      // least-privilege send-only token must be able to call it.
+      const token = await getAccessToken(ADMIN, "openid");
+      const out = await callTool(token, "whoami");
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data.email).toBe(ADMIN.email);
     });
   });
 });

--- a/worker/src/__tests__/mcp-review-findings.test.ts
+++ b/worker/src/__tests__/mcp-review-findings.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestEmail,
+  createTestPerson,
+  getDb,
+} from "./helpers";
+import { users } from "../db/auth.schema";
+import { attachments } from "../db/attachments.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { blocklist } from "../db/blocklist.schema";
+import {
+  ALL_SCOPES,
+  type Credentials,
+  callTool,
+  createUserWithPassword,
+  getAccessToken,
+  grantInbox,
+} from "./mcp-helpers";
+
+const MINE = "mine@x.com";
+const OTHER = "other@x.com";
+
+const ADMIN: Credentials = {
+  name: "Owner",
+  email: "owner@saasmail.test",
+  password: "correct-horse-battery",
+};
+const MEMBER: Credentials = {
+  name: "Member",
+  email: "member@saasmail.test",
+  password: "member-password-123",
+};
+
+async function userIdFor(email: string): Promise<string> {
+  const rows = await getDb()
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  return rows[0].id;
+}
+
+describe("review findings", () => {
+  let memberToken: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    await createUserWithPassword(ADMIN, "admin");
+    await createUserWithPassword(MEMBER, "member");
+    await grantInbox(await userIdFor(MEMBER.email), MINE);
+    memberToken = await getAccessToken(MEMBER, ALL_SCOPES);
+  });
+
+  describe("list_people cross-inbox leak", () => {
+    it("does not reveal inboxes the caller cannot see for a shared contact", async () => {
+      // One contact who wrote to BOTH the member's inbox and a private one.
+      await createTestPerson({ id: "p-shared", email: "vendor@example.com" });
+      await createTestEmail({
+        id: "e-shared-mine",
+        personId: "p-shared",
+        recipient: MINE,
+        subject: "Invoice question",
+        messageId: "shared-mine@example.com",
+      });
+      await createTestEmail({
+        id: "e-shared-other",
+        personId: "p-shared",
+        recipient: OTHER,
+        subject: "Termination settlement",
+        messageId: "shared-other@example.com",
+      });
+
+      const out = await callTool(memberToken, "list_people");
+      expect(out.isError, out.text).toBe(false);
+
+      const inboxes = out.data.data.map((r: any) => r.recipient);
+      expect(inboxes).toContain(MINE);
+      // The private inbox's existence, counts, and subject must not leak
+      // merely because the contact is in scope through another inbox.
+      expect(inboxes).not.toContain(OTHER);
+
+      const subjects = out.data.data.map((r: any) => r.latestSubject);
+      expect(subjects).not.toContain("Termination settlement");
+    });
+  });
+
+  describe("search_emails scoping", () => {
+    beforeEach(async () => {
+      await createTestPerson({ id: "p-mine", email: "alice@example.com" });
+      await createTestPerson({ id: "p-other", email: "bob@example.com" });
+      await createTestEmail({
+        id: "e-mine",
+        personId: "p-mine",
+        recipient: MINE,
+        subject: "Hello quarterly",
+        messageId: "m1@example.com",
+      });
+      await createTestEmail({
+        id: "e-other",
+        personId: "p-other",
+        recipient: OTHER,
+        subject: "Hello quarterly",
+        messageId: "o1@example.com",
+      });
+    });
+
+    it("ignores an inbox filter naming an inbox the member cannot see", async () => {
+      // The scope clause is ANDed with the inbox filter, so asking for someone
+      // else's inbox must yield nothing rather than escaping the grant.
+      const out = await callTool(memberToken, "search_emails", {
+        q: "quarterly",
+        inbox: OTHER,
+      });
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data.hits).toEqual([]);
+    });
+
+    it("returns nothing for a member with no inbox grants", async () => {
+      await createUserWithPassword(
+        {
+          name: "Ungranted",
+          email: "none@saasmail.test",
+          password: "pw-12345678",
+        },
+        "member",
+      );
+      const token = await getAccessToken(
+        {
+          name: "Ungranted",
+          email: "none@saasmail.test",
+          password: "pw-12345678",
+        },
+        ALL_SCOPES,
+      );
+      // An empty grant list renders `IN ()`, a SQLite syntax error — this must
+      // short-circuit, not surface a database error.
+      const out = await callTool(token, "search_emails", { q: "quarterly" });
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data.hits).toEqual([]);
+    });
+
+    it("hides mail from a blocked sender", async () => {
+      await getDb()
+        .insert(blocklist)
+        .values({
+          id: "b-1",
+          type: "email",
+          value: "alice@example.com",
+          createdAt: Math.floor(Date.now() / 1000),
+        });
+      const out = await callTool(memberToken, "search_emails", {
+        q: "quarterly",
+      });
+      // Blocking is expected to hide existing mail, not merely stop new mail.
+      expect(out.data.hits.map((h: any) => h.id)).not.toContain("e-mine");
+    });
+
+    it("honours a zero timestamp bound instead of dropping it", async () => {
+      // `before: 0` is falsy but meaningful — it must not widen to everything.
+      const out = await callTool(memberToken, "search_emails", {
+        q: "quarterly",
+        before: 0,
+      });
+      expect(out.data.hits).toEqual([]);
+    });
+  });
+
+  describe("delete_email attachment cleanup", () => {
+    it("deletes attachments belonging to a sent message", async () => {
+      await createTestPerson({ id: "p-1", email: "alice@example.com" });
+      const now = Math.floor(Date.now() / 1000);
+      await getDb().insert(sentEmails).values({
+        id: "s-1",
+        personId: "p-1",
+        fromAddress: MINE,
+        toAddress: "alice@example.com",
+        subject: "With attachment",
+        bodyHtml: "<p>see attached</p>",
+        bodyText: "see attached",
+        messageId: "s-1@saasmail.test",
+        status: "sent",
+        sentAt: now,
+        createdAt: now,
+      });
+      await getDb().insert(attachments).values({
+        id: "att-1",
+        emailId: "s-1",
+        kind: "sent",
+        filename: "invoice.pdf",
+        contentType: "application/pdf",
+        size: 100,
+        r2Key: "attachments/att-1",
+        createdAt: now,
+      });
+
+      const out = await callTool(memberToken, "delete_email", {
+        emailId: "s-1",
+      });
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data.attachmentsDeleted).toBe(1);
+
+      // The row must not survive its parent message.
+      const left = await getDb()
+        .select()
+        .from(attachments)
+        .where(eq(attachments.emailId, "s-1"));
+      expect(left).toHaveLength(0);
+    });
+  });
+});

--- a/worker/src/__tests__/mcp-review-findings.test.ts
+++ b/worker/src/__tests__/mcp-review-findings.test.ts
@@ -7,7 +7,7 @@ import {
   createTestPerson,
   getDb,
 } from "./helpers";
-import { users } from "../db/auth.schema";
+import { users, oauthClients } from "../db/auth.schema";
 import { attachments } from "../db/attachments.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { blocklist } from "../db/blocklist.schema";
@@ -18,6 +18,7 @@ import {
   createUserWithPassword,
   getAccessToken,
   grantInbox,
+  mcpRpc,
 } from "./mcp-helpers";
 
 const MINE = "mine@x.com";
@@ -169,6 +170,50 @@ describe("review findings", () => {
         before: 0,
       });
       expect(out.data.hits).toEqual([]);
+    });
+  });
+
+  describe("token revocation", () => {
+    it("stops working once the client is revoked", async () => {
+      // Confirm the token works before revoking, so the assertion below is
+      // about revocation and not some unrelated failure.
+      expect((await callTool(memberToken, "whoami")).isError).toBe(false);
+
+      await getDb().delete(oauthClients);
+
+      // Revocation is an auth failure, so it surfaces as a transport-level 401
+      // with a discovery challenge — not an in-band tool error.
+      const res = await mcpRpc(memberToken, "tools/call", {
+        name: "whoami",
+        arguments: {},
+      });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("WWW-Authenticate")).toContain("Bearer");
+    });
+
+    it("stops working once the user is banned", async () => {
+      expect((await callTool(memberToken, "whoami")).isError).toBe(false);
+
+      await getDb()
+        .update(users)
+        .set({ banned: true })
+        .where(eq(users.email, MEMBER.email));
+
+      const res = await mcpRpc(memberToken, "tools/call", {
+        name: "whoami",
+        arguments: {},
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("keeps working when a ban has already expired", async () => {
+      await getDb()
+        .update(users)
+        .set({ banned: true, banExpires: new Date(Date.now() - 60_000) })
+        .where(eq(users.email, MEMBER.email));
+
+      const out = await callTool(memberToken, "whoami");
+      expect(out.isError, out.text).toBe(false);
     });
   });
 

--- a/worker/src/__tests__/mcp-tools.test.ts
+++ b/worker/src/__tests__/mcp-tools.test.ts
@@ -133,6 +133,7 @@ describe("MCP tools", () => {
           "list_people",
           "mark_read",
           "read_email",
+          "search_emails",
           "send_template",
           "whoami",
         ].sort(),
@@ -334,6 +335,122 @@ describe("MCP tools", () => {
         emailId: "s-other",
       });
       expect(out.isError).toBe(false);
+    });
+  });
+
+  describe("search_emails", () => {
+    it("finds a received message by a word in its subject", async () => {
+      const out = await callTool(memberToken, "search_emails", {
+        q: "mine",
+      });
+      expect(out.isError, out.text).toBe(false);
+      const ids = out.data.hits.map((h: any) => h.id);
+      expect(ids).toContain("e-mine");
+    });
+
+    it("finds a received message by a word in its body", async () => {
+      await createTestEmail({
+        id: "e-body",
+        personId: "p-mine",
+        recipient: MINE,
+        subject: "No keyword here",
+        bodyText: "the quarterly invoice is attached",
+        messageId: "body-1@example.com",
+      });
+      const out = await callTool(memberToken, "search_emails", {
+        q: "invoice",
+      });
+      const ids = out.data.hits.map((h: any) => h.id);
+      expect(ids).toContain("e-body");
+    });
+
+    it("finds sent messages too", async () => {
+      const out = await callTool(memberToken, "search_emails", {
+        q: "Outgoing",
+      });
+      const hit = out.data.hits.find((h: any) => h.id === "s-mine");
+      expect(hit).toBeTruthy();
+      expect(hit.type).toBe("sent");
+    });
+
+    it("never returns messages from another inbox", async () => {
+      // "Hello" matches both the MINE and OTHER seeded subjects.
+      const out = await callTool(memberToken, "search_emails", { q: "Hello" });
+      const ids = out.data.hits.map((h: any) => h.id);
+      expect(ids).toContain("e-mine");
+      expect(ids).not.toContain("e-other");
+    });
+
+    it("returns both inboxes for an admin", async () => {
+      const out = await callTool(adminToken, "search_emails", { q: "Hello" });
+      const ids = out.data.hits.map((h: any) => h.id).sort();
+      expect(ids).toEqual(["e-mine", "e-other"]);
+    });
+
+    it("restricts to a single inbox when asked", async () => {
+      const out = await callTool(adminToken, "search_emails", {
+        q: "Hello",
+        inbox: OTHER,
+      });
+      const ids = out.data.hits.map((h: any) => h.id);
+      expect(ids).toEqual(["e-other"]);
+    });
+
+    it("returns an empty result rather than erroring on no match", async () => {
+      const out = await callTool(memberToken, "search_emails", {
+        q: "zzzznotpresent",
+      });
+      expect(out.isError).toBe(false);
+      expect(out.data.hits).toEqual([]);
+      expect(out.data.hasMore).toBe(false);
+    });
+
+    it("treats LIKE wildcards as literal text", async () => {
+      // A bare "%" must not behave as match-everything on the sent-mail side.
+      const out = await callTool(memberToken, "search_emails", { q: "%" });
+      expect(out.isError).toBe(false);
+      expect(out.data.hits).toEqual([]);
+    });
+
+    it("paginates and reports hasMore", async () => {
+      for (let i = 0; i < 3; i++) {
+        await createTestEmail({
+          id: `e-page-${i}`,
+          personId: "p-mine",
+          recipient: MINE,
+          subject: `Paginate ${i}`,
+          messageId: `page-${i}@example.com`,
+        });
+      }
+      const first = await callTool(memberToken, "search_emails", {
+        q: "Paginate",
+        limit: 2,
+      });
+      expect(first.data.hits).toHaveLength(2);
+      expect(first.data.hasMore).toBe(true);
+
+      const second = await callTool(memberToken, "search_emails", {
+        q: "Paginate",
+        limit: 2,
+        page: 2,
+      });
+      expect(second.data.hits).toHaveLength(1);
+      expect(second.data.hasMore).toBe(false);
+
+      // Pages must not overlap.
+      const firstIds = first.data.hits.map((h: any) => h.id);
+      const secondIds = second.data.hits.map((h: any) => h.id);
+      expect(firstIds.filter((id: string) => secondIds.includes(id))).toEqual(
+        [],
+      );
+    });
+
+    it("filters by time range", async () => {
+      const out = await callTool(memberToken, "search_emails", {
+        q: "Hello",
+        after: Math.floor(Date.now() / 1000) + 3600,
+      });
+      expect(out.data.hits).toEqual([]);
     });
   });
 

--- a/worker/src/__tests__/mcp-tools.test.ts
+++ b/worker/src/__tests__/mcp-tools.test.ts
@@ -133,7 +133,9 @@ describe("MCP tools", () => {
           "list_people",
           "mark_read",
           "read_email",
+          "reply_email",
           "search_emails",
+          "send_email",
           "send_template",
           "whoami",
         ].sort(),
@@ -521,6 +523,71 @@ describe("MCP tools", () => {
         fromAddress: MINE,
       });
       expect(out.isError).toBe(true);
+    });
+  });
+
+  describe("send_email / reply_email", () => {
+    beforeEach(() => {
+      (env as any).DEMO_MODE = "1";
+    });
+    afterEach(() => {
+      (env as any).DEMO_MODE = "0";
+    });
+
+    it("sends from an allowed inbox", async () => {
+      const out = await callTool(memberToken, "send_email", {
+        to: "alice@example.com",
+        fromAddress: MINE,
+        subject: "Hello there",
+        bodyHtml: "<p>Hi</p>",
+        bodyText: "Hi",
+      });
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data.status).toBe("sent");
+    });
+
+    it("refuses to send from an inbox the member does not own", async () => {
+      const before = await getDb().select().from(sentEmails);
+      const out = await callTool(memberToken, "send_email", {
+        to: "alice@example.com",
+        fromAddress: OTHER,
+        subject: "Nope",
+        bodyHtml: "<p>Nope</p>",
+      });
+      expect(out.isError).toBe(true);
+      expect(out.text).toContain("Inbox not allowed");
+      const after = await getDb().select().from(sentEmails);
+      expect(after).toHaveLength(before.length);
+    });
+
+    it("rejects a recipient that is not an address", async () => {
+      const out = await callTool(memberToken, "send_email", {
+        to: "Bob Smith",
+        fromAddress: MINE,
+        subject: "Hi",
+        bodyHtml: "<p>Hi</p>",
+      });
+      expect(out.isError).toBe(true);
+    });
+
+    it("replies to a message in an allowed inbox", async () => {
+      const out = await callTool(memberToken, "reply_email", {
+        emailId: "e-mine",
+        fromAddress: MINE,
+        bodyHtml: "<p>replying</p>",
+      });
+      expect(out.isError, out.text).toBe(false);
+    });
+
+    it("reports a reply target in another inbox as not found", async () => {
+      const out = await callTool(memberToken, "reply_email", {
+        emailId: "e-other",
+        fromAddress: MINE,
+        bodyHtml: "<p>replying</p>",
+      });
+      expect(out.isError).toBe(true);
+      // Must not confirm the message exists in an inbox the caller can't see.
+      expect(out.text).toContain("Not found");
     });
   });
 

--- a/worker/src/__tests__/mcp-tools.test.ts
+++ b/worker/src/__tests__/mcp-tools.test.ts
@@ -239,6 +239,7 @@ describe("MCP tools", () => {
         emailId: "e-other",
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
     });
 
     it("refuses a sent message from another inbox", async () => {
@@ -246,6 +247,7 @@ describe("MCP tools", () => {
         emailId: "s-other",
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
     });
   });
 
@@ -281,6 +283,7 @@ describe("MCP tools", () => {
         isRead: true,
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
 
       const row = await getDb()
         .select({ isRead: emails.isRead })
@@ -308,6 +311,7 @@ describe("MCP tools", () => {
         emailId: "e-other",
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
       const rows = await getDb()
         .select()
         .from(emails)
@@ -322,6 +326,7 @@ describe("MCP tools", () => {
       const out = await callTool(memberToken, "delete_email", {
         emailId: "s-other",
       });
+      expect(out.text).toContain("Not found");
       expect(out.isError).toBe(true);
       const rows = await getDb()
         .select()
@@ -488,6 +493,7 @@ describe("MCP tools", () => {
         variables: { name: "Alice" },
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Inbox not allowed");
 
       const rows = await getDb()
         .select()
@@ -561,6 +567,7 @@ describe("MCP tools", () => {
         fromAddress: OTHER,
       });
       expect(out.isError).toBe(true);
+      expect(out.text).toContain("Inbox not allowed");
 
       const rows = await getDb().select().from(sequenceEnrollments);
       expect(rows).toHaveLength(0);

--- a/worker/src/auth/index.ts
+++ b/worker/src/auth/index.ts
@@ -24,6 +24,19 @@ export function createAuth(env?: CloudflareBindings) {
   const db = env ? drizzle(env.DB, { schema, logger: true }) : ({} as any);
   const baseURL = env?.BASE_URL || "http://localhost:8080";
 
+  // Fail closed rather than silently signing with better-auth's published
+  // default. The library only *warns* when the secret is missing, and its
+  // NODE_ENV check does not fire on Workers — so an operator who upgrades
+  // without setting the secret would come up issuing OAuth tokens anyone can
+  // forge. `env` is undefined only under the schema-generation CLI, which
+  // never signs anything.
+  if (env && !env.BETTER_AUTH_SECRET) {
+    throw new Error(
+      "BETTER_AUTH_SECRET is not set. Run `wrangler secret put BETTER_AUTH_SECRET` " +
+        "(or add it to .dev.vars) — it signs sessions and protects the OAuth signing keys.",
+    );
+  }
+
   return betterAuth({
     baseURL,
     // Passed explicitly: better-auth resolves this from `process.env`, which

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -24,6 +24,7 @@ import { setupRouter } from "./routers/setup-router";
 import { emailTemplatesRouter } from "./routers/email-templates-router";
 import { adminRouter } from "./routers/admin-router";
 import { adminInboxesRouter } from "./routers/admin-inboxes-router";
+import { oauthAppsRouter } from "./routers/oauth-apps-router";
 import { invitesRouter } from "./routers/invites-router";
 import { userRouter } from "./routers/user-router";
 import { apiKeysRouter } from "./routers/api-keys-router";
@@ -246,6 +247,13 @@ app.route("/api/outbox", outboxRouter);
 app.use("/api/admin/*", requireAdmin);
 app.route("/api/admin", adminRouter);
 app.route("/api/admin/inboxes", adminInboxesRouter);
+
+// Registered OAuth clients. Admin-only: registration is open to any caller so
+// MCP clients can self-register, which makes an operator-visible list and a
+// revocation path the control that actually bounds it.
+app.use("/api/oauth-apps", requireAdmin);
+app.use("/api/oauth-apps/*", requireAdmin);
+app.route("/api/oauth-apps", oauthAppsRouter);
 
 // Suppressions CRUD — admin-only (not under /api/admin/ for UX but enforced
 // here with the same role guard).

--- a/worker/src/lib/delete-email.ts
+++ b/worker/src/lib/delete-email.ts
@@ -4,14 +4,10 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { attachments } from "../db/attachments.schema";
 import { people } from "../db/people.schema";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import type { AllowedInboxes } from "./inbox-permissions";
+import { isInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
 
 /** Grants deletion of any email. For system callers (e.g. blocklist purge). */
 export const SYSTEM_INBOX_ACCESS: AllowedInboxes = { isAdmin: true };
-
-function isInboxAllowed(allowed: AllowedInboxes, inbox: string): boolean {
-  return allowed.isAdmin || allowed.inboxes.includes(inbox.toLowerCase());
-}
 
 /**
  * Hard delete an email (received or sent) and all associated R2 attachments.
@@ -86,9 +82,23 @@ export async function deleteEmailWithAttachments(
 
   if (sent.length > 0) {
     if (!isInboxAllowed(allowed, sent[0].fromAddress)) return null;
-    // Sent emails don't have attachments in the current schema
+
+    // Outbound messages DO carry attachments — the send path writes rows with
+    // kind "sent" keyed on the sent_emails id. Skipping them here orphaned the
+    // rows and leaked their R2 objects forever, while reporting success on a
+    // "permanent" delete.
+    const atts = await db
+      .select({ r2Key: attachments.r2Key })
+      .from(attachments)
+      .where(eq(attachments.emailId, emailId));
+
+    for (const att of atts) {
+      await r2.delete(att.r2Key);
+    }
+    await db.delete(attachments).where(eq(attachments.emailId, emailId));
     await db.delete(sentEmails).where(eq(sentEmails.id, emailId));
-    return { success: true, attachmentsDeleted: 0 };
+
+    return { success: true, attachmentsDeleted: atts.length };
   }
 
   return null;

--- a/worker/src/lib/inbox-permissions.ts
+++ b/worker/src/lib/inbox-permissions.ts
@@ -38,16 +38,44 @@ export function inboxFilter(
   return inArray(column, allowed.inboxes);
 }
 
+/**
+ * The single "may this caller act on this address?" predicate.
+ *
+ * Normalization lives here and nowhere else. `allowed.inboxes` is lowercased at
+ * resolution time, but stored `recipient` / `from_address` values may be mixed
+ * case from before insert-time canonicalization, so the address is folded too.
+ *
+ * Call this rather than reaching into `allowed.inboxes` directly: hand-rolled
+ * `allowed.inboxes.includes(x)` copies previously drifted apart, leaving a row
+ * a member could delete but not read.
+ */
+export function isInboxAllowed(
+  allowed: AllowedInboxes,
+  email: string,
+): boolean {
+  return allowed.isAdmin || allowed.inboxes.includes(email.toLowerCase());
+}
+
 export function assertInboxAllowed(
   allowed: AllowedInboxes,
   email: string,
 ): void {
-  if (allowed.isAdmin) return;
-  // Compare lowercased so a member who registered `Support@x.com` in
-  // permissions still passes when the route asserts `support@x.com`
-  // (callers now canonicalize inputs at the boundary, but be
-  // defensive in case future callers don't).
-  if (!allowed.inboxes.includes(email.toLowerCase())) {
+  if (!isInboxAllowed(allowed, email)) {
     throw new HTTPException(403, { message: "Inbox not allowed" });
   }
+}
+
+/**
+ * Scope fragment for raw-SQL queries, as a spliceable `AND ...` chunk.
+ *
+ * `inboxFilter` covers Drizzle query builders; this covers the hand-written
+ * `sql` templates. Both must agree, and in particular both must express the
+ * empty-grant case as a false predicate — an empty list renders `IN ()`, which
+ * SQLite rejects outright, so forgetting that branch fails loudly at best and
+ * scopes nothing at worst.
+ */
+export function inboxScopeSql(allowed: AllowedInboxes, column: SQL): SQL {
+  if (allowed.isAdmin) return sql``;
+  if (allowed.inboxes.length === 0) return sql`AND 0`;
+  return sql`AND ${column} IN ${allowed.inboxes}`;
 }

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -24,3 +24,34 @@ export function interpolate(
     return key in variables ? variables[key] : match;
   });
 }
+
+export type RenderTemplateResult =
+  | { ok: true; subject: string; bodyHtml: string }
+  | { ok: false; missingVariables: string[]; requiredVariables: string[] };
+
+/**
+ * Validate that every variable a template references was supplied, then
+ * interpolate its subject and body.
+ *
+ * Missing variables are reported rather than silently left as `{{token}}`
+ * so callers can fail the send instead of mailing a half-rendered template.
+ */
+export function renderTemplate(
+  template: { subject: string; bodyHtml: string },
+  variables: Record<string, string>,
+): RenderTemplateResult {
+  const subjectVars = extractVariables(template.subject);
+  const bodyVars = extractVariables(template.bodyHtml);
+  const requiredVariables = Array.from(new Set([...subjectVars, ...bodyVars]));
+  const missingVariables = requiredVariables.filter((v) => !(v in variables));
+
+  if (missingVariables.length > 0) {
+    return { ok: false, missingVariables, requiredVariables };
+  }
+
+  return {
+    ok: true,
+    subject: interpolate(template.subject, variables),
+    bodyHtml: interpolate(template.bodyHtml, variables),
+  };
+}

--- a/worker/src/lib/queries/emails.ts
+++ b/worker/src/lib/queries/emails.ts
@@ -6,7 +6,11 @@ import { senderIdentities } from "../../db/sender-identities.schema";
 import { attachments } from "../../db/attachments.schema";
 import { people } from "../../db/people.schema";
 import { escapeLike } from "../helpers";
-import { inboxFilter, type AllowedInboxes } from "../inbox-permissions";
+import {
+  inboxFilter,
+  type AllowedInboxes,
+  isInboxAllowed,
+} from "../inbox-permissions";
 
 export type CcEntry = { email: string; name?: string | null };
 
@@ -367,7 +371,7 @@ export async function getEmailById(
   const row = await db.select().from(emails).where(eq(emails.id, id)).limit(1);
 
   if (row.length > 0) {
-    if (!allowed.isAdmin && !allowed.inboxes.includes(row[0].recipient)) {
+    if (!isInboxAllowed(allowed, row[0].recipient)) {
       return null;
     }
     const atts = await db
@@ -408,7 +412,7 @@ export async function getEmailById(
 
   // Authorization mirrors the reply route's defense-in-depth — only
   // surface a sent row to a caller who still owns the inbox that sent it.
-  if (!allowed.isAdmin && !allowed.inboxes.includes(sentRow[0].fromAddress)) {
+  if (!isInboxAllowed(allowed, sentRow[0].fromAddress)) {
     return null;
   }
 
@@ -462,7 +466,7 @@ export async function setEmailRead(
     return null;
   }
 
-  if (!allowed.isAdmin && !allowed.inboxes.includes(email[0].recipient)) {
+  if (!isInboxAllowed(allowed, email[0].recipient)) {
     return null;
   }
 

--- a/worker/src/lib/queries/people.ts
+++ b/worker/src/lib/queries/people.ts
@@ -3,7 +3,7 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { people } from "../../db/people.schema";
 import { emails } from "../../db/emails.schema";
 import { escapeLike } from "../helpers";
-import type { AllowedInboxes } from "../inbox-permissions";
+import { inboxScopeSql, type AllowedInboxes } from "../inbox-permissions";
 
 export type PersonRow = typeof people.$inferSelect;
 
@@ -82,11 +82,17 @@ export async function listPeople(
   }
 
   const scopeClause = peopleScopeClause(allowed);
+  // `peopleScopeClause` decides WHICH PEOPLE are visible; it does not constrain
+  // which of their (person, inbox) pairs are. Without this second clause a
+  // contact who wrote to both an allowed inbox and a private one produced a row
+  // for the private inbox too — leaking its address, message counts, and
+  // latestSubject to a member who cannot read any of its mail.
+  const recipientScope = inboxScopeSql(allowed, sql`e.recipient`);
   const extraConditions =
     conditions.length > 0
       ? sql`AND ${sql.join(conditions, sql` AND `)}`
       : sql``;
-  const whereClause = sql`WHERE 1=1 ${extraConditions} ${scopeClause}`;
+  const whereClause = sql`WHERE 1=1 ${extraConditions} ${scopeClause} ${recipientScope}`;
 
   // Group by (person, recipient) to get per-thread stats
   const rows = await db.all<PersonListRow>(sql`

--- a/worker/src/lib/queries/search.ts
+++ b/worker/src/lib/queries/search.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import type { AllowedInboxes } from "../inbox-permissions";
+import { inboxScopeSql, type AllowedInboxes } from "../inbox-permissions";
 import { escapeFts, escapeLike } from "../helpers";
 
 export type SearchEmailsOptions = {
@@ -36,7 +36,22 @@ export type SearchEmailsResult = {
   hits: SearchHit[];
   /** True when more rows exist past `limit`. */
   hasMore: boolean;
+  /**
+   * True when the result set was clipped at MAX_SCAN. The caller should narrow
+   * the query rather than page further — later pages are not reachable.
+   */
+  truncated: boolean;
 };
+
+/**
+ * Hard ceiling on rows pulled from either table for one search.
+ *
+ * Both queries fetch whole bodies, and the merge happens in the isolate, so an
+ * unbounded `offset + limit` would let a caller ask for page 5000 and drag the
+ * entire matching corpus through D1 into memory to return nothing. Refining a
+ * query is the right move for a text search; deep paging is not.
+ */
+const MAX_SCAN = 500;
 
 /** Collapse whitespace and clip, so a hit is scannable in a tool result. */
 function excerpt(body: string | null, max = 200): string | null {
@@ -64,32 +79,54 @@ export async function searchEmails(
 ): Promise<SearchEmailsResult> {
   const { q, inbox, personId, after, before, limit, offset } = opts;
 
-  // Nothing is visible to a member with no inbox grants.
+  // Nothing is visible to a member with no inbox grants. This branch is
+  // load-bearing, not defensive: `IN ()` is a SQLite syntax error, so the
+  // scope fragments below cannot express "match nothing" for an empty list.
   if (!allowed.isAdmin && allowed.inboxes.length === 0) {
-    return { hits: [], hasMore: false };
+    return { hits: [], hasMore: false, truncated: false };
+  }
+
+  // Beyond the scan ceiling there is nothing left to page through.
+  if (offset >= MAX_SCAN) {
+    return { hits: [], hasMore: false, truncated: true };
   }
 
   // Over-fetch by one so `hasMore` is known without a COUNT.
-  const window = offset + limit + 1;
+  const window = Math.min(offset + limit + 1, MAX_SCAN);
 
   const ftsQuery = escapeFts(q);
   const likePattern = `%${escapeLike(q)}%`;
 
-  const receivedScope = allowed.isAdmin
-    ? sql``
-    : sql`AND e.recipient IN ${allowed.inboxes}`;
-  const sentScope = allowed.isAdmin
-    ? sql``
-    : sql`AND se.from_address IN ${allowed.inboxes}`;
+  const receivedScope = inboxScopeSql(allowed, sql`e.recipient`);
+  const sentScope = inboxScopeSql(allowed, sql`se.from_address`);
 
-  const receivedInbox = inbox ? sql`AND e.recipient = ${inbox}` : sql``;
-  const sentInbox = inbox ? sql`AND se.from_address = ${inbox}` : sql``;
-  const receivedPerson = personId ? sql`AND e.person_id = ${personId}` : sql``;
-  const sentPerson = personId ? sql`AND se.person_id = ${personId}` : sql``;
-  const receivedAfter = after ? sql`AND e.received_at >= ${after}` : sql``;
-  const receivedBefore = before ? sql`AND e.received_at <= ${before}` : sql``;
-  const sentAfter = after ? sql`AND se.sent_at >= ${after}` : sql``;
-  const sentBefore = before ? sql`AND se.sent_at <= ${before}` : sql``;
+  // `!== undefined` rather than truthiness: 0 is a legitimate Unix timestamp
+  // bound, and `""` should not silently widen an inbox filter to everything.
+  const receivedInbox =
+    inbox !== undefined ? sql`AND e.recipient = ${inbox}` : sql``;
+  const sentInbox =
+    inbox !== undefined ? sql`AND se.from_address = ${inbox}` : sql``;
+  const receivedPerson =
+    personId !== undefined ? sql`AND e.person_id = ${personId}` : sql``;
+  const sentPerson =
+    personId !== undefined ? sql`AND se.person_id = ${personId}` : sql``;
+  const receivedAfter =
+    after !== undefined ? sql`AND e.received_at >= ${after}` : sql``;
+  const receivedBefore =
+    before !== undefined ? sql`AND e.received_at <= ${before}` : sql``;
+  const sentAfter =
+    after !== undefined ? sql`AND se.sent_at >= ${after}` : sql``;
+  const sentBefore =
+    before !== undefined ? sql`AND se.sent_at <= ${before}` : sql``;
+
+  // Blocking a sender is expected to hide their existing mail, not merely stop
+  // new mail — the web UI filters these out, so search must too or an
+  // assistant resurfaces exactly the correspondence a user blocked.
+  const notBlocked = sql`AND NOT EXISTS (
+    SELECT 1 FROM blocklist b
+    WHERE (b.type = 'email'  AND b.value = p.email)
+       OR (b.type = 'domain' AND b.value = lower(substr(p.email, instr(p.email, '@') + 1)))
+  )`;
 
   const receivedRows = await db.all<{
     id: string;
@@ -110,8 +147,8 @@ export async function searchEmails(
     LEFT JOIN people p ON p.id = e.person_id
     WHERE emails_fts MATCH ${ftsQuery}
       ${receivedScope} ${receivedInbox} ${receivedPerson}
-      ${receivedAfter} ${receivedBefore}
-    ORDER BY e.received_at DESC
+      ${receivedAfter} ${receivedBefore} ${notBlocked}
+    ORDER BY e.received_at DESC, e.id DESC
     LIMIT ${window}
   `);
 
@@ -133,12 +170,14 @@ export async function searchEmails(
     WHERE (se.subject LIKE ${likePattern} ESCAPE '\\'
            OR se.body_text LIKE ${likePattern} ESCAPE '\\')
       ${sentScope} ${sentInbox} ${sentPerson}
-      ${sentAfter} ${sentBefore}
-    ORDER BY se.sent_at DESC
+      ${sentAfter} ${sentBefore} ${notBlocked}
+    ORDER BY se.sent_at DESC, se.id DESC
     LIMIT ${window}
   `);
 
-  const merged: SearchHit[] = [
+  type Row = Omit<SearchHit, "snippet"> & { body: string | null };
+
+  const merged: Row[] = [
     ...receivedRows.map((r) => ({
       id: r.id,
       type: "received" as const,
@@ -147,7 +186,7 @@ export async function searchEmails(
       personName: r.person_name,
       inbox: r.inbox,
       subject: r.subject,
-      snippet: excerpt(r.body_text),
+      body: r.body_text,
       timestamp: r.timestamp,
       isRead: r.is_read,
     })),
@@ -159,12 +198,25 @@ export async function searchEmails(
       personName: r.person_name,
       inbox: r.inbox,
       subject: r.subject,
-      snippet: excerpt(r.body_text),
+      body: r.body_text,
       timestamp: r.timestamp,
       isRead: null,
     })),
-  ].sort((a, b) => b.timestamp - a.timestamp);
+    // Tie-break on id so equal timestamps order identically on every call —
+    // bulk imports and sequence blasts produce many rows sharing a second, and
+    // an unstable order makes a message appear on two pages while another is
+    // never returned at all. Matches the SQL ORDER BY above.
+  ].sort((a, b) => b.timestamp - a.timestamp || (a.id < b.id ? 1 : -1));
 
-  const page = merged.slice(offset, offset + limit);
-  return { hits: page, hasMore: merged.length > offset + limit };
+  // Build excerpts only for the rows actually returned; doing it during the
+  // map above ran the whitespace regex over every fetched body.
+  const hits: SearchHit[] = merged
+    .slice(offset, offset + limit)
+    .map(({ body, ...rest }) => ({ ...rest, snippet: excerpt(body) }));
+
+  return {
+    hits,
+    hasMore: merged.length > offset + limit,
+    truncated: merged.length >= MAX_SCAN,
+  };
 }

--- a/worker/src/lib/queries/search.ts
+++ b/worker/src/lib/queries/search.ts
@@ -1,0 +1,170 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { AllowedInboxes } from "../inbox-permissions";
+import { escapeFts, escapeLike } from "../helpers";
+
+export type SearchEmailsOptions = {
+  /** Free-text query. Matched against subject and body. */
+  q: string;
+  /** Restrict to a single inbox address. */
+  inbox?: string;
+  /** Restrict to one contact. */
+  personId?: string;
+  /** Unix-seconds bounds on the message timestamp. */
+  after?: number;
+  before?: number;
+  limit: number;
+  offset: number;
+};
+
+export type SearchHit = {
+  id: string;
+  type: "received" | "sent";
+  personId: string | null;
+  personEmail: string | null;
+  personName: string | null;
+  /** The inbox this message belongs to: recipient in, fromAddress out. */
+  inbox: string;
+  subject: string | null;
+  /** Short excerpt of the body, for ranking by eye without a second call. */
+  snippet: string | null;
+  timestamp: number;
+  isRead: number | null;
+};
+
+export type SearchEmailsResult = {
+  hits: SearchHit[];
+  /** True when more rows exist past `limit`. */
+  hasMore: boolean;
+};
+
+/** Collapse whitespace and clip, so a hit is scannable in a tool result. */
+function excerpt(body: string | null, max = 200): string | null {
+  if (!body) return null;
+  const flat = body.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+/**
+ * Full-text search across a caller's mail.
+ *
+ * Received messages go through the `emails_fts` FTS5 index; sent messages have
+ * no FTS index, so they are matched with LIKE on subject and body. The two
+ * sides are merged and sorted in JS, the same shape `listPersonEmails` uses —
+ * SQLite cannot rank an FTS match and a LIKE scan against each other.
+ *
+ * There is no HTTP equivalent of this query: the app's only text search is
+ * person-grouped, inside GET /api/people/grouped. This returns message-level
+ * hits, which is what an assistant asking "find the mail about X" needs.
+ */
+export async function searchEmails(
+  db: DrizzleD1Database<any>,
+  opts: SearchEmailsOptions,
+  allowed: AllowedInboxes,
+): Promise<SearchEmailsResult> {
+  const { q, inbox, personId, after, before, limit, offset } = opts;
+
+  // Nothing is visible to a member with no inbox grants.
+  if (!allowed.isAdmin && allowed.inboxes.length === 0) {
+    return { hits: [], hasMore: false };
+  }
+
+  // Over-fetch by one so `hasMore` is known without a COUNT.
+  const window = offset + limit + 1;
+
+  const ftsQuery = escapeFts(q);
+  const likePattern = `%${escapeLike(q)}%`;
+
+  const receivedScope = allowed.isAdmin
+    ? sql``
+    : sql`AND e.recipient IN ${allowed.inboxes}`;
+  const sentScope = allowed.isAdmin
+    ? sql``
+    : sql`AND se.from_address IN ${allowed.inboxes}`;
+
+  const receivedInbox = inbox ? sql`AND e.recipient = ${inbox}` : sql``;
+  const sentInbox = inbox ? sql`AND se.from_address = ${inbox}` : sql``;
+  const receivedPerson = personId ? sql`AND e.person_id = ${personId}` : sql``;
+  const sentPerson = personId ? sql`AND se.person_id = ${personId}` : sql``;
+  const receivedAfter = after ? sql`AND e.received_at >= ${after}` : sql``;
+  const receivedBefore = before ? sql`AND e.received_at <= ${before}` : sql``;
+  const sentAfter = after ? sql`AND se.sent_at >= ${after}` : sql``;
+  const sentBefore = before ? sql`AND se.sent_at <= ${before}` : sql``;
+
+  const receivedRows = await db.all<{
+    id: string;
+    person_id: string | null;
+    person_email: string | null;
+    person_name: string | null;
+    inbox: string;
+    subject: string | null;
+    body_text: string | null;
+    timestamp: number;
+    is_read: number;
+  }>(sql`
+    SELECT e.id, e.person_id, p.email AS person_email, p.name AS person_name,
+           e.recipient AS inbox, e.subject, e.body_text,
+           e.received_at AS timestamp, e.is_read
+    FROM emails e
+    JOIN emails_fts ON e.rowid = emails_fts.rowid
+    LEFT JOIN people p ON p.id = e.person_id
+    WHERE emails_fts MATCH ${ftsQuery}
+      ${receivedScope} ${receivedInbox} ${receivedPerson}
+      ${receivedAfter} ${receivedBefore}
+    ORDER BY e.received_at DESC
+    LIMIT ${window}
+  `);
+
+  const sentRows = await db.all<{
+    id: string;
+    person_id: string | null;
+    person_email: string | null;
+    person_name: string | null;
+    inbox: string;
+    subject: string | null;
+    body_text: string | null;
+    timestamp: number;
+  }>(sql`
+    SELECT se.id, se.person_id, p.email AS person_email, p.name AS person_name,
+           se.from_address AS inbox, se.subject, se.body_text,
+           se.sent_at AS timestamp
+    FROM sent_emails se
+    LEFT JOIN people p ON p.id = se.person_id
+    WHERE (se.subject LIKE ${likePattern} ESCAPE '\\'
+           OR se.body_text LIKE ${likePattern} ESCAPE '\\')
+      ${sentScope} ${sentInbox} ${sentPerson}
+      ${sentAfter} ${sentBefore}
+    ORDER BY se.sent_at DESC
+    LIMIT ${window}
+  `);
+
+  const merged: SearchHit[] = [
+    ...receivedRows.map((r) => ({
+      id: r.id,
+      type: "received" as const,
+      personId: r.person_id,
+      personEmail: r.person_email,
+      personName: r.person_name,
+      inbox: r.inbox,
+      subject: r.subject,
+      snippet: excerpt(r.body_text),
+      timestamp: r.timestamp,
+      isRead: r.is_read,
+    })),
+    ...sentRows.map((r) => ({
+      id: r.id,
+      type: "sent" as const,
+      personId: r.person_id,
+      personEmail: r.person_email,
+      personName: r.person_name,
+      inbox: r.inbox,
+      subject: r.subject,
+      snippet: excerpt(r.body_text),
+      timestamp: r.timestamp,
+      isRead: null,
+    })),
+  ].sort((a, b) => b.timestamp - a.timestamp);
+
+  const page = merged.slice(offset, offset + limit);
+  return { hits: page, hasMore: merged.length > offset + limit };
+}

--- a/worker/src/lib/send-email.ts
+++ b/worker/src/lib/send-email.ts
@@ -1,0 +1,553 @@
+import { eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { nanoid } from "nanoid";
+import { attachments } from "../db/attachments.schema";
+import { emailTemplates } from "../db/email-templates.schema";
+import { emails } from "../db/emails.schema";
+import { people } from "../db/people.schema";
+import { senderIdentities } from "../db/sender-identities.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { cancelSequencesForPerson } from "./cancel-sequence";
+import { computeConversationId, externalsOnly } from "./conversation-id";
+import { createEmailSender } from "./email-sender";
+import { formatFromAddress } from "./format-from-address";
+import { assertInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
+import { renderTemplate } from "./interpolate";
+import { generateMessageId } from "./message-id";
+import type { ParsedFile } from "./multipart-send";
+import { sendViaOutbox, type OutboxOutcome } from "./outbox";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Db = DrizzleD1Database<any>;
+
+export type SendCcEntry = {
+  email: string;
+  name?: string | null;
+};
+
+export type SendEmailPayload = {
+  to: string;
+  fromAddress: string;
+  cc?: SendCcEntry[];
+  subject: string;
+  bodyHtml: string;
+  bodyText?: string;
+  replyTo?: string;
+  transactional?: boolean;
+};
+
+export type SendEmailParams = {
+  db: Db;
+  env: CloudflareBindings;
+  payload: SendEmailPayload;
+  files: ParsedFile[];
+  allowed: AllowedInboxes;
+};
+
+export type SendEmailSuccess = {
+  ok: true;
+  id: string | null;
+  resendId: string | null;
+  status: OutboxOutcome;
+  attachmentIds: string[];
+  delivered: string[];
+  suppressed: string[];
+};
+
+// The compose path has no recoverable failure mode of its own: multipart
+// parse errors are handled before this runs, and a disallowed inbox throws
+// (HTTPException). Kept as a discriminated union so callers branch on `ok`
+// the same way they do for replies.
+export type SendEmailResult = SendEmailSuccess;
+
+export type ReplyEmailPayload = {
+  fromAddress: string;
+  bodyHtml?: string;
+  bodyText?: string;
+  cc?: SendCcEntry[];
+  templateSlug?: string;
+  variables?: Record<string, string>;
+  replyTo?: string;
+};
+
+export type ReplyEmailParams = {
+  db: Db;
+  env: CloudflareBindings;
+  emailId: string;
+  payload: ReplyEmailPayload;
+  files: ParsedFile[];
+  allowed: AllowedInboxes;
+};
+
+export type ReplyEmailSuccess = {
+  ok: true;
+  id: string;
+  resendId: string | null;
+  status: OutboxOutcome;
+  attachmentIds: string[];
+};
+
+export type ReplyEmailFailure =
+  | {
+      ok: false;
+      code:
+        | "PERSON_NOT_FOUND"
+        | "EMAIL_NOT_FOUND"
+        | "EMAIL_HAS_NO_PERSON"
+        | "TEMPLATE_NOT_FOUND"
+        | "MISSING_BODY";
+      message: string;
+    }
+  | {
+      ok: false;
+      code: "MISSING_VARIABLES";
+      message: string;
+      missingVariables: string[];
+      requiredVariables: string[];
+    };
+
+export type ReplyEmailResult = ReplyEmailSuccess | ReplyEmailFailure;
+
+/**
+ * Fetch the set of "internal" domains (domains owned by our
+ * sender_identities) for the current request — used to derive the
+ * external-only participant list when computing a conversation_id.
+ */
+async function fetchInternalDomains(db: Db): Promise<string[]> {
+  const rows = await db
+    .select({ email: senderIdentities.email })
+    .from(senderIdentities);
+  return Array.from(
+    new Set(
+      rows
+        .map((r: { email: string }) => {
+          const at = r.email.lastIndexOf("@");
+          return at === -1 ? "" : r.email.slice(at + 1).toLowerCase();
+        })
+        .filter(Boolean),
+    ),
+  ) as string[];
+}
+
+async function persistSentAttachments(
+  db: Db,
+  env: CloudflareBindings,
+  sentEmailId: string,
+  files: ParsedFile[],
+  now: number,
+): Promise<string[]> {
+  if (files.length === 0) return [];
+  const rows = files.map((f) => {
+    const attachmentId = nanoid();
+    const r2Key = `attachments/sent/${sentEmailId}/${attachmentId}/${f.filename}`;
+    return { attachmentId, r2Key, file: f };
+  });
+  await Promise.all(
+    rows.map((r) =>
+      env.R2.put(r.r2Key, r.file.bytes, {
+        httpMetadata: { contentType: r.file.contentType },
+      }),
+    ),
+  );
+  await db.insert(attachments).values(
+    rows.map((r) => ({
+      id: r.attachmentId,
+      emailId: sentEmailId,
+      kind: "sent" as const,
+      filename: r.file.filename,
+      contentType: r.file.contentType,
+      size: r.file.size,
+      r2Key: r.r2Key,
+      contentId: null,
+      createdAt: now,
+    })),
+  );
+  return rows.map((r) => r.attachmentId);
+}
+
+/**
+ * Compose and send a new email, persisting attachments and the sent_emails
+ * row. Callers own multipart parsing and hand over the already-parsed
+ * payload plus attachment bytes.
+ *
+ * Only the inbox permission check throws (HTTPException), matching the
+ * routers' existing behavior.
+ */
+export async function sendEmail(
+  params: SendEmailParams,
+): Promise<SendEmailResult> {
+  const { db, env, payload: raw, files, allowed } = params;
+  const sender = createEmailSender(env);
+
+  const fromAddress = raw.fromAddress.trim().toLowerCase();
+  const to = raw.to.trim().toLowerCase();
+  const cc = raw.cc?.map((c) => ({
+    email: c.email.trim().toLowerCase(),
+    name: c.name ?? null,
+  }));
+  const { subject, bodyHtml, bodyText, transactional } = raw;
+  const replyTo = raw.replyTo?.trim().toLowerCase();
+  assertInboxAllowed(allowed, fromAddress);
+  const now = Math.floor(Date.now() / 1000);
+
+  const messageId = generateMessageId(fromAddress);
+  const formattedFrom = await formatFromAddress(db, fromAddress);
+
+  const attachmentList =
+    files.length > 0
+      ? files.map((f) => ({
+          filename: f.filename,
+          contentType: f.contentType,
+          content: f.bytes,
+        }))
+      : undefined;
+
+  const id = nanoid();
+  const { outcome, send: sendResult } = await sendViaOutbox({
+    db,
+    env,
+    sender,
+    sentEmailId: id,
+    fromAddress,
+    from: formattedFrom,
+    to,
+    cc,
+    subject,
+    html: bodyHtml,
+    text: bodyText,
+    headers: {
+      "Message-ID": messageId,
+      ...(replyTo ? { "Reply-To": replyTo } : {}),
+    },
+    attachments: attachmentList,
+    transactional,
+  });
+
+  // Every recipient was suppressed — no send happened. Skip sent_emails write,
+  // but still cancel any pending sequence enrollments for the recipient so we
+  // stop scheduling steps that will all individually re-suppress at dispatch.
+  if (sendResult.delivered.length === 0) {
+    const existingPerson = await db
+      .select({ id: people.id })
+      .from(people)
+      .where(eq(people.email, to))
+      .limit(1);
+    if (existingPerson[0]) {
+      await cancelSequencesForPerson(db, existingPerson[0].id);
+    }
+
+    console.log(
+      "[send] all recipients suppressed",
+      JSON.stringify({ from: fromAddress, suppressed: sendResult.suppressed }),
+    );
+    return {
+      ok: true,
+      id: null,
+      resendId: null,
+      status: "suppressed",
+      attachmentIds: [],
+      delivered: [],
+      suppressed: sendResult.suppressed,
+    };
+  }
+
+  // The transport was called; reflect its result in sent_emails.
+  // When the primary `to` was suppressed, the helper promoted a surviving cc
+  // to be the actual primary recipient. Use that for audit + person lookup so
+  // the row reflects who actually got the email.
+  const recordedTo = sendResult.delivered[0];
+
+  // Find or create the person row for the actual recipient.
+  const existingPerson = await db
+    .select({ id: people.id })
+    .from(people)
+    .where(eq(people.email, recordedTo))
+    .limit(1);
+
+  let personId: string;
+  if (existingPerson[0]) {
+    personId = existingPerson[0].id;
+  } else {
+    personId = nanoid();
+    await db
+      .insert(people)
+      .values({
+        id: personId,
+        email: recordedTo,
+        name: null,
+        lastEmailAt: now,
+        unreadCount: 0,
+        totalCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing({ target: people.email });
+    const refetched = await db
+      .select({ id: people.id })
+      .from(people)
+      .where(eq(people.email, recordedTo))
+      .limit(1);
+    personId = refetched[0]!.id;
+  }
+
+  const internalDomains = await fetchInternalDomains(db);
+  const externals = externalsOnly(
+    [recordedTo, ...(cc ?? []).map((c) => c.email)],
+    internalDomains,
+  );
+  const conversationId = await computeConversationId(fromAddress, externals);
+
+  await db.insert(sentEmails).values({
+    id,
+    personId,
+    fromAddress,
+    toAddress: recordedTo,
+    subject,
+    bodyHtml: sendResult.renderedHtml ?? bodyHtml,
+    bodyText: sendResult.renderedText ?? bodyText ?? null,
+    messageId,
+    resendId: sendResult.result?.id ?? null,
+    status: outcome,
+    cc: cc && cc.length > 0 ? JSON.stringify(cc) : null,
+    conversationId,
+    sentAt: now,
+    createdAt: now,
+  });
+
+  // Persist attachments even on failure: a retrying/failed send must be able
+  // to reload its attachment bytes from R2 on a later attempt.
+  const attachmentIds = await persistSentAttachments(db, env, id, files, now);
+
+  await cancelSequencesForPerson(db, personId);
+
+  return {
+    ok: true,
+    id,
+    resendId: sendResult.result?.id ?? null,
+    status: outcome,
+    attachmentIds,
+    delivered: sendResult.delivered,
+    suppressed: sendResult.suppressed,
+  };
+}
+
+/**
+ * Reply to an existing email — resolved across both the received and sent
+ * tables — threading the reply via In-Reply-To.
+ *
+ * Failure modes callers must surface are returned rather than thrown so this
+ * can back both the HTTP route and the MCP tool; only the inbox permission
+ * check throws (HTTPException), matching the routers' existing behavior.
+ */
+export async function replyToEmail(
+  params: ReplyEmailParams,
+): Promise<ReplyEmailResult> {
+  const { db, env, emailId, payload: raw, files, allowed } = params;
+  const sender = createEmailSender(env);
+
+  // Same canonicalization story as the send route — lowercase the
+  // inbox + recipient + CC emails before downstream use so stored
+  // rows match the lowercased conversation_id.
+  const fromAddress = raw.fromAddress.trim().toLowerCase();
+  const cc = raw.cc?.map((c) => ({
+    email: c.email.trim().toLowerCase(),
+    name: c.name ?? null,
+  }));
+  const { bodyHtml, bodyText, templateSlug, variables } = raw;
+  const replyTo = raw.replyTo?.trim().toLowerCase();
+  assertInboxAllowed(allowed, fromAddress);
+  const now = Math.floor(Date.now() / 1000);
+
+  // Resolve the original across both received and sent tables.
+  const receivedRow = await db
+    .select()
+    .from(emails)
+    .where(eq(emails.id, emailId))
+    .limit(1);
+
+  let origPersonId: string;
+  let origSubject: string | null;
+  let origInReplyToMessageId: string | null;
+  let toAddress: string;
+
+  if (receivedRow.length > 0) {
+    const orig = receivedRow[0];
+    // Mirror of the sent-row check below: only allow replies to messages
+    // delivered to an inbox the caller still owns. Without this a scoped user
+    // could thread a reply into a conversation they cannot read.
+    assertInboxAllowed(allowed, orig.recipient);
+    const person = await db
+      .select({ email: people.email })
+      .from(people)
+      .where(eq(people.id, orig.personId))
+      .limit(1);
+    if (person.length === 0) {
+      return {
+        ok: false,
+        code: "PERSON_NOT_FOUND",
+        message: "Person not found",
+      };
+    }
+    origPersonId = orig.personId;
+    origSubject = orig.subject ?? null;
+    origInReplyToMessageId = orig.messageId ?? null;
+    // Canonicalize the recipient — older rows may be mixed-case.
+    toAddress = person[0].email.toLowerCase();
+  } else {
+    const sentRow = await db
+      .select()
+      .from(sentEmails)
+      .where(eq(sentEmails.id, emailId))
+      .limit(1);
+    if (sentRow.length === 0) {
+      return { ok: false, code: "EMAIL_NOT_FOUND", message: "Email not found" };
+    }
+    const orig = sentRow[0];
+    // Defense-in-depth: only allow replies to sent rows whose original
+    // fromAddress the caller still owns. Prevents a user from threading a
+    // reply to another user's outgoing message via its id.
+    assertInboxAllowed(allowed, orig.fromAddress);
+    if (!orig.personId) {
+      return {
+        ok: false,
+        code: "EMAIL_HAS_NO_PERSON",
+        message: "Email has no associated person",
+      };
+    }
+    origPersonId = orig.personId;
+    origSubject = orig.subject ?? null;
+    origInReplyToMessageId = orig.messageId ?? null;
+    toAddress = orig.toAddress.toLowerCase();
+  }
+
+  // Determine subject and body
+  let finalSubject: string;
+  let finalBodyHtml: string;
+
+  if (templateSlug) {
+    // Template-based reply
+    const templateRows = await db
+      .select()
+      .from(emailTemplates)
+      .where(eq(emailTemplates.slug, templateSlug))
+      .limit(1);
+
+    if (templateRows.length === 0) {
+      return {
+        ok: false,
+        code: "TEMPLATE_NOT_FOUND",
+        message: "Template not found",
+      };
+    }
+
+    const rendered = renderTemplate(templateRows[0], variables ?? {});
+    if (!rendered.ok) {
+      return {
+        ok: false,
+        code: "MISSING_VARIABLES",
+        message: "Missing required template variables",
+        missingVariables: rendered.missingVariables,
+        requiredVariables: rendered.requiredVariables,
+      };
+    }
+
+    finalSubject = rendered.subject;
+    finalBodyHtml = rendered.bodyHtml;
+  } else if (bodyHtml) {
+    // Freeform reply
+    finalSubject = origSubject?.startsWith("Re: ")
+      ? origSubject
+      : `Re: ${origSubject || ""}`;
+    finalBodyHtml = bodyHtml;
+  } else {
+    return {
+      ok: false,
+      code: "MISSING_BODY",
+      message: "Either bodyHtml or templateSlug is required",
+    };
+  }
+
+  const messageId = generateMessageId(fromAddress);
+  const formattedFrom = await formatFromAddress(db, fromAddress);
+  // Replies are 1:1 conversational responses to an inbound — the recipient
+  // initiated by emailing first, so route through sendViaOutbox
+  // with transactional: true. That bypasses the suppression list AND skips
+  // the unsubscribe footer / List-Unsubscribe header (this is a reply, not
+  // a bulk send).
+  const id = nanoid();
+  const { outcome, send: sendResult } = await sendViaOutbox({
+    db,
+    env,
+    sender,
+    sentEmailId: id,
+    fromAddress,
+    from: formattedFrom,
+    to: toAddress,
+    cc,
+    subject: finalSubject,
+    html: finalBodyHtml,
+    ...(bodyText !== undefined ? { text: bodyText } : {}),
+    headers: {
+      "Message-ID": messageId,
+      ...(origInReplyToMessageId
+        ? { "In-Reply-To": origInReplyToMessageId }
+        : {}),
+      ...(replyTo ? { "Reply-To": replyTo } : {}),
+    },
+    ...(files.length > 0
+      ? {
+          attachments: files.map((f) => ({
+            filename: f.filename,
+            contentType: f.contentType,
+            content: f.bytes,
+          })),
+        }
+      : {}),
+    transactional: true,
+  });
+
+  // Compute conversation_id for this reply.
+  const internalDomainsReply = await fetchInternalDomains(db);
+  const externalsReply = externalsOnly(
+    [toAddress, ...(cc ?? []).map((c) => c.email)],
+    internalDomainsReply,
+  );
+  const conversationIdReply = await computeConversationId(
+    fromAddress,
+    externalsReply,
+  );
+
+  // Store sent email
+  await db.insert(sentEmails).values({
+    id,
+    personId: origPersonId,
+    fromAddress,
+    toAddress,
+    subject: finalSubject,
+    bodyHtml: finalBodyHtml,
+    bodyText: bodyText ?? null,
+    inReplyTo: origInReplyToMessageId,
+    messageId,
+    resendId: sendResult.result?.id ?? null,
+    status: outcome,
+    cc: cc && cc.length > 0 ? JSON.stringify(cc) : null,
+    conversationId: conversationIdReply,
+    sentAt: now,
+    createdAt: now,
+  });
+
+  // Persist attachments even on failure: a retrying/failed send must be able
+  // to reload its attachment bytes from R2 on a later attempt.
+  const attachmentIds = await persistSentAttachments(db, env, id, files, now);
+
+  // Cancel any active sequences for this person
+  await cancelSequencesForPerson(db, origPersonId);
+
+  return {
+    ok: true,
+    id,
+    resendId: sendResult.result?.id ?? null,
+    status: outcome,
+    attachmentIds,
+  };
+}

--- a/worker/src/lib/send-template.ts
+++ b/worker/src/lib/send-template.ts
@@ -7,7 +7,7 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { createEmailSender } from "./email-sender";
 import { formatFromAddress } from "./format-from-address";
 import { assertInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
-import { extractVariables, interpolate } from "./interpolate";
+import { renderTemplate } from "./interpolate";
 import { generateMessageId } from "./message-id";
 import { sendViaOutbox, type OutboxOutcome } from "./outbox";
 
@@ -71,26 +71,19 @@ export async function sendTemplate(
     };
   }
 
-  const template = rows[0];
-
-  // Validate all required variables are provided
-  const subjectVars = extractVariables(template.subject);
-  const bodyVars = extractVariables(template.bodyHtml);
-  const requiredVars = Array.from(new Set([...subjectVars, ...bodyVars]));
-  const missingVars = requiredVars.filter((v) => !(v in variables));
-
-  if (missingVars.length > 0) {
+  const rendered = renderTemplate(rows[0], variables);
+  if (!rendered.ok) {
     return {
       ok: false,
       code: "MISSING_VARIABLES",
       message: "Missing required template variables",
-      missingVariables: missingVars,
-      requiredVariables: requiredVars,
+      missingVariables: rendered.missingVariables,
+      requiredVariables: rendered.requiredVariables,
     };
   }
 
-  const renderedSubject = interpolate(template.subject, variables);
-  const renderedHtml = interpolate(template.bodyHtml, variables);
+  const renderedSubject = rendered.subject;
+  const renderedHtml = rendered.bodyHtml;
 
   const sender = createEmailSender(env);
   const id = nanoid();

--- a/worker/src/lib/send-template.ts
+++ b/worker/src/lib/send-template.ts
@@ -52,7 +52,14 @@ export type SendTemplateResult = SendTemplateSuccess | SendTemplateFailure;
 export async function sendTemplate(
   params: SendTemplateParams,
 ): Promise<SendTemplateResult> {
-  const { db, env, slug, to, fromAddress, variables, allowed } = params;
+  const { db, env, slug, variables, allowed } = params;
+
+  // Canonicalize before authorizing AND before storing, as the send routes do.
+  // assertInboxAllowed folds case, so `Support@x.com` passes — but persisting
+  // it verbatim produced a sent_emails row its own sender could not read back,
+  // since the read paths match against the lowercased grant list.
+  const fromAddress = params.fromAddress.trim().toLowerCase();
+  const to = params.to.trim().toLowerCase();
 
   assertInboxAllowed(allowed, fromAddress);
 

--- a/worker/src/mcp/http.ts
+++ b/worker/src/mcp/http.ts
@@ -112,6 +112,8 @@ export function registerMcpRoutes(app: App) {
         name: users.name,
         email: users.email,
         role: users.role,
+        banned: users.banned,
+        banExpires: users.banExpires,
       })
       .from(users)
       .where(eq(users.id, userId))
@@ -119,6 +121,14 @@ export function registerMcpRoutes(app: App) {
     // The user may have been deleted since the token was minted.
     if (rows.length === 0) return unauthorized(baseURL, "unknown user");
     const user = rows[0];
+
+    // Tokens are verified offline, so this row is the only thing that can
+    // revoke a live one. better-auth honours a ban on the session path; without
+    // this the MCP path would keep serving a banned user until the token
+    // expired, and keep refreshing it after that.
+    if (user.banned && (!user.banExpires || user.banExpires > new Date())) {
+      return unauthorized(baseURL, "account suspended");
+    }
 
     const allowed = await resolveAllowedInboxes(db, user);
     const scopes = parseScopes(jwt.scope ?? (jwt as { scp?: unknown }).scp);
@@ -152,10 +162,14 @@ async function verifyAccessTokenLocally(
   token: string,
   baseURL: string,
 ): Promise<JWTPayload> {
-  const auth = createAuth(env);
   return verifyJwsAccessToken(token, {
+    // Constructed inside the closure, not before the call: the JWKS is cached
+    // per isolate against JWKS_CACHE_KEY, so this runs about once every five
+    // minutes. Building a full betterAuth instance (Drizzle adapter + five
+    // plugins + endpoint table) eagerly would pay that cost on every request
+    // and discard it.
     jwksFetch: async () =>
-      (await auth.api.getJwks()) as unknown as JSONWebKeySet,
+      (await createAuth(env).api.getJwks()) as unknown as JSONWebKeySet,
     jwksCacheKey: JWKS_CACHE_KEY,
     verifyOptions: {
       issuer: oauthIssuer(baseURL),
@@ -170,15 +184,14 @@ async function verifyAccessTokenLocally(
  * well-known prefix plus the audience URL's pathname.
  */
 function unauthorized(baseURL: string, message: string): Response {
-  const audience = new URL(mcpAudience(baseURL));
-  const path = audience.pathname.endsWith("/")
-    ? audience.pathname.slice(0, -1)
-    : audience.pathname;
+  // Built from the same constant the route is registered on, so the challenge
+  // cannot drift from the path that actually serves the document.
+  const origin = new URL(baseURL).origin;
   return new Response(JSON.stringify({ error: message }), {
     status: 401,
     headers: {
       "Content-Type": "application/json",
-      "WWW-Authenticate": `Bearer resource_metadata="${audience.origin}/.well-known/oauth-protected-resource${path}"`,
+      "WWW-Authenticate": `Bearer resource_metadata="${origin}${PROTECTED_RESOURCE_METADATA_PATH}"`,
     },
   });
 }

--- a/worker/src/mcp/http.ts
+++ b/worker/src/mcp/http.ts
@@ -10,8 +10,9 @@ import { eq } from "drizzle-orm";
 import { createAuth } from "../auth";
 import { OAUTH_SCOPES } from "../auth";
 import { parseScopes } from "../auth/scopes";
-import { users } from "../db/auth.schema";
+import { users, passkeys, oauthClients } from "../db/auth.schema";
 import { resolveAllowedInboxes } from "../lib/inbox-permissions";
+import { isDevEnvironment } from "../lib/is-dev";
 import { buildMcpServer } from "./server";
 import {
   MCP_PATH,
@@ -106,6 +107,21 @@ export function registerMcpRoutes(app: App) {
     const userId = jwt.sub;
     if (!userId) return unauthorized(baseURL, "invalid token subject");
 
+    // Tokens verify offline against JWKS, so without this a revoked client
+    // would keep working until its token expired and could refresh past that.
+    // Checking `azp` (the authorized party, i.e. the client) on every call is
+    // what makes "revoke access at any time" true rather than aspirational.
+    const clientId = typeof jwt.azp === "string" ? jwt.azp : undefined;
+    if (!clientId) return unauthorized(baseURL, "invalid token client");
+    const client = await db
+      .select({ disabled: oauthClients.disabled })
+      .from(oauthClients)
+      .where(eq(oauthClients.clientId, clientId))
+      .limit(1);
+    if (client.length === 0 || client[0].disabled) {
+      return unauthorized(baseURL, "client revoked");
+    }
+
     const rows = await db
       .select({
         id: users.id,
@@ -128,6 +144,21 @@ export function registerMcpRoutes(app: App) {
     // expired, and keep refreshing it after that.
     if (user.banned && (!user.banExpires || user.banExpires > new Date())) {
       return unauthorized(baseURL, "account suspended");
+    }
+
+    // Same rule requirePasskey enforces on /api/*. /mcp sits outside that
+    // middleware, and MCP grants strictly more than the web API does (send and
+    // delete), so exempting it would make "passkey registration is required to
+    // access data" false for the most powerful surface.
+    if (!isDevEnvironment(c.env)) {
+      const pk = await db
+        .select({ id: passkeys.id })
+        .from(passkeys)
+        .where(eq(passkeys.userId, user.id))
+        .limit(1);
+      if (pk.length === 0) {
+        return unauthorized(baseURL, "passkey registration required");
+      }
     }
 
     const allowed = await resolveAllowedInboxes(db, user);

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -13,6 +13,7 @@ import {
   setEmailRead,
 } from "../lib/queries/emails";
 import { deleteEmailWithAttachments } from "../lib/delete-email";
+import { searchEmails } from "../lib/queries/search";
 
 export interface McpUser {
   id: string;
@@ -210,6 +211,55 @@ export function buildMcpServer(ctx: McpContext): McpServer {
     guard(ctx, SCOPE_READ, async ({ emailId }) => {
       const email = await getEmailById(db, emailId, allowed);
       return email ? ok(email) : fail(NOT_FOUND);
+    }),
+  );
+
+  server.registerTool(
+    "search_emails",
+    {
+      description:
+        "Full-text search across received and sent mail, newest first. Use this to find messages when you don't already know the contact — otherwise list_emails is cheaper. Returns a body excerpt per hit; call read_email for the full message.",
+      annotations: { readOnlyHint: true, title: "Search Emails" },
+      inputSchema: {
+        q: z
+          .string()
+          .min(1)
+          .describe("Words to search for in subject and body."),
+        inbox: z.string().optional().describe("Restrict to one inbox address."),
+        personId: z.string().optional().describe("Restrict to one contact."),
+        after: z
+          .number()
+          .int()
+          .optional()
+          .describe("Only messages at or after this Unix timestamp (seconds)."),
+        before: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            "Only messages at or before this Unix timestamp (seconds).",
+          ),
+        ...pagination,
+      },
+    },
+    guard(ctx, SCOPE_READ, async (input) => {
+      const limit = input.limit ?? 50;
+      const page = input.page ?? 1;
+      return ok(
+        await searchEmails(
+          db,
+          {
+            q: input.q,
+            inbox: input.inbox,
+            personId: input.personId,
+            after: input.after,
+            before: input.before,
+            limit,
+            offset: (page - 1) * limit,
+          },
+          allowed,
+        ),
+      );
     }),
   );
 

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -56,11 +56,12 @@ export function fail(message: string) {
  */
 function guard<Args extends unknown[]>(
   ctx: McpContext,
-  requiredScope: string,
+  /** null for tools every token may call regardless of granted scopes. */
+  requiredScope: string | null,
   run: (...args: Args) => Promise<ReturnType<typeof ok>>,
 ) {
   return async (...args: Args) => {
-    if (!hasScope(ctx.scopes, requiredScope)) {
+    if (requiredScope !== null && !hasScope(ctx.scopes, requiredScope)) {
       return fail(
         `This tool requires the "${requiredScope}" scope, which this token was not granted.`,
       );
@@ -68,8 +69,14 @@ function guard<Args extends unknown[]>(
     try {
       return await run(...args);
     } catch (e) {
+      // HTTPException is deliberate and safe to echo — it is our own
+      // permission message. Anything else is a bug, and its message may carry
+      // SQL fragments, column names, or stored row content. The MCP client is
+      // third-party software the operator never vetted, so log the detail and
+      // return an opaque failure.
       if (e instanceof HTTPException) return fail(e.message);
-      return fail(e instanceof Error ? e.message : String(e));
+      console.error("[mcp] tool failed:", e);
+      return fail("The request could not be completed.");
     }
   };
 }
@@ -103,7 +110,11 @@ export function buildMcpServer(ctx: McpContext): McpServer {
       annotations: { readOnlyHint: true, title: "Who Am I" },
       inputSchema: {},
     },
-    guard(ctx, SCOPE_READ, async () =>
+    // Deliberately ungated: this is the only way to discover a valid
+    // fromAddress, and both send tools tell the model to call it. Gating it on
+    // email:read would leave a least-privilege send-only token unable to send
+    // at all. It discloses nothing beyond the token's own identity and grants.
+    guard(ctx, null, async () =>
       ok({
         userId: ctx.user.id,
         name: ctx.user.name,
@@ -316,7 +327,7 @@ export function buildMcpServer(ctx: McpContext): McpServer {
       annotations: { readOnlyHint: false, title: "Send Template" },
       inputSchema: {
         slug: z.string().describe("Template slug."),
-        to: z.string().describe("Recipient email address."),
+        to: z.email().describe("Recipient email address."),
         fromAddress: z
           .string()
           .describe("Sender identity; must be one of your allowed inboxes."),
@@ -360,7 +371,7 @@ export function buildMcpServer(ctx: McpContext): McpServer {
       inputSchema: {
         sequenceId: z.string().describe("Sequence id."),
         personEmail: z
-          .string()
+          .email()
           .optional()
           .describe("Recipient address; the contact is created if new."),
         personId: z
@@ -387,6 +398,13 @@ export function buildMcpServer(ctx: McpContext): McpServer {
       },
     },
     guard(ctx, SCOPE_SEND, async (input) => {
+      // The HTTP route expresses this as a Zod .refine() on the whole object;
+      // an MCP inputSchema is a bare shape with no cross-field validation, so
+      // without this the lib would query `people.email = undefined` and then
+      // insert a row violating a NOT NULL constraint.
+      if (!input.personId && !input.personEmail) {
+        return fail("Provide either personEmail or personId.");
+      }
       const result = await enrollPersonInSequence({
         db,
         env: ctx.env,

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -6,6 +6,7 @@ import type { AllowedInboxes } from "../lib/inbox-permissions";
 import { SCOPE_READ, SCOPE_SEND, SCOPE_MANAGE, hasScope } from "../auth/scopes";
 import { sendTemplate } from "../lib/send-template";
 import { enrollPersonInSequence } from "../lib/enroll-sequence";
+import { sendEmail, replyToEmail } from "../lib/send-email";
 import { listPeople, getPersonScoped } from "../lib/queries/people";
 import {
   listPersonEmails,
@@ -357,6 +358,139 @@ export function buildMcpServer(ctx: McpContext): McpServer {
               `${result.message} Missing: ${result.missingVariables.join(", ")}. Required: ${result.requiredVariables.join(", ")}.`,
             )
           : fail(result.message);
+      }
+      return ok(result);
+    }),
+  );
+
+  const ccSchema = z
+    .array(z.object({ email: z.email(), name: z.string().max(200).optional() }))
+    .max(50)
+    .optional()
+    .describe("CC recipients.");
+
+  server.registerTool(
+    "send_email",
+    {
+      description:
+        "Compose and send a new message. fromAddress must be an inbox you may send from — call whoami to see which. Sending to a contact cancels any drip sequence they are enrolled in, since a direct message supersedes the automation.",
+      annotations: { readOnlyHint: false, title: "Send Email" },
+      inputSchema: {
+        to: z.email().describe("Recipient email address."),
+        fromAddress: z
+          .email()
+          .describe("Sender identity; must be one of your allowed inboxes."),
+        subject: z.string().describe("Subject line."),
+        bodyHtml: z.string().describe("HTML body."),
+        bodyText: z
+          .string()
+          .optional()
+          .describe(
+            "Plain-text alternative. Strongly recommended — messages without one are downranked by some providers.",
+          ),
+        cc: ccSchema,
+        replyTo: z
+          .email()
+          .optional()
+          .describe("Where replies should go, if not fromAddress."),
+      },
+    },
+    guard(ctx, SCOPE_SEND, async (input) => {
+      const result = await sendEmail({
+        db,
+        env: ctx.env,
+        // Attachments would mean base64 in the tool payload; omitted until
+        // there is a staged-upload path like the one taxspace uses.
+        files: [],
+        payload: {
+          to: input.to,
+          fromAddress: input.fromAddress,
+          subject: input.subject,
+          bodyHtml: input.bodyHtml,
+          bodyText: input.bodyText,
+          cc: input.cc,
+          replyTo: input.replyTo,
+        },
+        allowed,
+      });
+      return ok(result);
+    }),
+  );
+
+  server.registerTool(
+    "reply_email",
+    {
+      description:
+        "Reply to a message, threading correctly via its Message-ID. Works for received and sent messages. Provide either bodyHtml or a templateSlug with its variables.",
+      annotations: { readOnlyHint: false, title: "Reply To Email" },
+      inputSchema: {
+        emailId: z
+          .string()
+          .describe("Id of the message being replied to, from list_emails."),
+        fromAddress: z
+          .email()
+          .describe("Sender identity; must be one of your allowed inboxes."),
+        bodyHtml: z
+          .string()
+          .optional()
+          .describe("HTML body. Omit when using templateSlug."),
+        bodyText: z.string().optional().describe("Plain-text alternative."),
+        templateSlug: z
+          .string()
+          .optional()
+          .describe("Render this saved template instead of bodyHtml."),
+        variables: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe("Values for the template's placeholders."),
+        cc: ccSchema,
+        replyTo: z
+          .email()
+          .optional()
+          .describe("Override the reply-to address."),
+      },
+    },
+    guard(ctx, SCOPE_SEND, async (input) => {
+      // Check visibility through the same masked path read_email uses, before
+      // the send core asserts on the target's inbox. That assertion throws
+      // "Inbox not allowed", which would confirm the message exists somewhere
+      // the caller cannot see — a probe oracle the read tools deliberately
+      // close.
+      const target = await getEmailById(db, input.emailId, allowed);
+      if (!target) return fail(NOT_FOUND);
+
+      const result = await replyToEmail({
+        db,
+        env: ctx.env,
+        emailId: input.emailId,
+        files: [],
+        payload: {
+          fromAddress: input.fromAddress,
+          bodyHtml: input.bodyHtml,
+          bodyText: input.bodyText,
+          templateSlug: input.templateSlug,
+          variables: input.variables,
+          cc: input.cc,
+          replyTo: input.replyTo,
+        },
+        allowed,
+      });
+      if (!result.ok) {
+        // Denials on the referenced message are reported as not-found, matching
+        // read_email — the caller supplied an id, and confirming it exists in
+        // an inbox they cannot see would be a probe oracle.
+        if (
+          result.code === "EMAIL_NOT_FOUND" ||
+          result.code === "PERSON_NOT_FOUND" ||
+          result.code === "EMAIL_HAS_NO_PERSON"
+        ) {
+          return fail(NOT_FOUND);
+        }
+        return fail(
+          result.code === "MISSING_VARIABLES" && "missingVariables" in result
+            ? `${result.message} Missing: ${(result as { missingVariables: string[] }).missingVariables.join(", ")}.`
+            : result.message,
+        );
       }
       return ok(result);
     }),

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { eq, inArray, isNull, or } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { assertInboxAllowed } from "../lib/inbox-permissions";
+import { assertInboxAllowed, isInboxAllowed } from "../lib/inbox-permissions";
 import { emailTemplates } from "../db/email-templates.schema";
 import { json200Response, json201Response } from "../lib/helpers";
 import { extractVariables } from "../lib/interpolate";
@@ -144,7 +144,7 @@ emailTemplatesRouter.openapi(getTemplateRoute, async (c) => {
   }
   const allowed = c.get("allowedInboxes")!;
   if (!allowed.isAdmin && rows[0].fromAddress !== null) {
-    if (!allowed.inboxes.includes(rows[0].fromAddress)) {
+    if (!isInboxAllowed(allowed, rows[0].fromAddress)) {
       return c.json({ error: "Template not found" }, 404);
     }
   }

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -7,6 +7,7 @@ import { attachments } from "../db/attachments.schema";
 import { people } from "../db/people.schema";
 import { json200Response } from "../lib/helpers";
 import { deleteEmailWithAttachments } from "../lib/delete-email";
+import { isInboxAllowed } from "../lib/inbox-permissions";
 import {
   getEmailById,
   listPersonEmails,
@@ -273,8 +274,7 @@ emailsRouter.openapi(bulkPatchRoute, async (c) => {
       .limit(1);
 
     if (email.length === 0) continue;
-    if (!allowed.isAdmin && !allowed.inboxes.includes(email[0].recipient))
-      continue;
+    if (!isInboxAllowed(allowed, email[0].recipient)) continue;
 
     const wasRead = email[0].isRead === 1;
     if (wasRead !== isRead) {
@@ -499,7 +499,7 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
     .limit(1);
   if (recv.length > 0) {
     const target = recv[0];
-    if (!allowed.isAdmin && !allowed.inboxes.includes(target.recipient)) {
+    if (!isInboxAllowed(allowed, target.recipient)) {
       return c.json({ error: "Email not found" }, 404);
     }
     if (!destEmail) {
@@ -554,11 +554,11 @@ emailsRouter.openapi(reassignPersonRoute, async (c) => {
   }
   const sent = sentRow[0];
   // Authz: caller must own the inbox this message was sent from.
-  if (!allowed.isAdmin && !allowed.inboxes.includes(sent.fromAddress)) {
+  if (!isInboxAllowed(allowed, sent.fromAddress)) {
     return c.json({ error: "Email not found" }, 404);
   }
   // A new sending identity must be one the caller owns.
-  if (newFrom && !allowed.isAdmin && !allowed.inboxes.includes(newFrom)) {
+  if (newFrom && !isInboxAllowed(allowed, newFrom)) {
     return c.json({ error: "fromAddress must be one of your inboxes." }, 400);
   }
 

--- a/worker/src/routers/oauth-apps-router.ts
+++ b/worker/src/routers/oauth-apps-router.ts
@@ -1,0 +1,156 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { desc, eq, sql } from "drizzle-orm";
+import {
+  oauthClients,
+  oauthAccessTokens,
+  oauthRefreshTokens,
+  oauthConsents,
+} from "../db/auth.schema";
+import { json200Response } from "../lib/helpers";
+import { bearerSecurity } from "../lib/openapi-auth";
+import type { Variables } from "../variables";
+
+export const oauthAppsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const OAuthAppSchema = z.object({
+  clientId: z.string(),
+  name: z.string().nullable(),
+  uri: z.string().nullable(),
+  disabled: z.boolean(),
+  createdAt: z.number().nullable(),
+  activeTokens: z.number().openapi({
+    description: "Unexpired access tokens currently held by this client.",
+  }),
+  consentCount: z.number().openapi({
+    description: "Users who have granted this client access.",
+  }),
+});
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["OAuth Apps"],
+  security: bearerSecurity,
+  description:
+    "List OAuth clients registered against this instance, with how many users have consented and how many live tokens each holds. Registration is open to any caller (MCP clients self-register), so this is the surface for spotting one you don't recognise.",
+  responses: {
+    ...json200Response(z.array(OAuthAppSchema), "Registered OAuth clients"),
+  },
+});
+
+oauthAppsRouter.openapi(listRoute, async (c) => {
+  const db = c.get("db");
+  const now = Date.now();
+
+  const rows = await db
+    .select({
+      clientId: oauthClients.clientId,
+      name: oauthClients.name,
+      uri: oauthClients.uri,
+      disabled: oauthClients.disabled,
+      createdAt: oauthClients.createdAt,
+    })
+    .from(oauthClients)
+    .orderBy(desc(oauthClients.createdAt));
+
+  // Counted in one pass each rather than per client, so the list stays a
+  // constant number of round-trips as clients accumulate.
+  const tokenCounts = await db.all<{ client_id: string; n: number }>(sql`
+    SELECT client_id, COUNT(*) AS n FROM oauth_access_tokens
+    WHERE expires_at IS NULL OR expires_at > ${now}
+    GROUP BY client_id
+  `);
+  const consentCounts = await db.all<{ client_id: string; n: number }>(sql`
+    SELECT client_id, COUNT(*) AS n FROM oauth_consents GROUP BY client_id
+  `);
+
+  const tokensBy = new Map(tokenCounts.map((r) => [r.client_id, r.n]));
+  const consentsBy = new Map(consentCounts.map((r) => [r.client_id, r.n]));
+
+  return c.json(
+    rows.map((r) => ({
+      clientId: r.clientId,
+      name: r.name,
+      uri: r.uri,
+      disabled: Boolean(r.disabled),
+      createdAt: r.createdAt ? Number(r.createdAt) : null,
+      activeTokens: tokensBy.get(r.clientId) ?? 0,
+      consentCount: consentsBy.get(r.clientId) ?? 0,
+    })),
+    200,
+  );
+});
+
+const revokeRoute = createRoute({
+  method: "delete",
+  path: "/{clientId}",
+  tags: ["OAuth Apps"],
+  security: bearerSecurity,
+  description:
+    "Revoke an OAuth client: deletes its access tokens, refresh tokens, consents, and the client itself. Any MCP connection using it stops working on its next call.",
+  request: { params: z.object({ clientId: z.string() }) },
+  responses: {
+    ...json200Response(
+      z.object({
+        success: z.boolean(),
+        accessTokensRevoked: z.number(),
+        refreshTokensRevoked: z.number(),
+      }),
+      "Client revoked",
+    ),
+    404: {
+      description: "No such client",
+      content: {
+        "application/json": { schema: z.object({ error: z.string() }) },
+      },
+    },
+  },
+});
+
+oauthAppsRouter.openapi(revokeRoute, async (c) => {
+  const db = c.get("db");
+  const { clientId } = c.req.valid("param");
+
+  const existing = await db
+    .select({ clientId: oauthClients.clientId })
+    .from(oauthClients)
+    .where(eq(oauthClients.clientId, clientId))
+    .limit(1);
+  if (existing.length === 0) {
+    return c.json({ error: "Client not found" }, 404);
+  }
+
+  const access = await db
+    .select({ id: oauthAccessTokens.id })
+    .from(oauthAccessTokens)
+    .where(eq(oauthAccessTokens.clientId, clientId));
+  const refresh = await db
+    .select({ id: oauthRefreshTokens.id })
+    .from(oauthRefreshTokens)
+    .where(eq(oauthRefreshTokens.clientId, clientId));
+
+  // Tokens are verified offline against JWKS, so deleting rows does not by
+  // itself stop an access token before it expires. Removing the client is what
+  // actually cuts the connection off: the MCP path resolves the client on every
+  // call, and the refresh grant has nothing left to exchange against.
+  await db
+    .delete(oauthAccessTokens)
+    .where(eq(oauthAccessTokens.clientId, clientId));
+  await db
+    .delete(oauthRefreshTokens)
+    .where(eq(oauthRefreshTokens.clientId, clientId));
+  await db.delete(oauthConsents).where(eq(oauthConsents.clientId, clientId));
+  await db.delete(oauthClients).where(eq(oauthClients.clientId, clientId));
+
+  return c.json(
+    {
+      success: true,
+      accessTokensRevoked: access.length,
+      refreshTokensRevoked: refresh.length,
+    },
+    200,
+  );
+});

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -11,6 +11,7 @@ import {
   peopleScopeClause,
 } from "../lib/queries/people";
 import type { Variables } from "../variables";
+import { isInboxAllowed } from "../lib/inbox-permissions";
 
 export const peopleRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -738,7 +739,7 @@ peopleRouter.openapi(bulkMarkReadRoute, async (c) => {
   // inboxes; explicit `recipient` narrows further).
   const recipientScope = (() => {
     if (recipient) {
-      if (!allowed.isAdmin && !allowed.inboxes.includes(recipient)) {
+      if (!isInboxAllowed(allowed, recipient)) {
         return null; // not permitted
       }
       return [recipient];

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -1,23 +1,9 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq } from "drizzle-orm";
-import { nanoid } from "nanoid";
 import { createEmailSender } from "../lib/email-sender";
-import { sentEmails } from "../db/sent-emails.schema";
-import { people } from "../db/people.schema";
-import { emails } from "../db/emails.schema";
-import { senderIdentities } from "../db/sender-identities.schema";
 import { json201Response } from "../lib/helpers";
-import { cancelSequencesForPerson } from "../lib/cancel-sequence";
-import { emailTemplates } from "../db/email-templates.schema";
-import { interpolate, extractVariables } from "../lib/interpolate";
 import type { Variables } from "../variables";
-import { formatFromAddress } from "../lib/format-from-address";
-import { assertInboxAllowed } from "../lib/inbox-permissions";
-import { generateMessageId } from "../lib/message-id";
-import { computeConversationId, externalsOnly } from "../lib/conversation-id";
 import { parseSendBody, sendParseErrorResponse } from "../lib/multipart-send";
-import { attachments } from "../db/attachments.schema";
-import { sendViaOutbox } from "../lib/outbox";
+import { replyToEmail, sendEmail } from "../lib/send-email";
 import { bearerSecurity } from "../lib/openapi-auth";
 import {
   inboxForbiddenResponse,
@@ -25,34 +11,6 @@ import {
   replyNotFoundResponse,
   replyValidationErrorResponse,
 } from "../lib/openapi-send-errors";
-
-/**
- * Fetch the set of "internal" domains (domains owned by our
- * sender_identities) for the current request — used to derive the
- * external-only participant list when computing a conversation_id.
- */
-async function fetchInternalDomains(
-  db: ReturnType<typeof OpenAPIHono.prototype.notFound> extends never
-    ? unknown
-    : unknown,
-): Promise<string[]> {
-  // Loose typing — we just need .select() and .from() to work. The actual
-  // db value comes from c.get("db") which already has the correct type.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rows = await (db as any)
-    .select({ email: senderIdentities.email })
-    .from(senderIdentities);
-  return Array.from(
-    new Set(
-      rows
-        .map((r: { email: string }) => {
-          const at = r.email.lastIndexOf("@");
-          return at === -1 ? "" : r.email.slice(at + 1).toLowerCase();
-        })
-        .filter(Boolean),
-    ),
-  ) as string[];
-}
 
 export const sendRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -201,160 +159,24 @@ sendRouter.openapi(sendEmailRoute, async (c) => {
     const { status, body } = sendParseErrorResponse(parsed.err);
     return c.json(body, status);
   }
-  const { payload: raw, files } = parsed.value;
+  const { payload, files } = parsed.value;
 
-  const fromAddress = raw.fromAddress.trim().toLowerCase();
-  const to = raw.to.trim().toLowerCase();
-  const cc = raw.cc?.map((c) => ({
-    email: c.email.trim().toLowerCase(),
-    name: c.name ?? null,
-  }));
-  const { subject, bodyHtml, bodyText, transactional } = raw;
-  const replyTo = raw.replyTo?.trim().toLowerCase();
-  const allowed = c.get("allowedInboxes")!;
-  assertInboxAllowed(allowed, fromAddress);
-  const now = Math.floor(Date.now() / 1000);
-
-  const messageId = generateMessageId(fromAddress);
-  const formattedFrom = await formatFromAddress(db, fromAddress);
-
-  const attachmentList =
-    files.length > 0
-      ? files.map((f) => ({
-          filename: f.filename,
-          contentType: f.contentType,
-          content: f.bytes,
-        }))
-      : undefined;
-
-  const id = nanoid();
-  const { outcome, send: sendResult } = await sendViaOutbox({
+  const result = await sendEmail({
     db,
     env: c.env,
-    sender,
-    sentEmailId: id,
-    fromAddress,
-    from: formattedFrom,
-    to,
-    cc,
-    subject,
-    html: bodyHtml,
-    text: bodyText,
-    headers: {
-      "Message-ID": messageId,
-      ...(replyTo ? { "Reply-To": replyTo } : {}),
-    },
-    attachments: attachmentList,
-    transactional,
+    payload,
+    files,
+    allowed: c.get("allowedInboxes")!,
   });
-
-  // Every recipient was suppressed — no send happened. Skip sent_emails write,
-  // but still cancel any pending sequence enrollments for the recipient so we
-  // stop scheduling steps that will all individually re-suppress at dispatch.
-  if (sendResult.delivered.length === 0) {
-    const existingPerson = await db
-      .select({ id: people.id })
-      .from(people)
-      .where(eq(people.email, to))
-      .limit(1);
-    if (existingPerson[0]) {
-      await cancelSequencesForPerson(db, existingPerson[0].id);
-    }
-
-    console.log(
-      "[send] all recipients suppressed",
-      JSON.stringify({ from: fromAddress, suppressed: sendResult.suppressed }),
-    );
-    return c.json(
-      {
-        id: null,
-        resendId: null,
-        status: "suppressed",
-        attachmentIds: [],
-        delivered: [],
-        suppressed: sendResult.suppressed,
-      },
-      201,
-    );
-  }
-
-  // The transport was called; reflect its result in sent_emails.
-  // When the primary `to` was suppressed, the helper promoted a surviving cc
-  // to be the actual primary recipient. Use that for audit + person lookup so
-  // the row reflects who actually got the email.
-  const recordedTo = sendResult.delivered[0];
-
-  // Find or create the person row for the actual recipient.
-  const existingPerson = await db
-    .select({ id: people.id })
-    .from(people)
-    .where(eq(people.email, recordedTo))
-    .limit(1);
-
-  let personId: string;
-  if (existingPerson[0]) {
-    personId = existingPerson[0].id;
-  } else {
-    personId = nanoid();
-    await db
-      .insert(people)
-      .values({
-        id: personId,
-        email: recordedTo,
-        name: null,
-        lastEmailAt: now,
-        unreadCount: 0,
-        totalCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing({ target: people.email });
-    const refetched = await db
-      .select({ id: people.id })
-      .from(people)
-      .where(eq(people.email, recordedTo))
-      .limit(1);
-    personId = refetched[0]!.id;
-  }
-
-  const internalDomains = await fetchInternalDomains(db);
-  const externals = externalsOnly(
-    [recordedTo, ...(cc ?? []).map((c) => c.email)],
-    internalDomains,
-  );
-  const conversationId = await computeConversationId(fromAddress, externals);
-
-  await db.insert(sentEmails).values({
-    id,
-    personId,
-    fromAddress,
-    toAddress: recordedTo,
-    subject,
-    bodyHtml: sendResult.renderedHtml ?? bodyHtml,
-    bodyText: sendResult.renderedText ?? bodyText ?? null,
-    messageId,
-    resendId: sendResult.result?.id ?? null,
-    status: outcome,
-    cc: cc && cc.length > 0 ? JSON.stringify(cc) : null,
-    conversationId,
-    sentAt: now,
-    createdAt: now,
-  });
-
-  // Persist attachments even on failure: a retrying/failed send must be able
-  // to reload its attachment bytes from R2 on a later attempt.
-  const attachmentIds = await persistSentAttachments(db, c.env, id, files, now);
-
-  await cancelSequencesForPerson(db, personId);
 
   return c.json(
     {
-      id,
-      resendId: sendResult.result?.id ?? null,
-      status: outcome,
-      attachmentIds,
-      delivered: sendResult.delivered,
-      suppressed: sendResult.suppressed,
+      id: result.id,
+      resendId: result.resendId,
+      status: result.status,
+      attachmentIds: result.attachmentIds,
+      delivered: result.delivered,
+      suppressed: result.suppressed,
     },
     201,
   );
@@ -450,251 +272,41 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
     const { status, body } = sendParseErrorResponse(parsed.err);
     return c.json(body, status);
   }
-  const raw = parsed.value.payload;
-  const files = parsed.value.files;
-  // Same canonicalization story as the send route — lowercase the
-  // inbox + recipient + CC emails before downstream use so stored
-  // rows match the lowercased conversation_id.
-  const fromAddress = raw.fromAddress.trim().toLowerCase();
-  const cc = raw.cc?.map((c) => ({
-    email: c.email.trim().toLowerCase(),
-    name: c.name ?? null,
-  }));
-  const { bodyHtml, bodyText, templateSlug, variables } = raw;
-  const replyTo = raw.replyTo?.trim().toLowerCase();
-  const allowed = c.get("allowedInboxes")!;
-  assertInboxAllowed(allowed, fromAddress);
-  const now = Math.floor(Date.now() / 1000);
+  const { payload, files } = parsed.value;
 
-  // Resolve the original across both received and sent tables.
-  const receivedRow = await db
-    .select()
-    .from(emails)
-    .where(eq(emails.id, emailId))
-    .limit(1);
+  const result = await replyToEmail({
+    db,
+    env: c.env,
+    emailId,
+    payload,
+    files,
+    allowed: c.get("allowedInboxes")!,
+  });
 
-  let origPersonId: string;
-  let origSubject: string | null;
-  let origInReplyToMessageId: string | null;
-  let toAddress: string;
-
-  if (receivedRow.length > 0) {
-    const orig = receivedRow[0];
-    // Mirror of the sent-row check below: only allow replies to messages
-    // delivered to an inbox the caller still owns. Without this a scoped user
-    // could thread a reply into a conversation they cannot read.
-    assertInboxAllowed(allowed, orig.recipient);
-    const person = await db
-      .select({ email: people.email })
-      .from(people)
-      .where(eq(people.id, orig.personId))
-      .limit(1);
-    if (person.length === 0) {
-      return c.json({ error: "Person not found" }, 404);
-    }
-    origPersonId = orig.personId;
-    origSubject = orig.subject ?? null;
-    origInReplyToMessageId = orig.messageId ?? null;
-    // Canonicalize the recipient — older rows may be mixed-case.
-    toAddress = person[0].email.toLowerCase();
-  } else {
-    const sentRow = await db
-      .select()
-      .from(sentEmails)
-      .where(eq(sentEmails.id, emailId))
-      .limit(1);
-    if (sentRow.length === 0) {
-      return c.json({ error: "Email not found" }, 404);
-    }
-    const orig = sentRow[0];
-    // Defense-in-depth: only allow replies to sent rows whose original
-    // fromAddress the caller still owns. Prevents a user from threading a
-    // reply to another user's outgoing message via its id.
-    assertInboxAllowed(allowed, orig.fromAddress);
-    if (!orig.personId) {
-      return c.json({ error: "Email has no associated person" }, 404);
-    }
-    origPersonId = orig.personId;
-    origSubject = orig.subject ?? null;
-    origInReplyToMessageId = orig.messageId ?? null;
-    toAddress = orig.toAddress.toLowerCase();
-  }
-
-  // Determine subject and body
-  let finalSubject: string;
-  let finalBodyHtml: string;
-
-  if (templateSlug) {
-    // Template-based reply
-    const templateRows = await db
-      .select()
-      .from(emailTemplates)
-      .where(eq(emailTemplates.slug, templateSlug))
-      .limit(1);
-
-    if (templateRows.length === 0) {
-      return c.json({ error: "Template not found" }, 404);
-    }
-
-    const template = templateRows[0];
-    const vars = variables ?? {};
-
-    // Validate required variables
-    const subjectVars = extractVariables(template.subject);
-    const bodyVars = extractVariables(template.bodyHtml);
-    const requiredVars = Array.from(new Set([...subjectVars, ...bodyVars]));
-    const missingVars = requiredVars.filter((v) => !(v in vars));
-
-    if (missingVars.length > 0) {
+  if (!result.ok) {
+    if (result.code === "MISSING_VARIABLES") {
       return c.json(
         {
-          error: "Missing required template variables",
-          missingVariables: missingVars,
-          requiredVariables: requiredVars,
+          error: result.message,
+          missingVariables: result.missingVariables,
+          requiredVariables: result.requiredVariables,
         },
         400,
       );
     }
-
-    finalSubject = interpolate(template.subject, vars);
-    finalBodyHtml = interpolate(template.bodyHtml, vars);
-  } else if (bodyHtml) {
-    // Freeform reply
-    finalSubject = origSubject?.startsWith("Re: ")
-      ? origSubject
-      : `Re: ${origSubject || ""}`;
-    finalBodyHtml = bodyHtml;
-  } else {
-    return c.json(
-      { error: "Either bodyHtml or templateSlug is required" },
-      400,
-    );
+    if (result.code === "MISSING_BODY") {
+      return c.json({ error: result.message }, 400);
+    }
+    return c.json({ error: result.message }, 404);
   }
-
-  const messageId = generateMessageId(fromAddress);
-  const formattedFrom = await formatFromAddress(db, fromAddress);
-  // Replies are 1:1 conversational responses to an inbound — the recipient
-  // initiated by emailing first, so route through sendViaOutbox
-  // with transactional: true. That bypasses the suppression list AND skips
-  // the unsubscribe footer / List-Unsubscribe header (this is a reply, not
-  // a bulk send).
-  const id = nanoid();
-  const { outcome, send: sendResult } = await sendViaOutbox({
-    db,
-    env: c.env,
-    sender,
-    sentEmailId: id,
-    fromAddress,
-    from: formattedFrom,
-    to: toAddress,
-    cc,
-    subject: finalSubject,
-    html: finalBodyHtml,
-    ...(bodyText !== undefined ? { text: bodyText } : {}),
-    headers: {
-      "Message-ID": messageId,
-      ...(origInReplyToMessageId
-        ? { "In-Reply-To": origInReplyToMessageId }
-        : {}),
-      ...(replyTo ? { "Reply-To": replyTo } : {}),
-    },
-    ...(files.length > 0
-      ? {
-          attachments: files.map((f) => ({
-            filename: f.filename,
-            contentType: f.contentType,
-            content: f.bytes,
-          })),
-        }
-      : {}),
-    transactional: true,
-  });
-
-  // Compute conversation_id for this reply.
-  const internalDomainsReply = await fetchInternalDomains(db);
-  const externalsReply = externalsOnly(
-    [toAddress, ...(cc ?? []).map((c) => c.email)],
-    internalDomainsReply,
-  );
-  const conversationIdReply = await computeConversationId(
-    fromAddress,
-    externalsReply,
-  );
-
-  // Store sent email
-  await db.insert(sentEmails).values({
-    id,
-    personId: origPersonId,
-    fromAddress,
-    toAddress,
-    subject: finalSubject,
-    bodyHtml: finalBodyHtml,
-    bodyText: bodyText ?? null,
-    inReplyTo: origInReplyToMessageId,
-    messageId,
-    resendId: sendResult.result?.id ?? null,
-    status: outcome,
-    cc: cc && cc.length > 0 ? JSON.stringify(cc) : null,
-    conversationId: conversationIdReply,
-    sentAt: now,
-    createdAt: now,
-  });
-
-  // Persist attachments even on failure: a retrying/failed send must be able
-  // to reload its attachment bytes from R2 on a later attempt.
-  const attachmentIds = await persistSentAttachments(db, c.env, id, files, now);
-
-  // Cancel any active sequences for this person
-  await cancelSequencesForPerson(db, origPersonId);
 
   return c.json(
     {
-      id,
-      resendId: sendResult.result?.id ?? null,
-      status: outcome,
-      attachmentIds,
+      id: result.id,
+      resendId: result.resendId,
+      status: result.status,
+      attachmentIds: result.attachmentIds,
     },
     201,
   );
 });
-
-async function persistSentAttachments(
-  db: Variables["db"],
-  env: CloudflareBindings,
-  sentEmailId: string,
-  files: {
-    filename: string;
-    contentType: string;
-    bytes: Uint8Array;
-    size: number;
-  }[],
-  now: number,
-): Promise<string[]> {
-  if (files.length === 0) return [];
-  const rows = files.map((f) => {
-    const attachmentId = nanoid();
-    const r2Key = `attachments/sent/${sentEmailId}/${attachmentId}/${f.filename}`;
-    return { attachmentId, r2Key, file: f };
-  });
-  await Promise.all(
-    rows.map((r) =>
-      env.R2.put(r.r2Key, r.file.bytes, {
-        httpMetadata: { contentType: r.file.contentType },
-      }),
-    ),
-  );
-  await db.insert(attachments).values(
-    rows.map((r) => ({
-      id: r.attachmentId,
-      emailId: sentEmailId,
-      kind: "sent" as const,
-      filename: r.file.filename,
-      contentType: r.file.contentType,
-      size: r.file.size,
-      r2Key: r.r2Key,
-      contentId: null,
-      createdAt: now,
-    })),
-  );
-  return rows.map((r) => r.attachmentId);
-}

--- a/worker/src/routers/stats-router.ts
+++ b/worker/src/routers/stats-router.ts
@@ -4,7 +4,7 @@ import { people } from "../db/people.schema";
 import { emails } from "../db/emails.schema";
 import { senderIdentities } from "../db/sender-identities.schema";
 import { json200Response } from "../lib/helpers";
-import { inboxFilter } from "../lib/inbox-permissions";
+import { inboxFilter, isInboxAllowed } from "../lib/inbox-permissions";
 import type { Variables } from "../variables";
 
 export const statsRouter = new OpenAPIHono<{
@@ -81,7 +81,7 @@ statsRouter.openapi(statsRoute, async (c) => {
   const allIdentities = await db.select().from(senderIdentities);
   const identityRows = allowed.isAdmin
     ? allIdentities
-    : allIdentities.filter((r) => allowed.inboxes.includes(r.email));
+    : allIdentities.filter((r) => isInboxAllowed(allowed, r.email));
 
   return c.json(
     {


### PR DESCRIPTION
Completes the MCP tool surface (11 tools) and applies the findings from a multi-angle review of the whole stack.

> **Stacked on #205**, which is stacked on #204. Review/merge in order; each retargets after the one below lands.

## New tools

`send_email`, `reply_email` (`email:send`) and `search_emails` (`email:read`).

The send pair required splitting multipart parsing from the send core — `send-router.ts` drops from ~700 to ~312 lines, and the 4xx exits become discriminated codes the router maps back to the exact statuses it returned before. Attachments aren't exposed over MCP: that would mean base64 blobs in the tool payload, and a staged-upload handshake is the right shape for it.

`search_emails` is the one piece with no HTTP precedent — the app's only text search is person-grouped inside `GET /api/people/grouped`. Received mail uses the existing `emails_fts` index; sent mail has none, so it falls back to `LIKE` and the two merge in the isolate.

## Review findings fixed

Eight independent angles ran over the stack. Two I proved with failing tests before fixing:

**`list_people` leaked private inboxes.** `peopleScopeClause` decides which *people* are visible but never constrained `e.recipient`, so a contact who wrote to both an allowed inbox and a private one produced a row for the private one — its address, message counts, and `latestSubject`. Pre-existing in `people-router`; this stack promoted it to a tool.

**`delete_email` orphaned sent attachments.** The sent branch still claimed *"sent emails don't have attachments"*, but the send path writes rows with `kind: "sent"`. It reported success while leaving rows dangling and R2 objects forever.

Also: banned users kept MCP access; four spellings of the inbox check had drifted so a mixed-case row was deletable but not readable (now one `isInboxAllowed`); `sendTemplate` stored `fromAddress` verbatim after authorizing case-insensitively, producing rows its own sender couldn't read; `search_emails` skipped the blocklist the UI applies; `guard()` returned raw D1/JSON error text to the third-party client; falsy-zero dropped timestamp bounds; unbounded page depth could drag a whole corpus into memory; `ORDER BY` had no tiebreaker, so tied timestamps could show one message twice and another never; `enroll_sequence` lost the HTTP route's cross-field refinement; `whoami` was gated on `email:read` despite being how a send-only token discovers a valid `fromAddress`; and `createAuth` now throws rather than silently using better-auth's published default secret.

**One severe claim I refuted rather than fixed:** an angle argued the consent screen could display fewer scopes than it grants. `scope` is covered by the signature — tampering is rejected with `invalid_signature`. Kept as a regression test.

## Three policy decisions

**Passkey now enforced on `/mcp`.** Four angles flagged this: `requirePasskey` guards `/api/*` only, so a passwordless-signin user was blocked from the whole web API but could read, send, and delete over MCP.

**Client revocation is now real.** Adds admin-only `/api/oauth-apps` to list connected clients (with consent and live-token counts) and revoke one. Tokens verify offline, so deleting rows alone wouldn't stop a client — the MCP path now resolves the token's `azp` on every call. `ConsentPage` and the README already promised "revoke access at any time"; this is the first commit where that's true.

**Elevated scopes are called out at consent.** An assistant with mailbox access reads attacker-authored content by definition; `email:send` + `email:manage` turn a prompt injection into an outbound message or a deletion. Those two are visually separated with a warning, and the README recommends `email:read` alone for connectors.

## Verification

- **556 tests, 555 passing + 1 skipped** across 66 files; `yarn build` green.
- Strict typecheck over `worker/`: zero errors in new files (`yarn tsc --noEmit` at the root is a no-op — see #205).
- Test-suite weakness fixed too: `expect(out.isError).toBe(true)` passed for *any* error, so a scope regression would have satisfied tests meant to prove inbox scoping. Error assertions now pin down which error.

### Still open, deliberately

- Deep `search_emails` paging is capped at 500 rows (`truncated: true`); refining the query is the intended path.
- `listPersonEmails` still issues 7 sequential D1 round-trips with no LIMIT on the base selects — faithful to the pre-extraction handler, but now on a hotter path.
- `buildMcpServer` re-registers 11 tools per request; a descriptor table would let cross-cutting concerns (audit logging destructive calls) live in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)