### PR TITLE
feat(inboxes): per-inbox forward destination (works around Outlook blocking Cloudflare Email Routing IPs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-inbox forwarding.** Admins can set an optional destination address per inbox on the **Inboxes** page (alongside display name, signature, mode, and members). Every message the inbox receives is re-sent to that address through the configured outbound provider. This exists because Cloudflare Email Routing's own forwarding rules relay from shared IPs that Outlook/Hotmail blocklist (`550 5.7.1 … S3150`), so those forwards bounce; re-sending leaves from different IPs and is DKIM-signed for your own domain. Copies are sent from the inbox address with the original sender in `Reply-To`. Off by default. Migration `0031`.
 - OpenAPI email responses: document `attachments` on `EmailSchema`, clarify `replyTo` is only populated on `GET /api/emails/{id}` for received messages.
 - OpenAPI `/doc`: register `SendEmailSchema`, `CcEntry`, and `ReplyEmailSchema` under `components.schemas` (including `transactional` and reply payload fields).
 - OpenAPI `/doc`: global auth documentation, `BearerAuth` security scheme, and `security` requirements on integrator-facing routes (`/api/send`, template send, sequence enroll, API keys).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,47 @@ Different inboxes call for different UX. Set each inbox to render as **Thread** 
 
 One deployment, one person timeline, but the interaction model matches the channel.
 
+### Per-Inbox Forwarding
+
+Give any inbox a **Forward to** address and every message it receives is re-sent to
+that address. Configured per inbox on the **Inboxes** page, right next to display
+name, signature, mode, and member permissions. Off by default.
+
+**Why not just use a Cloudflare Email Routing forwarding rule?** Because Email
+Routing relays forwarded mail from a shared IP pool that Outlook, Hotmail, and Live
+blocklist. Forwards to a Microsoft-hosted mailbox come back as:
+
+```
+permanent error (550): 5.7.1 Unfortunately, messages from [104.30.10.66] weren't
+sent. Please contact your Internet service provider since part of their network is
+on our block list (S3150).
+```
+
+That IP belongs to Cloudflare, not to you, so there is no delisting path. saasmail
+sidesteps it by sending the copy itself through your configured outbound provider —
+different IPs, and DKIM-signed for your own domain, so it authenticates cleanly.
+
+How the forwarded copy looks:
+
+- **From** the inbox address, with the original sender named in the display name
+  (`"Jane Customer (via Acme Support)" <support@acme.com>`). It cannot keep the
+  original `From:` — sending as `jane@example.com` from your infrastructure would
+  fail SPF and DMARC and get filtered harder than the block being avoided.
+- **Reply-To** the original sender, so replying reaches the customer.
+- Original `From` / `Date` / `Subject` / `Cc` and the SPF/DKIM/DMARC verdicts are
+  restated in a header block at the top of the body.
+- Attachments are included, up to your provider's size ceiling; anything too large
+  is named in the body rather than silently dropped. Inline images arrive as regular
+  attachments.
+- The original `Cc` recipients are **not** re-sent to — only the destination is.
+
+Forwarding is best-effort and never blocks inbound mail: it runs after the message
+is safely stored, and after the blocklist and duplicate checks, so blocked senders
+and duplicate deliveries are never forwarded. There is no retry — failures are
+logged. Loops are prevented three ways: an inbox can't forward to itself, can't
+forward to another inbox on the same instance, and any message already carrying the
+`X-SaaSMail-Forwarded-For` header is never forwarded again.
+
 ### Email Templates
 
 Create reusable HTML email templates with `{{variable}}` interpolation. Edit templates with a live HTML editor, preview rendered output, and send them via the API or the UI. Variables are automatically extracted and validated before sending. Templates are scoped to allowed inboxes.

--- a/migrations/0031_aspiring_caretaker.sql
+++ b/migrations/0031_aspiring_caretaker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sender_identities` ADD `forward_to` text;

--- a/migrations/meta/0031_snapshot.json
+++ b/migrations/meta/0031_snapshot.json
@@ -1,0 +1,2523 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8cacac14-3285-4d1f-a397-ffe59847d543",
+  "prevId": "c0837b98-c105-4979-9b52-ebf2d6cba7ee",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwkss": {
+      "name": "jwkss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_userId_idx": {
+          "name": "passkeys_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkeys_credentialID_idx": {
+          "name": "passkeys_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_email_at": {
+          "name": "last_email_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "people_last_email_at_idx": {
+          "name": "people_last_email_at_idx",
+          "columns": [
+            "last_email_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emails": {
+      "name": "emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spf": {
+          "name": "spf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dkim": {
+          "name": "dkim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dmarc": {
+          "name": "dmarc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "emails_message_id_unique": {
+          "name": "emails_message_id_unique",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "emails_person_received_idx": {
+          "name": "emails_person_received_idx",
+          "columns": [
+            "person_id",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_recipient_received_idx": {
+          "name": "emails_recipient_received_idx",
+          "columns": [
+            "recipient",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_conversation_idx": {
+          "name": "emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sent_emails": {
+      "name": "sent_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sent'"
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sent_emails_person_sent_idx": {
+          "name": "sent_emails_person_sent_idx",
+          "columns": [
+            "person_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_conversation_idx": {
+          "name": "sent_emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_from_sent_idx": {
+          "name": "sent_emails_from_sent_idx",
+          "columns": [
+            "from_address",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inbound'"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachments_email_id_idx": {
+          "name": "attachments_email_id_idx",
+          "columns": [
+            "email_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_templates_slug_unique": {
+          "name": "email_templates_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_used_by_users_id_fk": {
+          "name": "invitations_used_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_unique": {
+          "name": "api_keys_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequences": {
+      "name": "sequences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_enrollments": {
+      "name": "sequence_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrollments_person_status_idx": {
+          "name": "enrollments_person_status_idx",
+          "columns": [
+            "person_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "enrollments_sequence_status_idx": {
+          "name": "enrollments_sequence_status_idx",
+          "columns": [
+            "sequence_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_emails": {
+      "name": "sequence_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seq_emails_status_scheduled_idx": {
+          "name": "seq_emails_status_scheduled_idx",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "seq_emails_enrollment_id_idx": {
+          "name": "seq_emails_enrollment_id_idx",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sender_identities": {
+      "name": "sender_identities",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'thread'"
+        },
+        "signature_html": {
+          "name": "signature_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forward_to": {
+          "name": "forward_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_permissions": {
+      "name": "inbox_permissions",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inbox_permissions_email_idx": {
+          "name": "inbox_permissions_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_permissions_user_id_users_id_fk": {
+          "name": "inbox_permissions_user_id_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_permissions_created_by_users_id_fk": {
+          "name": "inbox_permissions_created_by_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "inbox_permissions_user_id_email_pk": {
+          "columns": [
+            "user_id",
+            "email"
+          ],
+          "name": "inbox_permissions_user_id_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suppressions": {
+      "name": "suppressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "suppressions_email_unique": {
+          "name": "suppressions_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "suppressions_created_at_idx": {
+          "name": "suppressions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocklist": {
+      "name": "blocklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blocklist_created_at_idx": {
+          "name": "blocklist_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "blocklist_type_value_unique": {
+          "name": "blocklist_type_value_unique",
+          "columns": [
+            "type",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1783987200000,
       "tag": "0030_outbox_emails",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1785060832032,
+      "tag": "0031_aspiring_caretaker",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/AdminInboxTable.tsx
+++ b/src/components/AdminInboxTable.tsx
@@ -41,6 +41,10 @@ export default function AdminInboxTable() {
   const [signatureEditingFor, setSignatureEditingFor] = useState<string | null>(
     null,
   );
+  // Per-inbox validation/save errors for the forward destination, keyed by inbox.
+  const [forwardErrors, setForwardErrors] = useState<Record<string, string>>(
+    {},
+  );
 
   useEffect(() => {
     Promise.all([fetchAdminInboxes(), fetchAdminUsers()])
@@ -123,10 +127,54 @@ export default function AdminInboxTable() {
               displayName: res.displayName,
               displayMode: res.displayMode,
               signatureHtml: res.signatureHtml,
+              forwardTo: res.forwardTo,
             }
           : r,
       ),
     );
+  }
+
+  async function commitForwardTo(inbox: AdminInbox, value: string) {
+    const trimmed = value.trim().toLowerCase();
+    const next = trimmed === "" ? null : trimmed;
+    if (next === inbox.forwardTo) return;
+
+    // Validate client-side so the admin gets a specific message — apiFetch
+    // collapses error responses to "API error: 400".
+    if (next !== null) {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(next)) {
+        setForwardErrors((p) => ({
+          ...p,
+          [inbox.email]: "Enter a valid email address.",
+        }));
+        return;
+      }
+      if (next === inbox.email.toLowerCase()) {
+        setForwardErrors((p) => ({
+          ...p,
+          [inbox.email]: "Can't forward an inbox to itself.",
+        }));
+        return;
+      }
+    }
+
+    setForwardErrors((p) => {
+      const { [inbox.email]: _drop, ...rest } = p;
+      return rest;
+    });
+    try {
+      const res = await updateInboxSettings(inbox.email, { forwardTo: next });
+      setInboxes((prev) =>
+        prev.map((r) =>
+          r.email === inbox.email ? { ...r, forwardTo: res.forwardTo } : r,
+        ),
+      );
+    } catch {
+      setForwardErrors((p) => ({
+        ...p,
+        [inbox.email]: "Couldn't save. Check the address and try again.",
+      }));
+    }
   }
 
   async function commitSignature(inbox: AdminInbox, html: string) {
@@ -367,6 +415,7 @@ export default function AdminInboxTable() {
                   <th className="px-3 py-2.5 font-semibold">Display name</th>
                   <th className="px-3 py-2.5 font-semibold">Signature</th>
                   <th className="px-3 py-2.5 font-semibold">Mode</th>
+                  <th className="px-3 py-2.5 font-semibold">Forward to</th>
                   <th className="px-3 py-2.5 font-semibold">Members</th>
                   <th className="w-16 px-3 py-2.5 text-right font-semibold">
                     {/* actions */}
@@ -476,6 +525,15 @@ export default function AdminInboxTable() {
                         </div>
                       </td>
 
+                      {/* Forward to (inline editable, blur to save) */}
+                      <td className="px-3 py-2.5">
+                        <ForwardToInput
+                          inbox={inbox}
+                          error={forwardErrors[inbox.email]}
+                          onCommit={(v) => commitForwardTo(inbox, v)}
+                        />
+                      </td>
+
                       {/* Members — inline chip toggles */}
                       <td className="px-3 py-2.5">
                         {members.length === 0 ? (
@@ -538,6 +596,20 @@ export default function AdminInboxTable() {
           </div>
         </div>
       )}
+
+      {inboxes.length > 0 && (
+        <p className="px-1 text-xs font-light leading-relaxed text-text-tertiary">
+          <span className="font-medium text-text-secondary">Forward to</span>{" "}
+          sends a copy of every message this inbox receives on to another
+          address, using your configured sending provider. Prefer it over a
+          Cloudflare Email Routing forwarding rule: Email Routing relays from
+          shared IPs that Outlook and Hotmail blocklist, so those forwards
+          bounce with <span className="font-mono">550 5.7.1 … (S3150)</span>.
+          Copies are sent from this inbox's address with the original sender in{" "}
+          <span className="font-mono">Reply-To</span>, so they authenticate on
+          your own domain.
+        </p>
+      )}
     </div>
   );
 }
@@ -573,6 +645,62 @@ function DisplayNameInput({ inbox, onCommit }: DisplayNameInputProps) {
       data-testid="inbox-display-name-input"
       className="h-8 w-full rounded-[6px] border border-transparent bg-transparent px-2 text-sm text-text-primary placeholder:font-light placeholder:italic placeholder:text-text-tertiary hover:border-border focus:border-border focus:bg-card focus:outline-none focus:ring-2 focus:ring-text-primary/15"
     />
+  );
+}
+
+interface ForwardToInputProps {
+  inbox: AdminInbox;
+  error?: string;
+  onCommit: (value: string) => Promise<void>;
+}
+
+/**
+ * Destination address for per-inbox forwarding. Blur-to-save, mirroring
+ * DisplayNameInput. Empty clears the rule.
+ */
+function ForwardToInput({ inbox, error, onCommit }: ForwardToInputProps) {
+  const [value, setValue] = useState(inbox.forwardTo ?? "");
+
+  useEffect(() => {
+    setValue(inbox.forwardTo ?? "");
+  }, [inbox.forwardTo]);
+
+  return (
+    <div className="min-w-[180px]">
+      <input
+        type="email"
+        value={value}
+        onChange={(e) => setValue(e.currentTarget.value)}
+        onBlur={() => onCommit(value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            (e.currentTarget as HTMLInputElement).blur();
+          } else if (e.key === "Escape") {
+            setValue(inbox.forwardTo ?? "");
+            (e.currentTarget as HTMLInputElement).blur();
+          }
+        }}
+        placeholder="No forwarding"
+        aria-label={`Forward destination for ${inbox.email}`}
+        aria-invalid={error ? true : undefined}
+        data-testid="inbox-forward-to-input"
+        className={cn(
+          "h-8 w-full rounded-[6px] border bg-transparent px-2 font-mono text-xs text-text-primary placeholder:font-sans placeholder:text-sm placeholder:font-light placeholder:italic placeholder:text-text-tertiary focus:bg-card focus:outline-none focus:ring-2",
+          error
+            ? "border-destructive focus:ring-destructive/20"
+            : "border-transparent hover:border-border focus:border-border focus:ring-text-primary/15",
+        )}
+      />
+      {error && (
+        <div
+          data-testid="inbox-forward-to-error"
+          className="mt-1 text-[10px] font-light text-destructive"
+        >
+          {error}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -720,6 +720,8 @@ export interface AdminInbox {
   displayName: string | null;
   displayMode: InboxDisplayMode;
   signatureHtml: string | null;
+  /** Destination address for per-inbox forwarding; null = forwarding off. */
+  forwardTo: string | null;
   assignedUserIds: string[];
 }
 
@@ -745,12 +747,14 @@ export async function updateInboxSettings(
     displayName?: string | null;
     displayMode?: InboxDisplayMode;
     signatureHtml?: string | null;
+    forwardTo?: string | null;
   },
 ): Promise<{
   email: string;
   displayName: string | null;
   displayMode: InboxDisplayMode;
   signatureHtml: string | null;
+  forwardTo: string | null;
 }> {
   return apiFetch(`/api/admin/inboxes/${encodeURIComponent(email)}`, {
     method: "PATCH",

--- a/src/pages/InboxesPage.tsx
+++ b/src/pages/InboxesPage.tsx
@@ -12,7 +12,7 @@ export default function InboxesPage() {
     <PageContainer>
       <PageHeader
         title="Inboxes"
-        subtitle="Set display names, choose chat or thread mode, and assign which members can access each inbox."
+        subtitle="Set display names, choose chat or thread mode, forward mail onward, and assign member access."
       />
       <AdminInboxTable />
     </PageContainer>

--- a/worker/src/__tests__/admin-inboxes-router.test.ts
+++ b/worker/src/__tests__/admin-inboxes-router.test.ts
@@ -378,4 +378,171 @@ describe("admin inboxes router", () => {
     const userIds = rows.map((r) => r.userId).sort();
     expect(userIds).toEqual(["u-m1", "u-m2"]);
   });
+
+  it("PATCH persists forwardTo and surfaces it in GET", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    await createTestPerson();
+    await createTestEmail({ recipient: "a@x.com" });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ forwardTo: "boss@outlook.com" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { forwardTo: string | null };
+    expect(body.forwardTo).toBe("boss@outlook.com");
+
+    const list = await authFetch("/api/admin/inboxes", { apiKey });
+    const rows = (await list.json()) as Array<{
+      email: string;
+      forwardTo: string | null;
+    }>;
+    expect(rows.find((r) => r.email === "a@x.com")?.forwardTo).toBe(
+      "boss@outlook.com",
+    );
+  });
+
+  it("PATCH lowercases the forward destination", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ forwardTo: "Boss@Outlook.COM" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { forwardTo: string | null };
+    expect(body.forwardTo).toBe("boss@outlook.com");
+  });
+
+  it("PATCH rejects a malformed forward destination", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ forwardTo: "not-an-email" }),
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH rejects forwarding an inbox to itself", async () => {
+    // Tight loop: would re-enter handleEmail forever.
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ forwardTo: "a@x.com" }),
+      },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/itself/i);
+  });
+
+  it("PATCH with forwardTo='' clears the stored destination", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const now = Math.floor(Date.now() / 1000);
+    await getDb().insert(senderIdentities).values({
+      email: "a@x.com",
+      displayName: "Alpha",
+      displayMode: "thread",
+      forwardTo: "boss@outlook.com",
+      createdAt: now,
+      updatedAt: now,
+    });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ forwardTo: "" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { forwardTo: string | null };
+    expect(body.forwardTo).toBeNull();
+  });
+
+  it("PATCH of another field preserves a configured forwardTo", async () => {
+    // Regression guard: a partial update must not silently drop the forward.
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const now = Math.floor(Date.now() / 1000);
+    await getDb().insert(senderIdentities).values({
+      email: "a@x.com",
+      displayName: "Alpha",
+      displayMode: "thread",
+      forwardTo: "boss@outlook.com",
+      createdAt: now,
+      updatedAt: now,
+    });
+    const res = await authFetch(
+      `/api/admin/inboxes/${encodeURIComponent("a@x.com")}`,
+      {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "Renamed" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { forwardTo: string | null };
+    expect(body.forwardTo).toBe("boss@outlook.com");
+  });
+
+  it("does not sparse-delete the row when only forwardTo is set", async () => {
+    // Clearing the display fields must not discard the forwarding rule.
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const now = Math.floor(Date.now() / 1000);
+    await getDb().insert(senderIdentities).values({
+      email: "a@x.com",
+      displayName: null,
+      displayMode: "chat",
+      forwardTo: "boss@outlook.com",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await authFetch(`/api/admin/inboxes/${encodeURIComponent("a@x.com")}`, {
+      apiKey,
+      method: "PATCH",
+      body: JSON.stringify({ displayName: null, displayMode: "chat" }),
+    });
+    const rows = await getDb()
+      .select()
+      .from(senderIdentities)
+      .where(eq(senderIdentities.email, "a@x.com"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].forwardTo).toBe("boss@outlook.com");
+  });
+
+  it("sparse-deletes the row once forwardTo is cleared too", async () => {
+    const { apiKey } = await createTestUser({ role: "admin" });
+    const now = Math.floor(Date.now() / 1000);
+    await getDb().insert(senderIdentities).values({
+      email: "a@x.com",
+      displayName: null,
+      displayMode: "chat",
+      forwardTo: "boss@outlook.com",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await authFetch(`/api/admin/inboxes/${encodeURIComponent("a@x.com")}`, {
+      apiKey,
+      method: "PATCH",
+      body: JSON.stringify({ forwardTo: "" }),
+    });
+    const rows = await getDb()
+      .select()
+      .from(senderIdentities)
+      .where(eq(senderIdentities.email, "a@x.com"));
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -65,7 +65,7 @@ export async function applyMigrations() {
     `CREATE INDEX IF NOT EXISTS enrollments_person_status_idx ON sequence_enrollments(person_id, status)`,
     `CREATE TABLE IF NOT EXISTS sequence_emails (id TEXT PRIMARY KEY, enrollment_id TEXT NOT NULL, step_order INTEGER NOT NULL, template_slug TEXT NOT NULL, scheduled_at INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'pending', sent_at INTEGER, sent_email_id TEXT)`,
     `CREATE INDEX IF NOT EXISTS seq_emails_status_scheduled_idx ON sequence_emails(status, scheduled_at)`,
-    `CREATE TABLE IF NOT EXISTS sender_identities (email TEXT PRIMARY KEY NOT NULL, display_name TEXT, display_mode TEXT NOT NULL DEFAULT 'thread', signature_html TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS sender_identities (email TEXT PRIMARY KEY NOT NULL, display_name TEXT, display_mode TEXT NOT NULL DEFAULT 'thread', signature_html TEXT, forward_to TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS inbox_permissions (user_id TEXT NOT NULL, email TEXT NOT NULL, created_at INTEGER NOT NULL, created_by TEXT, PRIMARY KEY(user_id, email), FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE, FOREIGN KEY(created_by) REFERENCES users(id) ON DELETE SET NULL)`,
     `CREATE INDEX IF NOT EXISTS inbox_permissions_email_idx ON inbox_permissions(email)`,
     `CREATE TABLE IF NOT EXISTS push_subscriptions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, endpoint TEXT NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, user_agent TEXT, created_at INTEGER NOT NULL, last_used_at INTEGER)`,

--- a/worker/src/__tests__/inbound-forward.test.ts
+++ b/worker/src/__tests__/inbound-forward.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import {
+  FORWARD_LOOP_HEADER,
+  FORWARD_ORIGINAL_FROM_HEADER,
+  FORWARD_ORIGINAL_MESSAGE_ID_HEADER,
+  buildForwardMessage,
+  type BuildForwardMessageParams,
+} from "../lib/inbound-forward";
+
+function bytes(n: number): ArrayBuffer {
+  return new ArrayBuffer(n);
+}
+
+function params(
+  over: Partial<BuildForwardMessageParams> = {},
+): BuildForwardMessageParams {
+  return {
+    inbox: "support@acme.com",
+    forwardTo: "boss@outlook.com",
+    inboxDisplayName: "Acme Support",
+    from: { address: "jane@example.com", name: "Jane Customer" },
+    subject: "Help with my order",
+    fullBodyHtml: "<p>Hi, I can't log in</p>",
+    fullBodyText: "Hi, I can't log in",
+    messageId: "<abc123@example.com>",
+    receivedAt: 1_750_000_000,
+    cc: [],
+    auth: { spf: "pass", dkim: "pass", dmarc: "pass" },
+    attachments: [],
+    headers: {},
+    knownInboxes: ["support@acme.com", "sales@acme.com"],
+    maxAttachmentBytes: 1000,
+    ...over,
+  };
+}
+
+function ok(over: Partial<BuildForwardMessageParams> = {}) {
+  const r = buildForwardMessage(params(over));
+  if (!r.ok) throw new Error(`expected ok, got skip: ${r.reason}`);
+  return r;
+}
+
+describe("buildForwardMessage — skip conditions", () => {
+  it("skips when no destination is configured", () => {
+    const r = buildForwardMessage(params({ forwardTo: null }));
+    expect(r).toEqual({ ok: false, reason: "no-destination" });
+  });
+
+  it("skips a whitespace-only destination", () => {
+    const r = buildForwardMessage(params({ forwardTo: "   " }));
+    expect(r).toEqual({ ok: false, reason: "no-destination" });
+  });
+
+  it("skips when the destination is the inbox itself", () => {
+    const r = buildForwardMessage(params({ forwardTo: "support@acme.com" }));
+    expect(r).toEqual({ ok: false, reason: "loop-self" });
+  });
+
+  it("treats a differently-cased self-destination as a loop", () => {
+    const r = buildForwardMessage(params({ forwardTo: "SUPPORT@Acme.com" }));
+    expect(r).toEqual({ ok: false, reason: "loop-self" });
+  });
+
+  it("skips when the destination is another inbox on this instance", () => {
+    // Would bounce back through handleEmail and loop.
+    const r = buildForwardMessage(params({ forwardTo: "sales@acme.com" }));
+    expect(r).toEqual({ ok: false, reason: "loop-known-inbox" });
+  });
+
+  it("skips a message that already carries the forward trip-wire header", () => {
+    const r = buildForwardMessage(
+      params({ headers: { [FORWARD_LOOP_HEADER.toLowerCase()]: "x@y.com" } }),
+    );
+    expect(r).toEqual({ ok: false, reason: "loop-header" });
+  });
+
+  it("matches the trip-wire header case-insensitively", () => {
+    const r = buildForwardMessage(
+      params({ headers: { "X-SaaSMail-Forwarded-For": "x@y.com" } }),
+    );
+    expect(r).toEqual({ ok: false, reason: "loop-header" });
+  });
+});
+
+describe("buildForwardMessage — envelope rewriting", () => {
+  it("sends from the inbox, not the original sender", () => {
+    // The whole point: mail must authenticate on our own domain. Sending as
+    // jane@example.com from our IPs would fail SPF/DKIM/DMARC.
+    const { message } = ok();
+    expect(message.from).toContain("<support@acme.com>");
+    expect(message.from).not.toContain("<jane@example.com>");
+  });
+
+  it("names the original sender in the From display name", () => {
+    const { message } = ok();
+    expect(message.from).toContain("Jane Customer");
+    expect(message.from).toContain("via Acme Support");
+  });
+
+  it("quotes the display name, since it contains RFC 5322 specials", () => {
+    // "(" and ")" are specials — an unquoted From breaks provider parsing.
+    const { message } = ok();
+    expect(message.from.startsWith('"')).toBe(true);
+  });
+
+  it("falls back to the inbox address when it has no display name", () => {
+    const { message } = ok({ inboxDisplayName: null });
+    expect(message.from).toContain("via support@acme.com");
+  });
+
+  it("uses the sender address as the label when the sender has no name", () => {
+    const { message } = ok({
+      from: { address: "jane@example.com", name: "" },
+    });
+    expect(message.from).toContain("jane@example.com (via Acme Support)");
+  });
+
+  it("sets Reply-To to the original sender so replies reach them", () => {
+    const { message } = ok();
+    expect(message.headers?.["Reply-To"]).toBe("jane@example.com");
+  });
+
+  it("addresses the forward to the configured destination, lowercased", () => {
+    const { message } = ok({ forwardTo: "Boss@Outlook.COM" });
+    expect(message.to).toBe("boss@outlook.com");
+  });
+
+  it("passes the subject through unchanged so destination threading matches", () => {
+    const { message } = ok();
+    expect(message.subject).toBe("Help with my order");
+  });
+
+  it("substitutes a placeholder for an empty subject", () => {
+    const { message } = ok({ subject: "" });
+    expect(message.subject).toBe("(no subject)");
+  });
+
+  it("stamps the loop trip-wire header with the inbox", () => {
+    const { message } = ok();
+    expect(message.headers?.[FORWARD_LOOP_HEADER]).toBe("support@acme.com");
+  });
+
+  it("records the original sender and message id as headers", () => {
+    const { message } = ok();
+    expect(message.headers?.[FORWARD_ORIGINAL_FROM_HEADER]).toBe(
+      "jane@example.com",
+    );
+    expect(message.headers?.[FORWARD_ORIGINAL_MESSAGE_ID_HEADER]).toBe(
+      "<abc123@example.com>",
+    );
+  });
+
+  it("omits the original-message-id header when there was none", () => {
+    const { message } = ok({ messageId: null });
+    expect(
+      message.headers?.[FORWARD_ORIGINAL_MESSAGE_ID_HEADER],
+    ).toBeUndefined();
+  });
+
+  it("never reuses the original Message-ID on the new message", () => {
+    // Reusing it would collide with the message we already stored.
+    const { message } = ok();
+    expect(message.headers?.["Message-ID"]).toBeUndefined();
+  });
+
+  it("does NOT re-send to the original Cc recipients", () => {
+    // Critical: those are the sender's contacts. Mailing them would leak the
+    // redirect to people who never opted into it.
+    const { message } = ok({
+      cc: [
+        { email: "colleague@example.com", name: "Colleague" },
+        { email: "other@example.com", name: null },
+      ],
+    });
+    expect(message.cc).toBeUndefined();
+    expect(message.to).toBe("boss@outlook.com");
+  });
+
+  it("still shows the Cc list in the body header block", () => {
+    const { message } = ok({
+      cc: [{ email: "colleague@example.com", name: "Colleague" }],
+    });
+    expect(message.html).toContain("colleague@example.com");
+  });
+});
+
+describe("buildForwardMessage — body", () => {
+  it("uses the untrimmed body so quoted history survives", () => {
+    const full = '<p>my reply</p><div class="gmail_quote">older thread</div>';
+    const { message } = ok({ fullBodyHtml: full });
+    expect(message.html).toContain("older thread");
+  });
+
+  it("includes the original envelope in a header block", () => {
+    const { message } = ok();
+    expect(message.html).toContain("jane@example.com");
+    expect(message.html).toContain("Help with my order");
+    expect(message.html).toContain("support@acme.com");
+  });
+
+  it("reports the original auth verdicts", () => {
+    const { message } = ok({
+      auth: { spf: "fail", dkim: null, dmarc: "fail" },
+    });
+    expect(message.html).toContain("spf=fail");
+    expect(message.html).toContain("dkim=none");
+    expect(message.html).toContain("dmarc=fail");
+  });
+
+  it("escapes the header block against HTML injection via sender name", () => {
+    const { message } = ok({
+      from: {
+        address: "jane@example.com",
+        name: "<img src=x onerror=alert(1)>",
+      },
+    });
+    // The injected markup must appear escaped inside the block we build.
+    expect(message.html).toContain("&lt;img");
+    expect(message.html).not.toContain("<img src=x");
+  });
+
+  it("wraps a text-only message in a pre block", () => {
+    const { message } = ok({
+      fullBodyHtml: null,
+      fullBodyText: "plain only",
+    });
+    expect(message.html).toContain("<pre");
+    expect(message.html).toContain("plain only");
+  });
+
+  it("handles a message with no body at all", () => {
+    const { message } = ok({ fullBodyHtml: null, fullBodyText: null });
+    expect(message.html).toContain("no message body");
+    expect(message.text).toContain("no message body");
+  });
+
+  it("builds a plain-text alternative with the same header block", () => {
+    const { message } = ok();
+    expect(message.text).toContain("Forwarded by saasmail");
+    expect(message.text).toContain("From: Jane Customer <jane@example.com>");
+    expect(message.text).toContain("Hi, I can't log in");
+  });
+});
+
+describe("buildForwardMessage — attachments", () => {
+  it("forwards attachments that fit under the provider cap", () => {
+    const { message, skippedAttachments } = ok({
+      attachments: [
+        {
+          filename: "shot.png",
+          contentType: "image/png",
+          content: bytes(500),
+          contentId: null,
+          disposition: "attachment",
+        },
+      ],
+    });
+    expect(message.attachments).toHaveLength(1);
+    expect(message.attachments?.[0].filename).toBe("shot.png");
+    expect(skippedAttachments).toEqual([]);
+  });
+
+  it("skips attachments that would exceed the cap, and names them", () => {
+    const { message, skippedAttachments } = ok({
+      maxAttachmentBytes: 1000,
+      attachments: [
+        {
+          filename: "small.png",
+          contentType: "image/png",
+          content: bytes(600),
+          contentId: null,
+          disposition: "attachment",
+        },
+        {
+          filename: "huge.zip",
+          contentType: "application/zip",
+          content: bytes(900),
+          contentId: null,
+          disposition: "attachment",
+        },
+      ],
+    });
+    expect(message.attachments).toHaveLength(1);
+    expect(skippedAttachments).toEqual(["huge.zip"]);
+  });
+
+  it("tells the recipient in the body when attachments were withheld", () => {
+    // Silently dropping them would leave the reader unaware anything is missing.
+    const { message } = ok({
+      maxAttachmentBytes: 10,
+      attachments: [
+        {
+          filename: "huge.zip",
+          contentType: "application/zip",
+          content: bytes(5000),
+          contentId: null,
+          disposition: "attachment",
+        },
+      ],
+    });
+    expect(message.html).toContain("huge.zip");
+    expect(message.html).toContain("too large to forward");
+    expect(message.text).toContain("huge.zip");
+  });
+
+  it("omits the attachments key entirely when there are none", () => {
+    const { message } = ok({ attachments: [] });
+    expect(message.attachments).toBeUndefined();
+  });
+});

--- a/worker/src/db/sender-identities.schema.ts
+++ b/worker/src/db/sender-identities.schema.ts
@@ -7,6 +7,17 @@ export const senderIdentities = sqliteTable("sender_identities", {
     .notNull()
     .default("thread"),
   signatureHtml: text("signature_html"),
+  /**
+   * Optional destination address. When set, every inbound message to this
+   * inbox is re-sent to this address through the configured outbound
+   * provider. Null = forwarding off.
+   *
+   * This exists because Cloudflare Email Routing's own forwarding rules send
+   * from a shared IP pool that Outlook/Hotmail blocklists (550 5.7.1 S3150),
+   * so forwards to Microsoft-hosted mailboxes silently bounce. Re-sending via
+   * Email Sending uses different IPs and DKIM-signs for our own domain.
+   */
+  forwardTo: text("forward_to"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -18,6 +18,7 @@ import {
 } from "./lib/notification-fanout";
 import { sanitizeFilename } from "./lib/sanitize-filename";
 import { buildWebhookPayload, deliverWebhook } from "./lib/webhook-delivery";
+import { forwardInbound } from "./lib/inbound-forward";
 
 const MAX_ATTACHMENTS = 50;
 const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024; // 25 MB
@@ -160,21 +161,28 @@ export async function handleEmail(
   // External participants = the sender + everyone on the Cc line, minus
   // any addresses that match one of our sender_identities (those are
   // "internal" team members and don't change the group identity).
-  const ourDomains = await (async () => {
-    const rows = await db
-      .select({ email: senderIdentities.email })
-      .from(senderIdentities);
-    return Array.from(
-      new Set(
-        rows
-          .map((r) => {
-            const at = r.email.lastIndexOf("@");
-            return at === -1 ? "" : r.email.slice(at + 1).toLowerCase();
-          })
-          .filter(Boolean),
-      ),
-    );
-  })();
+  //
+  // One scan of sender_identities serves three consumers: the "our domains"
+  // set below, the forward destination for this inbox, and the known-inbox
+  // loop guard in `forwardInbound`.
+  const identityRows = await db
+    .select({
+      email: senderIdentities.email,
+      displayName: senderIdentities.displayName,
+      forwardTo: senderIdentities.forwardTo,
+    })
+    .from(senderIdentities);
+
+  const ourDomains = Array.from(
+    new Set(
+      identityRows
+        .map((r) => {
+          const at = r.email.lastIndexOf("@");
+          return at === -1 ? "" : r.email.slice(at + 1).toLowerCase();
+        })
+        .filter(Boolean),
+    ),
+  );
   const allParticipants = [
     fromAddressCanonical,
     ...parsed.cc.map((c) => c.email),
@@ -295,6 +303,33 @@ export async function handleEmail(
       baseUrl: env.BASE_URL,
     }),
   );
+
+  // Per-inbox forwarding ("redirect rule"). Re-sends this message to the
+  // inbox's configured destination through the outbound provider, because
+  // Cloudflare Email Routing's own forwarding rules relay from IPs that Outlook
+  // blocklists (550 5.7.1 S3150). See lib/inbound-forward.ts for the full
+  // rationale. Best-effort and non-blocking, like the webhook above — and it
+  // sits after the blocklist and dedupe gates, so blocked senders and duplicate
+  // deliveries are never forwarded.
+  const inboxIdentity = identityRows.find(
+    (r) => r.email.trim().toLowerCase() === recipientCanonical,
+  );
+  forwardInbound(env, ctx, {
+    inbox: recipientCanonical,
+    forwardTo: inboxIdentity?.forwardTo ?? null,
+    inboxDisplayName: inboxIdentity?.displayName ?? null,
+    from: parsed.from,
+    subject: parsed.subject,
+    fullBodyHtml: parsed.fullBodyHtml,
+    fullBodyText: parsed.fullBodyText,
+    messageId: parsed.messageId,
+    receivedAt: now,
+    cc: parsed.cc,
+    auth: parsed.auth,
+    attachments: cappedAttachments,
+    headers: parsed.headers,
+    knownInboxes: identityRows.map((r) => r.email),
+  });
 
   // Cancel any active sequences for this person
   await cancelSequencesForPerson(db, actualPersonId);

--- a/worker/src/lib/email-parser.ts
+++ b/worker/src/lib/email-parser.ts
@@ -17,8 +17,18 @@ export interface ParsedEmail {
   /** Additional recipients on the Cc: line, parsed from the MIME headers. */
   cc: ParsedEmailAddress[];
   subject: string;
+  /** Quote-trimmed HTML body, with `cid:` refs left intact. For display/storage. */
   bodyHtml: string | null;
+  /** Quote-trimmed plain-text body. For display/storage. */
   bodyText: string | null;
+  /**
+   * Untrimmed HTML body, exactly as received. Used when relaying the message
+   * onward (per-inbox forwarding), where dropping the quoted reply history
+   * would lose context the recipient needs.
+   */
+  fullBodyHtml: string | null;
+  /** Untrimmed plain-text body, exactly as received. See `fullBodyHtml`. */
+  fullBodyText: string | null;
   messageId: string | null;
   headers: Record<string, string>;
   attachments: ParsedAttachment[];
@@ -180,6 +190,8 @@ export async function parseEmail(
     subject: parsed.subject || "",
     bodyHtml: bodyHtml ? trimQuotedHtml(bodyHtml) : null,
     bodyText: bodyText ? trimQuotedText(bodyText) : null,
+    fullBodyHtml: bodyHtml,
+    fullBodyText: bodyText,
     messageId: parsed.messageId || null,
     headers,
     attachments: (parsed.attachments || []).map((att) => ({

--- a/worker/src/lib/inbound-forward.ts
+++ b/worker/src/lib/inbound-forward.ts
@@ -1,0 +1,321 @@
+import { createEmailSender } from "./email-sender";
+import { encodeDisplayName } from "./format-from-address";
+import type {
+  SendEmailAttachment,
+  SendEmailParams,
+} from "./email-sender/types";
+import type {
+  AuthResults,
+  ParsedAttachment,
+  ParsedEmailAddress,
+} from "./email-parser";
+
+/**
+ * Per-inbox forwarding ("redirect rule").
+ *
+ * Why this exists instead of a Cloudflare Email Routing forwarding rule:
+ * Email Routing relays forwarded mail from a shared IP pool, and Outlook /
+ * Hotmail / Live blocklist parts of it. The bounce looks like:
+ *
+ *   permanent error (550): 5.7.1 Unfortunately, messages from [104.30.10.66]
+ *   weren't sent ... part of their network is on our block list (S3150).
+ *
+ * That IP is Cloudflare's, not ours, so we can't get it delisted — anyone whose
+ * personal mailbox is Microsoft-hosted just stops receiving forwards. Re-sending
+ * the message ourselves through the configured outbound provider (Cloudflare
+ * Email Sending / Resend / Bavimail / Postmark) leaves from different IPs and is
+ * DKIM-signed for our own domain, so it authenticates cleanly.
+ *
+ * The consequence, and the central trade-off of this module: the forwarded copy
+ * is a re-composition, not a byte-for-byte relay. We cannot keep the original
+ * `From:` — sending as `customer@example.com` from our infrastructure fails SPF
+ * and has no DKIM signature for that domain, so it fails DMARC and gets filtered
+ * harder than the block we're routing around. Instead we send as the inbox, put
+ * the real sender in `Reply-To`, and restate the original envelope in a header
+ * block at the top of the body, the same way "forward as new message" works in
+ * any mail client.
+ */
+
+/**
+ * Trip-wire header stamped on every forward, used to break forwarding loops.
+ *
+ * Provider caveat: Bavimail's API has no generic custom-header field, so this
+ * (and the two X- headers below) are dropped on that provider. Loop protection
+ * there degrades to the self and same-instance destination checks, which still
+ * cover the realistic cases; only the indirect "destination forwards back to us"
+ * loop goes uncaught.
+ */
+export const FORWARD_LOOP_HEADER = "X-SaaSMail-Forwarded-For";
+
+/** Traceability: ties a forwarded copy back to the inbound message it came from. */
+export const FORWARD_ORIGINAL_MESSAGE_ID_HEADER =
+  "X-SaaSMail-Original-Message-Id";
+
+/** The real sender, preserved as a header as well as in Reply-To. */
+export const FORWARD_ORIGINAL_FROM_HEADER = "X-SaaSMail-Original-From";
+
+export type ForwardSkipReason =
+  | "no-destination"
+  | "loop-self"
+  | "loop-known-inbox"
+  | "loop-header";
+
+export type BuildForwardResult =
+  | { ok: true; message: SendEmailParams; skippedAttachments: string[] }
+  | { ok: false; reason: ForwardSkipReason };
+
+export interface BuildForwardMessageParams {
+  /** Canonical (lowercased) inbox address the mail arrived at. */
+  inbox: string;
+  /** Configured destination, or null when forwarding is off for this inbox. */
+  forwardTo: string | null;
+  /** Display name configured for the inbox, used in the rewritten From. */
+  inboxDisplayName: string | null;
+  from: { address: string; name: string };
+  subject: string;
+  /** Untrimmed bodies — see `ParsedEmail.fullBodyHtml`. */
+  fullBodyHtml: string | null;
+  fullBodyText: string | null;
+  messageId: string | null;
+  /** Epoch seconds. */
+  receivedAt: number;
+  cc: ParsedEmailAddress[];
+  auth: AuthResults;
+  attachments: ParsedAttachment[];
+  /** Inbound headers, lowercase-keyed (as produced by `parseEmail`). */
+  headers: Record<string, string>;
+  /** Every inbox address on this instance, lowercased. */
+  knownInboxes: string[];
+  /** Provider ceiling from `EmailSender.maxAttachmentBytes()`. */
+  maxAttachmentBytes: number;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function formatAddress(address: string, name: string | null): string {
+  return name ? `${name} <${address}>` : address;
+}
+
+/**
+ * Decides whether an inbound message should be forwarded and, if so, builds the
+ * outbound payload. Pure — no I/O — so the loop guards and header rewriting can
+ * be tested without a live `ForwardableEmailMessage`.
+ */
+export function buildForwardMessage(
+  params: BuildForwardMessageParams,
+): BuildForwardResult {
+  const destination = params.forwardTo?.trim().toLowerCase() ?? "";
+  if (!destination) return { ok: false, reason: "no-destination" };
+
+  const inbox = params.inbox.trim().toLowerCase();
+
+  // Guard 1: forwarding an inbox to itself is an immediate tight loop.
+  if (destination === inbox) return { ok: false, reason: "loop-self" };
+
+  // Guard 2: the destination is another inbox on this instance, which would
+  // bounce the message back through `handleEmail`. Checked here (not only at
+  // config time) because an inbox can be created after the forward was set.
+  if (params.knownInboxes.some((e) => e.trim().toLowerCase() === destination)) {
+    return { ok: false, reason: "loop-known-inbox" };
+  }
+
+  // Guard 3: this message is itself a forward we (or another saasmail) emitted.
+  // Breaks indirect loops where the destination auto-forwards back to us.
+  const loopHeaderKey = FORWARD_LOOP_HEADER.toLowerCase();
+  const seen = Object.keys(params.headers).some(
+    (k) => k.toLowerCase() === loopHeaderKey,
+  );
+  if (seen) return { ok: false, reason: "loop-header" };
+
+  const originalFrom = formatAddress(
+    params.from.address,
+    params.from.name || null,
+  );
+
+  // Send AS the inbox so the message authenticates on our own domain, but make
+  // the real sender obvious in the From display name and replyable via Reply-To.
+  const inboxLabel = params.inboxDisplayName || inbox;
+  const fromLabel = params.from.name
+    ? `${params.from.name} (via ${inboxLabel})`
+    : `${params.from.address} (via ${inboxLabel})`;
+  const from = `${encodeDisplayName(fromLabel)} <${inbox}>`;
+
+  // Attachments are capped by the provider's ceiling. Anything that doesn't fit
+  // is named in the body rather than silently dropped, so the recipient knows to
+  // go look at the message in saasmail.
+  const attachments: SendEmailAttachment[] = [];
+  const skippedAttachments: string[] = [];
+  let attachmentBytes = 0;
+  for (const att of params.attachments) {
+    const size = att.content.byteLength;
+    if (attachmentBytes + size > params.maxAttachmentBytes) {
+      skippedAttachments.push(att.filename);
+      continue;
+    }
+    attachmentBytes += size;
+    attachments.push({
+      filename: att.filename,
+      contentType: att.contentType,
+      content: att.content,
+    });
+  }
+
+  const subject = params.subject || "(no subject)";
+  const dateLabel = new Date(params.receivedAt * 1000).toUTCString();
+  const authLabel = `spf=${params.auth.spf ?? "none"} dkim=${
+    params.auth.dkim ?? "none"
+  } dmarc=${params.auth.dmarc ?? "none"}`;
+
+  const headerLines: Array<[string, string]> = [
+    ["From", originalFrom],
+    ["Date", dateLabel],
+    ["Subject", subject],
+    ["To", inbox],
+  ];
+  if (params.cc.length > 0) {
+    headerLines.push([
+      "Cc",
+      params.cc.map((c) => formatAddress(c.email, c.name)).join(", "),
+    ]);
+  }
+  headerLines.push(["Authentication", authLabel]);
+
+  const noteLines: string[] = [];
+  if (skippedAttachments.length > 0) {
+    noteLines.push(
+      `${skippedAttachments.length} attachment(s) were too large to forward and are not included: ${skippedAttachments.join(", ")}`,
+    );
+  }
+
+  const htmlHeaderBlock = [
+    `<div style="font:13px/1.5 -apple-system,Segoe UI,sans-serif;color:#555;border-left:3px solid #ddd;padding:8px 12px;margin:0 0 16px">`,
+    `<div style="font-weight:600;margin-bottom:6px">Forwarded by saasmail</div>`,
+    ...headerLines.map(
+      ([k, v]) =>
+        `<div><span style="color:#888">${escapeHtml(k)}:</span> ${escapeHtml(v)}</div>`,
+    ),
+    ...noteLines.map(
+      (n) => `<div style="margin-top:6px;color:#b45309">${escapeHtml(n)}</div>`,
+    ),
+    `</div>`,
+  ].join("");
+
+  const textHeaderBlock = [
+    "---------- Forwarded by saasmail ----------",
+    ...headerLines.map(([k, v]) => `${k}: ${v}`),
+    ...noteLines,
+    "",
+    "",
+  ].join("\n");
+
+  // The original body is relayed verbatim, not sanitized. This is a mail relay,
+  // not a page we render — the receiving mail client applies its own sandboxing,
+  // and rewriting the body would defeat the point of forwarding. (saasmail's own
+  // web view continues to render the sanitized, quote-trimmed copy.)
+  const originalHtml = params.fullBodyHtml;
+  const originalText = params.fullBodyText;
+
+  const html = originalHtml
+    ? `${htmlHeaderBlock}${originalHtml}`
+    : originalText
+      ? `${htmlHeaderBlock}<pre style="white-space:pre-wrap;font:inherit">${escapeHtml(originalText)}</pre>`
+      : `${htmlHeaderBlock}<p style="color:#888"><em>(no message body)</em></p>`;
+
+  const text = `${textHeaderBlock}${originalText ?? "(no message body)"}`;
+
+  return {
+    ok: true,
+    skippedAttachments,
+    message: {
+      from,
+      to: destination,
+      subject,
+      html,
+      text,
+      // Deliberately NOT forwarding the original Cc list as real recipients —
+      // those are the sender's contacts, and re-sending to them would leak the
+      // redirect and mail people who never opted into it. They appear in the
+      // header block only.
+      headers: {
+        "Reply-To": params.from.address,
+        [FORWARD_LOOP_HEADER]: inbox,
+        [FORWARD_ORIGINAL_FROM_HEADER]: params.from.address,
+        ...(params.messageId
+          ? { [FORWARD_ORIGINAL_MESSAGE_ID_HEADER]: params.messageId }
+          : {}),
+      },
+      ...(attachments.length > 0 ? { attachments } : {}),
+    },
+  };
+}
+
+export interface ForwardInboundParams extends Omit<
+  BuildForwardMessageParams,
+  "knownInboxes" | "maxAttachmentBytes"
+> {
+  knownInboxes: string[];
+}
+
+/**
+ * Fire-and-forget dispatch of the forwarded copy.
+ *
+ * Best-effort by design, mirroring `deliverWebhook`: it runs inside
+ * `ctx.waitUntil` with its own try/catch, after the inbound message is already
+ * durably stored, so a forwarding failure can never cost us the message.
+ *
+ * There is no retry. `sendViaOutbox` needs a `sent_emails` row id and reloads
+ * attachments from R2 filtered on `kind = "sent"`; a forward has neither, and
+ * synthesising one would put a duplicate of every inbound message into the Sent
+ * views. Failures are logged instead.
+ */
+export function forwardInbound(
+  env: CloudflareBindings,
+  ctx: ExecutionContext,
+  params: ForwardInboundParams,
+): void {
+  if (!params.forwardTo) return;
+
+  ctx.waitUntil(
+    (async () => {
+      try {
+        const sender = createEmailSender(env);
+        const built = buildForwardMessage({
+          ...params,
+          maxAttachmentBytes: sender.maxAttachmentBytes(),
+        });
+
+        if (!built.ok) {
+          console.warn(
+            `Forward skipped for ${params.inbox} → ${params.forwardTo}: ${built.reason}`,
+          );
+          return;
+        }
+
+        // Sent via the raw sender rather than `sendWithSuppressionCheck` on
+        // purpose: a relayed copy must not carry List-Unsubscribe headers or an
+        // appended unsubscribe footer for a message saasmail didn't author, and
+        // someone who unsubscribed from marketing must still receive their
+        // forwarded support mail.
+        const result = await sender.send(built.message);
+        if (result.error) {
+          console.error(
+            `Forward failed for ${params.inbox} → ${built.message.to}: ${result.error.message}`,
+          );
+        } else if (built.skippedAttachments.length > 0) {
+          console.warn(
+            `Forwarded ${params.inbox} → ${built.message.to} without ${built.skippedAttachments.length} oversized attachment(s)`,
+          );
+        }
+      } catch (err) {
+        // Non-fatal: the message is already stored; forwarding is best-effort.
+        console.error("Forward error:", err);
+      }
+    })(),
+  );
+}

--- a/worker/src/routers/admin-inboxes-router.ts
+++ b/worker/src/routers/admin-inboxes-router.ts
@@ -20,6 +20,7 @@ const InboxRowSchema = z.object({
   displayName: z.string().nullable(),
   displayMode: z.enum(["thread", "chat"]),
   signatureHtml: z.string().nullable(),
+  forwardTo: z.string().nullable(),
   assignedUserIds: z.array(z.string()),
 });
 
@@ -41,6 +42,7 @@ adminInboxesRouter.openapi(listInboxesRoute, async (c) => {
     displayName: string | null;
     displayMode: "thread" | "chat" | null;
     signatureHtml: string | null;
+    forwardTo: string | null;
     assignedUserIds: string | null;
   };
   const rows = await db.all<Row>(sql`
@@ -54,6 +56,7 @@ adminInboxesRouter.openapi(listInboxesRoute, async (c) => {
       s.display_name AS displayName,
       s.display_mode AS displayMode,
       s.signature_html AS signatureHtml,
+      s.forward_to AS forwardTo,
       (
         SELECT COALESCE(
           '[' || GROUP_CONCAT('"' || ip.user_id || '"') || ']',
@@ -73,6 +76,7 @@ adminInboxesRouter.openapi(listInboxesRoute, async (c) => {
       displayName: r.displayName,
       displayMode: r.displayMode ?? "chat",
       signatureHtml: r.signatureHtml,
+      forwardTo: r.forwardTo,
       assignedUserIds: r.assignedUserIds ? JSON.parse(r.assignedUserIds) : [],
     })),
     200,
@@ -105,6 +109,7 @@ const createInboxRoute = createRoute({
         displayName: z.string().nullable(),
         displayMode: z.enum(["thread", "chat"]),
         signatureHtml: z.string().nullable(),
+        forwardTo: z.string().nullable(),
         assignedUserIds: z.array(z.string()),
       }),
       "Created inbox",
@@ -151,6 +156,7 @@ adminInboxesRouter.openapi(createInboxRoute, async (c) => {
       displayName,
       displayMode,
       signatureHtml: null,
+      forwardTo: null,
       assignedUserIds: [],
     },
     201,
@@ -169,12 +175,18 @@ const PatchInboxBodySchema = z
       .max(MAX_SIGNATURE_HTML_LENGTH)
       .nullable()
       .optional(),
+    // Destination for per-inbox forwarding. "" clears it (the UI sends an empty
+    // input as ""), so the union accepts a valid address, "", or null.
+    forwardTo: z
+      .union([z.string().email(), z.literal(""), z.null()])
+      .optional(),
   })
   .refine(
     (b) =>
       b.displayName !== undefined ||
       b.displayMode !== undefined ||
-      b.signatureHtml !== undefined,
+      b.signatureHtml !== undefined ||
+      b.forwardTo !== undefined,
     "must update at least one field",
   );
 
@@ -183,7 +195,7 @@ const patchInboxRoute = createRoute({
   path: "/{email}",
   tags: ["Admin Inboxes"],
   description:
-    "Update display name, display mode, and/or signature HTML for an inbox. Row is deleted only when all three fields are at defaults (null + 'chat' + null).",
+    "Update display name, display mode, signature HTML, and/or forward destination for an inbox. Row is deleted only when all four fields are at defaults (null + 'chat' + null + null).",
   request: {
     params: z.object({ email: z.string() }),
     body: {
@@ -201,9 +213,18 @@ const patchInboxRoute = createRoute({
         displayName: z.string().nullable(),
         displayMode: z.enum(["thread", "chat"]),
         signatureHtml: z.string().nullable(),
+        forwardTo: z.string().nullable(),
       }),
       "Updated",
     ),
+    400: {
+      description: "Invalid forward destination",
+      content: {
+        "application/json": {
+          schema: z.object({ error: z.string() }),
+        },
+      },
+    },
   },
 });
 
@@ -242,12 +263,30 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
         ? null
         : await sanitizeSignatureHtml(body.signatureHtml)
       : (currentRow?.signatureHtml ?? null);
+  const nextForwardTo =
+    body.forwardTo !== undefined
+      ? body.forwardTo === "" || body.forwardTo === null
+        ? null
+        : body.forwardTo.trim().toLowerCase()
+      : (currentRow?.forwardTo ?? null);
+
+  // Reject the tight self-forward loop at config time so the admin gets an
+  // error instead of a silently-skipped forward. `buildForwardMessage` guards
+  // this again at send time (and also catches forwards aimed at *other* inboxes
+  // on this instance, which may not exist yet when the rule is saved).
+  if (nextForwardTo !== null && nextForwardTo === email.trim().toLowerCase()) {
+    return c.json(
+      { error: "Forward destination cannot be the inbox itself" },
+      400,
+    );
+  }
 
   // All fields at defaults → delete the row to keep the table sparse.
   if (
     nextDisplayName === null &&
     nextDisplayMode === "chat" &&
-    nextSignatureHtml === null
+    nextSignatureHtml === null &&
+    nextForwardTo === null
   ) {
     await db.delete(senderIdentities).where(eq(senderIdentities.email, email));
     return c.json(
@@ -256,6 +295,7 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
         displayName: null,
         displayMode: "chat",
         signatureHtml: null,
+        forwardTo: null,
       },
       200,
     );
@@ -268,6 +308,7 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
       displayName: nextDisplayName,
       displayMode: nextDisplayMode,
       signatureHtml: nextSignatureHtml,
+      forwardTo: nextForwardTo,
       createdAt: now,
       updatedAt: now,
     })
@@ -277,6 +318,7 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
         displayName: nextDisplayName,
         displayMode: nextDisplayMode,
         signatureHtml: nextSignatureHtml,
+        forwardTo: nextForwardTo,
         updatedAt: now,
       },
     });
@@ -287,6 +329,7 @@ adminInboxesRouter.openapi(patchInboxRoute, async (c) => {
       displayName: nextDisplayName,
       displayMode: nextDisplayMode,
       signatureHtml: nextSignatureHtml,
+      forwardTo: nextForwardTo,
     },
     200,
   );


### PR DESCRIPTION
## Why

Cloudflare Email Routing's own forwarding rules are unreliable for Microsoft-hosted destinations. Email Routing relays forwarded mail from a **shared Cloudflare IP pool**, and Outlook / Hotmail / Live blocklist parts of it:

```
upstream (outlook-com.olc.protection.outlook.com.) error: failed to initialize:
Permanent Unknown error: permanent error (550): 5.7.1 Unfortunately, messages
from [104.30.10.66] weren't sent. Please contact your Internet service provider
since part of their network is on our block list (S3150). You can also refer your
provider to http://mail.live.com/mail/troubleshooting.aspx#errors.
[Name=Protocol Filter Agent][AGT=PFA][MxId=11BDD0B5751186A1]
```

`104.30.10.66` is **Cloudflare's IP, not ours**, so there is no delisting path available to us. The practical effect: anyone whose personal mailbox is on `@outlook.com` / `@hotmail.com` / `@live.com` silently stops receiving forwarded copies, and it's a permanent 550 — no retry saves it.

**Cloudflare Email Sending is a different path with different IPs**, and it DKIM-signs for the domain you onboarded. So instead of configuring a forwarding rule in the Cloudflare dashboard, saasmail now re-sends the message itself through whichever outbound provider the deployment already uses (Email Sending, Resend, Bavimail, or Postmark).

## What

An optional **Forward to** address per inbox, on the same **Inboxes** page that already holds display name, signature, mode, and member permissions. Empty = off, which is the default — **no behavior change for existing deployments**.

**The new column** — `marketing@` unset, `support@` forwarding to an Outlook address:

<img width="1280" height="720" alt="saasmail-forward-to-full" src="https://github.com/user-attachments/assets/ecb9304b-f0e7-4fdf-a0da-84e20148ff39" />


**Full page**, including the explainer caption that gives admins the reason to prefer this over a dashboard rule:

<img width="1280" height="720" alt="saasmail-forward-to-full" src="https://github.com/user-attachments/assets/44860233-3f5c-47f2-a868-926fa1c8fa25" />


**Inline validation** on a malformed address:

<img width="1280" height="720" alt="saasmail-forward-to-validation" src="https://github.com/user-attachments/assets/8bdfdd1e-714c-4fea-abc8-77ae8cfb53b5" />


## Design decisions worth reviewing

These are the calls I made; each is the kind of thing you might want to overrule.

### 1. The forward is a re-composition, not a byte-for-byte relay

This is the crux. Three approaches were possible and two are dead ends:

| Approach | Verdict |
|---|---|
| `message.forward()` | ❌ **This *is* Email Routing forwarding** — the exact path Outlook rejects. Would reproduce the bug. |
| Pass original MIME through Email Sending | ❌ Keeps `From: customer@example.com`. Sent from our infra that fails SPF, has no DKIM for `example.com`, so it fails DMARC — filtered *harder* than the block we're routing around. Also only the Cloudflare provider can accept raw MIME; Resend/Postmark/Bavimail are structured-JSON. |
| **Rebuild from parsed parts** | ✅ Works on all four providers, authenticates on our own domain. |

So the copy is authored by us:

```
From:     "Jane Customer (via Acme Support)" <support@acme.com>
Reply-To: jane@example.com
To:       <the configured destination>
Subject:  <unchanged>
```

…with the original `From` / `Date` / `Subject` / `Cc` and the SPF/DKIM/DMARC verdicts restated in a header block at the top of the body. Same shape as "forward as new message" in any mail client.

**Accepted cost:** original DKIM signatures are not preserved. The original verdicts stay visible in saasmail and are restated in the forwarded body.

### 2. Subject is passed through unchanged (no `Fwd:` prefix)

This is a mail *redirect*, not a manual forward — an unchanged subject means the destination mailbox threads it the way the original conversation would. Easy to change if you'd rather see `Fwd:`.

### 3. No retry — best-effort, like the webhook

I deliberately did **not** use `sendViaOutbox`. It needs a `sent_emails` row id and its retry path reloads attachments from R2 filtered on `kind = "sent"`; a forward has neither. Threading one through would mean writing a **synthetic `sent_emails` row per inbound message**, which would put a duplicate of every inbound message into the Sent views and add a second, visually identical row to the Outbox page on failure. Failures are logged instead.

Worth revisiting if operators report dropped forwards — that's the main thing I'd flag as a possible follow-up.

### 4. Suppressions deliberately do not apply

Sent via `sender.send` rather than `sendWithSuppressionCheck`, because:
- Someone who unsubscribed from marketing must **still** receive their forwarded support mail.
- A relayed copy must not carry `List-Unsubscribe` headers or an appended unsubscribe footer for a message saasmail didn't author.

### 5. Original `Cc` recipients are NOT re-sent to

They're the *sender's* contacts. Mailing them would leak the redirect to people who never opted into it. They appear in the body header block only. There's an explicit test for this.

### 6. Loop prevention — three independent guards

1. **Config time** — the API rejects a destination equal to the inbox itself (400).
2. **Send time** — skips if the destination equals the inbox, or matches any row in `sender_identities`. Re-checked at send time because an inbox can be created *after* the rule was saved.
3. **Header trip-wire** — every forward carries `X-SaaSMail-Forwarded-For`; inbound mail already carrying it is never forwarded again, breaking indirect loops where the destination auto-forwards back.

> [!WARNING]
> **Provider caveat:** Bavimail's API has no generic custom-header field, so the trip-wire header is dropped there. Guard 3 degrades on Bavimail; guards 1 and 2 still cover the realistic cases. Documented in code.

### 7. Body fidelity required a small parser change

`parseEmail` returns quote-trimmed bodies for display. Forwarding a trimmed body would silently drop the quoted reply history the recipient needs, so `ParsedEmail` gains `fullBodyHtml` / `fullBodyText` (untrimmed; for HTML also *pre*-CID-rewrite). Storage and display are unchanged.

Pre-CID-rewrite matters: the stored HTML has `cid:` refs rewritten to `/api/attachments/{id}/inline`, which are session-authenticated relative paths — leaking those into external mail would render as broken images.

## Attachments

Passed through from the already-parsed in-memory buffers (no extra R2 reads), capped by the provider's `maxAttachmentBytes()`. Anything that doesn't fit is **named in the body** rather than silently dropped.

Known limitation: inline images arrive as ordinary attachments, since the Cloudflare provider's `addAttachment` has no `contentId`/inline support. Content preserved, inline rendering not.

## Safety

Forwarding runs **after** the message is durably stored, inside `ctx.waitUntil` with its own `try/catch` — the same contract as the existing webhook. Inbound ingestion is the primary job; a forward that fails can never cost us the message. It sits after the blocklist and Message-ID dedupe gates, so blocked senders and duplicate deliveries are never forwarded.

No new capability is granted: only admins can set this, and admins already have unrestricted `POST /api/send`. That's also why there's no destination-verification round-trip.

## Testing

- **`worker/src/__tests__/inbound-forward.test.ts`** — 33 new tests over the pure `buildForwardMessage`: all three loop guards (incl. case-insensitivity), From/Reply-To rewriting, RFC 5322 display-name quoting, Cc non-delivery, untrimmed-body usage, HTML-escaping of the header block against injection via sender name, attachment capping + the skip note, empty subject/body edges.
- **`admin-inboxes-router.test.ts`** — 7 new cases: persist, lowercase, malformed rejection, self-forward rejection, clearing, partial-update preservation, and both sides of the sparse-row-delete condition.

Keeping the decision logic pure is what makes this testable — `handleEmail` has no test coverage today and there's no way to construct a `ForwardableEmailMessage` in the suite.

```
Test Files  63 passed (63)
     Tests  522 passed | 1 skipped (523)
```

`yarn build` and `yarn format:check` both clean.

## ⚠️ Repo issue found along the way (not fixed here)

**CI's "Type check" step checks nothing.** Root `tsconfig.json` has `"files": []` with only a project reference, and `tsc --noEmit` without `--build` doesn't follow references — so `yarn tsc --noEmit` exits 0 in 0.4s having compiled zero files. On top of that, `tsconfig.app.json` only `include`s `src`, so **`worker/` is never type-checked at all**.

There are 6 pre-existing type errors in `src/` and ~26 in `worker/` (under `strict`) that CI has been silently passing over.

I verified my own code against a temporary strict config instead: **0 errors in `inbound-forward.ts`, `admin-inboxes-router.ts`, and `sender-identities.schema.ts`**; the 2 errors in files I edited (`email-handler.ts:295` `conversationId`, `email-parser.ts:197` attachment `content`) are on pre-existing lines I didn't touch.

Left alone to keep this PR focused — happy to open a separate one. `CLAUDE.md` also tells contributors to run `yarn tsc --noEmit`, which is currently a no-op.

## Migration

Generated with `yarn db:generate` (drizzle-kit) — `migrations/0031_aspiring_caretaker.sql`, plus `migrations/meta/0031_snapshot.json` and the journal entry:

```sql
ALTER TABLE `sender_identities` ADD `forward_to` text;
```

`worker/src/__tests__/helpers.ts` maintains the test schema as raw DDL separately, so that needed the column too.

<details>
<summary>Note on the snapshot chain (pre-existing, no action needed)</summary>

`db:generate` couldn't run in a fresh worktree until `.wrangler/state/.../*.sqlite` existed — `drizzle.config.ts` calls `getLocalD1DB()` eagerly and throws, even though `generate` needs no DB connection. Creating an empty placeholder file was enough.

Separately: snapshots stop at `0029` while migration `0030_outbox_emails` exists. That's consistent, not broken — `outbox_emails` is not exported from `worker/src/db/index.ts`, so drizzle-kit never tracked it, which is why `0030` was hand-written. The generated `0031` correctly contains only my `ALTER` and does not try to re-create `outbox_emails`. Its snapshot inherits the same omission.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
