### PR TITLE
docs(migrations): the drizzle generator works again — correct the stale README

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -3,7 +3,30 @@
 This directory holds the D1 (SQLite) migration history. Each
 `NNNN_*.sql` file is the actual DDL applied to the database; the
 `meta/_journal.json` index tells `wrangler d1 migrations apply`
-which files to run in what order.
+which files to run in what order, and `meta/NNNN_snapshot.json` is
+drizzle-kit's snapshot of the schema at that point (used to diff the
+next change).
+
+## Generating a migration
+
+The normal drizzle-kit workflow. **Do not hand-write migration SQL** —
+edit the schema and let the generator produce the file, so the
+snapshot chain stays consistent.
+
+```
+# 1. edit the schema in worker/src/db/*.schema.ts
+#    (for auth tables: change better-auth config + yarn auth:generate)
+yarn db:generate         # diffs schema against the latest snapshot ->
+                         # migrations/NNNN_*.sql + NNNN_snapshot.json + journal entry
+# 2. review the generated .sql (watch for unintended DROP / rename-as-drop)
+yarn db:migrate:dev      # apply to local D1
+```
+
+`yarn db:generate` reads its config from `drizzle.config.ts`, whose
+dev branch resolves the local D1 file under `.wrangler/`. If you
+haven't started the dev server yet it errors with
+`D1 directory not found … Run 'wrangler dev' first` — run the dev
+server once (or the e2e setup) so the local D1 exists, then generate.
 
 ## Apply path
 
@@ -15,40 +38,19 @@ yarn db:migrate:prod     # remote D1 — needs a wrangler login
 Both call `wrangler d1 migrations apply saasmail-db` under the hood.
 Migrations execute in `idx` order from `_journal.json`.
 
-## Why `yarn db:generate` (drizzle-kit) currently errors
+## History: the snapshot collision (resolved)
 
-`drizzle-kit generate` is broken on this repo with:
+`drizzle-kit generate` used to error on this repo because
+`0019_snapshot.json` and `0020_snapshot.json` shared an identical
+`id`, which the generator refuses to walk. During that window
+migrations `0021`–`0024` were hand-authored without snapshots.
 
-```
-Error: [migrations/meta/0019_snapshot.json,
-        migrations/meta/0020_snapshot.json] are pointing to a parent
-snapshot: …/0019_snapshot.json/snapshot.json which is a collision.
-```
-
-Both `0019_snapshot.json` and `0020_snapshot.json` have an identical
-`prevId` *and* `id`, which drizzle-kit refuses to walk. This
-predates the v0.5.0 cut — it ships from upstream `choyiny/saasmail`'s
-`dev` and isn't something this PR introduced.
-
-Until that collision is repaired upstream, drizzle-kit's generator
-isn't part of the workflow on this repo. Migrations from `0021_*`
-onward have therefore been **authored manually**:
-
-- The `.sql` file is hand-written and lives alongside the
-  drizzle-generated siblings.
-- A new entry is appended to `_journal.json` (`idx`, `version: "6"`,
-  `when` = the commit's `Date.now()`-style ms timestamp, `tag` =
-  the bare filename without extension, `breakpoints: true`).
-- No `NNNN_snapshot.json` is added — the generator that produces
-  those is the same one that fails on the prevId collision.
-
-The wrangler-applied path (which is what CI and prod actually use)
-is unaffected — it reads the `.sql` + `_journal.json` directly.
-
-## If you need `drizzle-kit generate` to work again
-
-Fix the `0019` / `0020` snapshot collision upstream and regenerate
-the schema diff from `0020` forward. That's a one-time cleanup;
-once `drizzle-kit generate` produces a clean snapshot for `0020`,
-new schema changes can go back through the normal generator
-workflow.
+Both problems were repaired in `42c8072` ("reconcile drizzle meta
+snapshots with migrations 0021–0024"): the `0020` snapshot id was
+made distinct and snapshots were backfilled for the hand-authored
+migrations. **The generator has worked since** — the normal
+`yarn db:generate` workflow above is the one to use. (`0030` is the
+only migration still missing a snapshot; it sits behind the latest
+snapshot `0031`, so it doesn't affect forward generation. If you want
+it fully clean, regenerate that one snapshot — it's not required for
+day-to-day work.)


### PR DESCRIPTION
`migrations/README.md` has a prominent section titled *"Why `yarn db:generate` (drizzle-kit) currently errors"* that tells contributors the generator is broken and instructs them to **hand-author migrations `0021+` without snapshots**. That guidance is stale and actively harmful — hand-authoring is exactly what desyncs drizzle's snapshot journal.

## The generator isn't broken

The `0019`/`0020` snapshot-id collision that once broke it was fixed in **`42c8072`** ("reconcile drizzle meta snapshots with migrations 0021–0024") back in May — that commit made the `0020` snapshot id distinct and backfilled the missing snapshots.

Verified empirically on `main` today:

```
$ yarn db:generate
26 tables
No schema changes, nothing to migrate 😴
```

No collision error, walks the full snapshot chain, reports no drift.

## What this PR changes

Docs only — `migrations/README.md`:

- Replaces the "generator is broken / hand-author instead" sections with the normal **edit-schema → `yarn db:generate` → review → apply** workflow.
- Documents a real gotcha: the dev config resolves the local D1 at load time, so `db:generate` errors with `D1 directory not found … Run 'wrangler dev' first` until the local D1 exists.
- Keeps a short history note about the resolved collision.
- Notes the one real remaining gap — `0030` has no snapshot — and flags it as harmless (it sits behind the latest snapshot `0031`, so forward generation is unaffected) and optional to fix.

## Why it matters now

This surfaced while renumbering PR #205's migration: I nearly followed the README down the hand-authoring path before testing the generator and finding it works. The regenerated `0032` migration on #205 came straight out of `yarn db:generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)