### PR TITLE
ci: stop dependabot bumps from driving the product version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,17 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # `major`/`minor`/`patch` mean "product release impact" here: the
+    # pr-labels workflow requires exactly one of them, and release-drafter's
+    # version-resolver maps them to the next saasmail version. Dependabot's
+    # own semver labels reuse those names to mean "size of the dependency
+    # jump", so a routine action bump from v6 to v7 was resolving the next
+    # release as a major one. Pinning to `patch` satisfies the label gate
+    # while keeping dependency updates out of the product's version number.
+    # The size of the bump is still legible in the PR title.
+    labels:
+      - "dependencies"
+      - "patch"
     groups:
       radix-ui:
         patterns:
@@ -43,3 +54,7 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
+    # Same reasoning as npm above.
+    labels:
+      - "dependencies"
+      - "patch"


### PR DESCRIPTION
`major` / `minor` / `patch` already had two consumers in this repo:

- **`.github/workflows/pr-labels.yml`** requires exactly one of them on every PR (`valid-labels: "major, minor, patch"`)
- **`.github/release-drafter.yml`**'s `version-resolver` maps them to saasmail's next version

Dependabot emits the same three names to describe the size of the **dependency** jump. Two different meanings, one namespace.

## This was already live, not hypothetical

- `actions/setup-node` and `release-drafter` going **v6 → v7** arrived labelled `major`. Left alone, `version-resolver` would have resolved the next release as **saasmail v1.0.0** — because two CI actions bumped.
- Merged tiptap (#201) and cloudflare (#196) group bumps carry `minor`, which is why the current draft is **v0.12.0** rather than a patch release.

## The fix

Pin dependabot to a static `patch` label on both ecosystems. That:

- satisfies the required label gate (so dep PRs still pass CI)
- keeps dependency updates out of the product's version number
- leaves human PRs using all three labels exactly as before

The size of a dependency bump remains legible in the PR title (`bump X from 6 to 7`).

## Worth verifying after merge

If dependabot appends its own semver label *on top of* the configured list, a major bump would carry both `patch` and `major`, and `version-resolver` checks `major` first. The next major dependency PR will show whether the override is total. If it isn't, the fallback is namespacing the release labels as `release:*` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)