### PR TITLE
feat(templates)!: Mustache-style sections and escaping by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `failed` rather than retried forever. (#112)
 - Section nesting is capped at 64 levels; deeper templates are rejected as a
   parse error rather than overflowing the renderer's stack. (#112)
+- Total section expansion is capped at 20,000 body renders per template, as
+  `TEMPLATE_RENDER_ERROR` (a parse error to every caller). The 64-level cap
+  bounds how deep a template nests and the variables cap bounds the payload,
+  but neither bounds their product: a section nested inside itself cannot
+  resolve the inner name against the item frame, so it falls back to the same
+  top-level array and iterates it again, making work grow as N^depth from a
+  few hundred bytes of template. A 20-element array nested 8 deep asks for
+  2.6e10 renders. (#112)
 
 ### Changed
+
+- **Behavior change:** a template variable used inside a section that creates
+  no per-item scope is now validated, and a send that omits it fails with
+  `400` instead of substituting nothing. A section only scopes its body when
+  its value is an array or an object; an inverted `{{^key}}` section, and a
+  `{{#key}}` section given a boolean, render against the top level, so names
+  in those bodies are ordinary top-level lookups. Previously they were treated
+  as per-item and blanked, so `{{^has_orders}}Hi {{first_name}}{{/has_orders}}`
+  mailed "Hi ," and reported success. Names inside an _iterating_ section still
+  render empty when absent, since items legitimately differ in which optional
+  fields they carry. These names do not appear in
+  `GET /api/email-templates/{slug}/variables`, which is a static analysis and
+  cannot know what value a section will receive — the check happens at send
+  time. Sequence sends are unaffected; they have no failure channel and keep
+  rendering as before. (#112)
+- **Behavior change:** a variable used in scalar position that receives an
+  object or an array is rejected with `400` rather than rendering as an empty
+  string. Before the payload schema widened this was unrepresentable; now it
+  parses cleanly and mails a blank. Names used as sections are unaffected, so
+  boolean conditional sections keep working. (#112)
 
 - **BREAKING:** Template variables are now HTML-escaped by default. `{{name}}`
   escapes its value; use `{{{name}}}` to pass pre-rendered HTML through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the send, so a template can add a variable before every caller supplies it. (#227)
 - `{{key|nl2br}}` converts newlines to `<br>` after escaping, for multi-line
   values such as message bodies and address blocks. (#227)
+- Malformed templates now fail with a `400` carrying the parse diagnostic
+  (internally `TEMPLATE_PARSE_ERROR`) instead of rendering something
+  half-formed. Unbalanced or mismatched section tags (`{{#items}}` with no
+  `{{/items}}`, `{{/other}}` closing the wrong section) and unknown filters
+  are parse errors. This is a new failure mode on
+  `POST /api/email-templates/{slug}/send`,
+  `GET /api/email-templates/{slug}/variables`, and
+  `POST /api/send/reply/{id}` — those routes could not return 400 for this
+  reason before. A sequence step whose template does not parse is marked
+  `failed` rather than retried forever. (#112)
+- Section nesting is capped at 64 levels; deeper templates are rejected as a
+  parse error rather than overflowing the renderer's stack. (#112)
 
 ### Changed
 
@@ -36,12 +48,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   escapes its value; use `{{{name}}}` to pass pre-rendered HTML through
   unescaped. Templates that intentionally rendered HTML from a variable must
   switch those tags to the triple-brace form. Affects both the templates API
-  and sequence sends. (#227)
+  and sequence sends. Escaping applies to the HTML body; the subject line is
+  a plain-text header and is substituted as-is, as it always was. (#227)
 - **BREAKING:** Templates containing three or more consecutive braces now
   parse differently, because `{{{key}}}` means raw output. Previously
   `{{{name}}}` rendered as `{` + the value + `}`; it is now an unescaped
   substitution. Templates that only use `{{key}}` and ordinary text are
   unaffected. (#112)
+- `GET /api/email-templates/{slug}/variables` now returns only the **required**
+  variables — the names a caller must supply or the send is rejected. Names
+  marked optional with `{{key?}}` and names used inside a `{{#section}}` body
+  are deliberately omitted: a section-body name resolves against the current
+  item at render time, so it is not something the caller passes at the top
+  level, and listing it would suggest a contract that does not exist. The
+  response is unchanged for templates that use only `{{key}}` tags; it differs
+  only once a template adopts the new syntax. (#112)
+
+### Known limitations
+
+- The template editor UI does not recognise sections yet: its variable list
+  comes from an older extractor, so a template using `{{#items}}…{{/items}}`
+  will show a misleading set of variables in the editor and its preview may
+  not match what is sent. Exercise section templates through the API until the
+  follow-up lands. Sending is unaffected — the API and sequence sends use the
+  new renderer.
 
 ## [0.10.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI bootstrap: add unauthenticated `GET /api/health` and `GET /api/config` to the generated spec.
 - OpenAPI notifications: convert `notifications-router` to zod-openapi; document config, WebSocket stream, push subscribe/unsubscribe, and subscription management routes.
 - New outbound email provider: **Postmark**. Set `POSTMARK_API_KEY` (your Postmark server API token) as a secret to send through Postmark. Runtime precedence is Bavimail > Postmark > Resend > Cloudflare Email Sending.
+- Mustache-style sections in templates: `{{#items}}…{{/items}}` renders
+  conditionally and iterates arrays, `{{^items}}…{{/items}}` inverts, and
+  `{{.}}` refers to the current item. (#112)
+- `{{key?}}` marks a variable optional — it renders empty instead of failing
+  the send, so a template can add a variable before every caller supplies it. (#227)
+- `{{key|nl2br}}` converts newlines to `<br>` after escaping, for multi-line
+  values such as message bodies and address blocks. (#227)
+
+### Changed
+
+- **BREAKING:** Template variables are now HTML-escaped by default. `{{name}}`
+  escapes its value; use `{{{name}}}` to pass pre-rendered HTML through
+  unescaped. Templates that intentionally rendered HTML from a variable must
+  switch those tags to the triple-brace form. Affects both the templates API
+  and sequence sends. (#227)
+- **BREAKING:** Templates containing three or more consecutive braces now
+  parse differently, because `{{{key}}}` means raw output. Previously
+  `{{{name}}}` rendered as `{` + the value + `}`; it is now an unescaped
+  substitution. Templates that only use `{{key}}` and ordinary text are
+  unaffected. (#112)
 
 ## [0.10.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,14 @@ forward to another inbox on the same instance, and any message already carrying 
 
 ### Email Templates
 
-Create reusable HTML email templates with `{{variable}}` interpolation. Edit templates with a live HTML editor, preview rendered output, and send them via the API or the UI. Variables are automatically extracted and validated before sending. Templates are scoped to allowed inboxes.
+Create reusable HTML email templates with `{{variable}}` interpolation. Edit templates with a live HTML editor, preview rendered output, and send them via the API or the UI. Top-level variables are automatically extracted and validated before sending — a send that omits one is rejected with `400` rather than mailing a half-rendered template. Templates are scoped to allowed inboxes.
+
+**Validation covers top-level names only.** Names used inside a `{{#section}}`
+body are _not_ validated, because they resolve against the current item at
+render time rather than against what the caller passed. An unresolved name
+inside a section renders **empty**; only the section's own name is required.
+`GET /api/email-templates/{slug}/variables` reflects exactly this: it lists the
+required names, and omits both `{{key?}}` optionals and section-body names.
 
 #### Template syntax
 
@@ -167,12 +174,36 @@ Create reusable HTML email templates with `{{variable}}` interpolation. Edit tem
 ```
 
 Names inside a section resolve against the current item first, then fall back
-to the top level — so `{{currency}}` above can live outside `items`.
+to the top level — so `{{currency}}` above can live outside `items`. A name a
+section body cannot resolve renders empty; it is not reported as missing,
+because only the section's own name (`items`) is a caller contract.
+
+A tag name is a run of word characters (or a bare `.`), with no spaces inside
+the braces. Anything else — `{{ spaced }}`, `{{user.name}}`, `{{not-a-var}}` —
+is left alone as literal text, exactly as before the rewrite, so prose that
+happens to contain braces is never mistaken for a variable. Sections may nest
+up to 64 levels.
+
+An unbalanced or mismatched section tag is a **parse error**: the request
+fails with `400` and a diagnostic naming the offending tag, rather than
+sending something half-formed. This affects
+`POST /api/email-templates/{slug}/send`,
+`GET /api/email-templates/{slug}/variables`, and `POST /api/send/reply/{id}`.
+A sequence step whose template does not parse is marked `failed`.
+
+> **Caveat: the editor UI does not understand sections yet.** Its variable
+> list is computed by an older extractor, so a template using
+> `{{#items}}…{{/items}}` shows a misleading variable list in the editor and
+> its preview may not match what actually goes out. Sending is unaffected —
+> the API and sequence sends use the new renderer. Exercise section templates
+> via the API until the follow-up UI change lands.
 
 ##### Upgrading: escaping is now the default
 
-Variables were previously substituted raw. They are now HTML-escaped, so a
-value containing markup renders as text rather than as HTML.
+Variables were previously substituted raw. They are now HTML-escaped in the
+body, so a value containing markup renders as text rather than as HTML. The
+subject line is a plain-text header, not HTML, so values substituted there are
+passed through unchanged — as they always have been.
 
 **If any of your templates deliberately pass HTML through a variable, change
 those tags from `{{key}}` to `{{{key}}}` before upgrading.** Templates whose

--- a/README.md
+++ b/README.md
@@ -143,6 +143,51 @@ forward to another inbox on the same instance, and any message already carrying 
 
 Create reusable HTML email templates with `{{variable}}` interpolation. Edit templates with a live HTML editor, preview rendered output, and send them via the API or the UI. Variables are automatically extracted and validated before sending. Templates are scoped to allowed inboxes.
 
+#### Template syntax
+
+| Tag                 | Behavior                                            |
+| ------------------- | --------------------------------------------------- |
+| `{{key}}`           | Value, HTML-escaped                                 |
+| `{{{key}}}`         | Value, raw — for pre-rendered HTML                  |
+| `{{key?}}`          | Optional; renders empty instead of failing the send |
+| `{{key\|nl2br}}`    | Escaped, then newlines become `<br>`                |
+| `{{#key}}…{{/key}}` | Renders if truthy; iterates arrays                  |
+| `{{^key}}…{{/key}}` | Renders if falsy or empty                           |
+| `{{.}}`             | Current item inside an array-of-strings section     |
+
+```html
+{{#items}}
+<tr>
+  <td>{{name}}</td>
+  <td>{{currency}}{{price}}</td>
+</tr>
+{{/items}} {{^items}}
+<p>Nothing to show yet.</p>
+{{/items}}
+```
+
+Names inside a section resolve against the current item first, then fall back
+to the top level — so `{{currency}}` above can live outside `items`.
+
+##### Upgrading: escaping is now the default
+
+Variables were previously substituted raw. They are now HTML-escaped, so a
+value containing markup renders as text rather than as HTML.
+
+**If any of your templates deliberately pass HTML through a variable, change
+those tags from `{{key}}` to `{{{key}}}` before upgrading.** Templates whose
+variables carry plain text need no change.
+
+One related consequence: because `{{{key}}}` now means raw output, any run of
+three or more consecutive braces is read differently than before. `{{{name}}}`
+used to render as `{` followed by the substituted value followed by `}`; it is
+now an unescaped substitution. This only affects templates that stack braces
+against a tag — ordinary `{{key}}` tags in ordinary text are untouched.
+
+This also applies to sequence sends, which share the same renderer.
+Multi-line values still collapse in HTML — use `{{key|nl2br}}`, or wrap the
+block in `style="white-space: pre-line"`.
+
 ### Email Sequencing
 
 Build multi-step drip campaigns. Enroll a contact into a sequence and saasmail sends templated emails on a schedule. Supports step skipping, delay overrides, custom variables, and automatic cancellation when the contact replies. Enrollment is enforced against the member's allowed inboxes.

--- a/worker/src/__tests__/email-templates-router.test.ts
+++ b/worker/src/__tests__/email-templates-router.test.ts
@@ -89,6 +89,38 @@ describe("email templates router", () => {
     });
   });
 
+  describe("GET /api/email-templates/:slug/variables", () => {
+    it("returns the required variables", async () => {
+      await createTestTemplate({
+        slug: "welcome",
+        subject: "Hello {{name}}",
+        bodyHtml: "<p>Hi {{name}}, from {{company}}</p>",
+      });
+
+      const res = await authFetch("/api/email-templates/welcome/variables", {
+        apiKey,
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(new Set(data.variables)).toEqual(new Set(["name", "company"]));
+    });
+
+    it("returns 400, not 500, for a template with an unbalanced section", async () => {
+      await createTestTemplate({
+        slug: "broken",
+        subject: "Hello",
+        bodyHtml: "{{#a}}oops",
+      });
+
+      const res = await authFetch("/api/email-templates/broken/variables", {
+        apiKey,
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBeTruthy();
+    });
+  });
+
   describe("PUT /api/email-templates/:slug", () => {
     it("updates template fields", async () => {
       await createTestTemplate({ slug: "welcome" });
@@ -184,6 +216,30 @@ describe("email templates router", () => {
       // No sent_emails row should have been written for the suppressed send
       const sentRows = await db.select().from(sentEmails);
       expect(sentRows).toHaveLength(0);
+    });
+
+    it("returns TEMPLATE_PARSE_ERROR with the parse diagnostic for an unbalanced section", async () => {
+      await createTestTemplate({
+        slug: "broken",
+        subject: "Hi",
+        bodyHtml: "{{#a}}oops",
+      });
+
+      const res = await authFetch("/api/email-templates/broken/send", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          to: "person@example.com",
+          fromAddress: "support@example.com",
+          variables: {},
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/\{\{#a\}\}/);
+      expect(data.missingVariables).toBeUndefined();
+      expect(data.requiredVariables).toBeUndefined();
     });
   });
 

--- a/worker/src/__tests__/interpolate-analyze.test.ts
+++ b/worker/src/__tests__/interpolate-analyze.test.ts
@@ -83,6 +83,22 @@ describe("analyzeTemplate — the validation split", () => {
     expect(a.optional).toEqual([]);
   });
 
+  it("does not require the dot as a section name", () => {
+    // `{{#.}}` iterates the current item; there is no top-level "." for a
+    // caller to supply, so requiring it made such a template unsendable.
+    const a = analyzeTemplate("{{#.}}x{{/.}}");
+    expect(a.required).toEqual([]);
+    expect(a.optional).toEqual([]);
+  });
+
+  it("does not treat padded or dotted names as variables", () => {
+    // Legacy left these as literal prose; promoting them to required would
+    // start failing sends for names the caller never heard of.
+    const a = analyzeTemplate("{{ spaced }} {{ name }} {{example.com}}");
+    expect(a.required).toEqual([]);
+    expect(a.optional).toEqual([]);
+  });
+
   it("merges duplicate section entries across sources by name", () => {
     const a = analyzeTemplate(
       "{{#items}}{{price}}{{/items}}",
@@ -123,6 +139,25 @@ describe("renderTemplate", () => {
     const r = renderTemplate({ subject: "Hi", bodyHtml: "{{promo?}}" }, {});
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.bodyHtml).toBe("");
+  });
+
+  it("renders the subject as plain text and the body as HTML", () => {
+    const r = renderTemplate(
+      { subject: "Hi {{name}}", bodyHtml: "<p>Hi {{name}}</p>" },
+      { name: `O'Brien & <VIP>` },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.subject).toBe(`Hi O'Brien & <VIP>`);
+    expect(r.bodyHtml).toBe("<p>Hi O&#39;Brien &amp; &lt;VIP&gt;</p>");
+  });
+
+  it("does not count an inherited member as a supplied variable", () => {
+    // With `v in variables` the missing-check would report `constructor` as
+    // supplied and let the send through with nothing behind it.
+    const r = renderTemplate({ subject: "x", bodyHtml: "{{constructor}}" }, {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.missingVariables).toEqual(["constructor"]);
   });
 
   it("reports a parse error instead of throwing", () => {

--- a/worker/src/__tests__/interpolate-analyze.test.ts
+++ b/worker/src/__tests__/interpolate-analyze.test.ts
@@ -26,6 +26,38 @@ describe("analyzeTemplate — the validation split", () => {
     expect(a.optional).toEqual(["b"]);
   });
 
+  it("reports a name used as both an inverted and a regular section as regular", () => {
+    // Order must not decide polarity. Writing the empty-state branch first
+    // used to leave the merged entry `inverted: true` while `required`
+    // (correctly) contained "items" — the API and the editor chip then
+    // described a required section as an optional absence branch.
+    const emptyFirst = analyzeTemplate(
+      "{{^items}}none{{/items}}{{#items}}{{label}}{{/items}}",
+    );
+    expect(emptyFirst.required).toEqual(["items"]);
+    expect(emptyFirst.sections).toEqual([
+      { name: "items", inverted: false, variables: ["label"] },
+    ]);
+
+    // The reverse order already worked; pin that it still does.
+    const loopFirst = analyzeTemplate(
+      "{{#items}}{{label}}{{/items}}{{^items}}none{{/items}}",
+    );
+    expect(loopFirst.sections).toEqual(emptyFirst.sections);
+  });
+
+  it("keeps a section inverted when every occurrence is inverted", () => {
+    const a = analyzeTemplate(
+      "{{^items}}none{{/items}}",
+      "{{^items}}x{{/items}}",
+    );
+    expect(a.required).toEqual([]);
+    expect(a.optional).toEqual(["items"]);
+    expect(a.sections).toEqual([
+      { name: "items", inverted: true, variables: [] },
+    ]);
+  });
+
   it("treats {{#a?}} as optional", () => {
     const a = analyzeTemplate("{{#a?}}x{{/a}}");
     expect(a.required).toEqual([]);

--- a/worker/src/__tests__/interpolate-analyze.test.ts
+++ b/worker/src/__tests__/interpolate-analyze.test.ts
@@ -48,6 +48,50 @@ describe("analyzeTemplate — the validation split", () => {
     const a = analyzeTemplate("Hi {{name}}", "<p>{{name}} {{email}}</p>");
     expect(a.required).toEqual(["name", "email"]);
   });
+
+  it("does not leak names from a doubly-nested section into required/optional", () => {
+    // Guards against collectInner's nested-section branch accidentally
+    // recursing via walkTopLevel instead of into itself, which would only
+    // leak names at depth >= 2 — a bug the single-nesting tests above would
+    // not catch.
+    const a = analyzeTemplate(
+      "{{#orders}}{{id}}{{#lines}}{{sku}}{{/lines}}{{/orders}}",
+    );
+    expect(a.required).toEqual(["orders"]);
+    expect(a.required).not.toContain("id");
+    expect(a.required).not.toContain("sku");
+    expect(a.required).not.toContain("lines");
+    expect(a.optional).not.toContain("id");
+    expect(a.optional).not.toContain("sku");
+    expect(a.optional).not.toContain("lines");
+  });
+
+  it("resolves a name that is both required and optional in favor of required", () => {
+    // Guards against the dedup loop running backwards (deleting from
+    // `required` based on `optional` membership instead of the other way
+    // around), which would silently make a required name optional.
+    const a = analyzeTemplate("{{name}}{{name?}}");
+    expect(a.required).toEqual(["name"]);
+    expect(a.optional).toEqual([]);
+  });
+
+  it("resolves the same required/optional collision across two sources", () => {
+    // The merge happens after both sources are walked, so this must hold
+    // regardless of which source declares the name optional first.
+    const a = analyzeTemplate("{{name?}}", "{{name}}");
+    expect(a.required).toEqual(["name"]);
+    expect(a.optional).toEqual([]);
+  });
+
+  it("merges duplicate section entries across sources by name", () => {
+    const a = analyzeTemplate(
+      "{{#items}}{{price}}{{/items}}",
+      "{{#items}}{{qty}}{{/items}}",
+    );
+    expect(a.sections).toEqual([
+      { name: "items", inverted: false, variables: ["price", "qty"] },
+    ]);
+  });
 });
 
 describe("extractVariables", () => {

--- a/worker/src/__tests__/interpolate-analyze.test.ts
+++ b/worker/src/__tests__/interpolate-analyze.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeTemplate,
+  extractVariables,
+  renderTemplate,
+} from "../lib/interpolate";
+
+describe("analyzeTemplate — the validation split", () => {
+  it("does NOT mark a section-body variable as required", () => {
+    // The regression that would break every existing send if inverted.
+    const a = analyzeTemplate("{{#items}}{{price}}{{/items}}");
+    expect(a.required).toEqual(["items"]);
+    expect(a.required).not.toContain("price");
+  });
+
+  it("reports section-body variables under sections", () => {
+    const a = analyzeTemplate("{{#items}}{{price}}{{qty}}{{/items}}");
+    expect(a.sections).toEqual([
+      { name: "items", inverted: false, variables: ["price", "qty"] },
+    ]);
+  });
+
+  it("marks a regular section required and an inverted section optional", () => {
+    const a = analyzeTemplate("{{#a}}x{{/a}}{{^b}}y{{/b}}");
+    expect(a.required).toEqual(["a"]);
+    expect(a.optional).toEqual(["b"]);
+  });
+
+  it("treats {{#a?}} as optional", () => {
+    const a = analyzeTemplate("{{#a?}}x{{/a}}");
+    expect(a.required).toEqual([]);
+    expect(a.optional).toEqual(["a"]);
+  });
+
+  it("separates optional from required top-level variables", () => {
+    const a = analyzeTemplate("{{name}}{{nickname?}}");
+    expect(a.required).toEqual(["name"]);
+    expect(a.optional).toEqual(["nickname"]);
+  });
+
+  it("ignores the dot tag", () => {
+    const a = analyzeTemplate("{{#tags}}{{.}}{{/tags}}");
+    expect(a.required).toEqual(["tags"]);
+    expect(a.sections[0].variables).toEqual([]);
+  });
+
+  it("merges across multiple sources and de-duplicates", () => {
+    const a = analyzeTemplate("Hi {{name}}", "<p>{{name}} {{email}}</p>");
+    expect(a.required).toEqual(["name", "email"]);
+  });
+});
+
+describe("extractVariables", () => {
+  it("returns the required set, preserving the pre-rewrite contract", () => {
+    expect(extractVariables("Hi {{name}}, {{email}}")).toEqual([
+      "name",
+      "email",
+    ]);
+  });
+});
+
+describe("renderTemplate", () => {
+  it("succeeds when only the section name is supplied", () => {
+    const r = renderTemplate(
+      { subject: "Digest", bodyHtml: "{{#items}}{{price}}{{/items}}" },
+      { items: [{ price: "10" }] },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bodyHtml).toBe("10");
+  });
+
+  it("still fails a send when a required top-level variable is missing", () => {
+    const r = renderTemplate({ subject: "Hi {{name}}", bodyHtml: "x" }, {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.missingVariables).toEqual(["name"]);
+  });
+
+  it("does not require an optional variable", () => {
+    const r = renderTemplate({ subject: "Hi", bodyHtml: "{{promo?}}" }, {});
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bodyHtml).toBe("");
+  });
+
+  it("reports a parse error instead of throwing", () => {
+    const r = renderTemplate({ subject: "x", bodyHtml: "{{#a}}oops" }, {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.parseError).toMatch(/unclosed section/i);
+  });
+});

--- a/worker/src/__tests__/interpolate-compat.test.ts
+++ b/worker/src/__tests__/interpolate-compat.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import { interpolate } from "../lib/interpolate";
+
+/**
+ * The pre-rewrite implementation, frozen verbatim. The differential test below
+ * asserts the new renderer agrees with this on every template shape that can
+ * exist in a deployed instance today. Do not "fix" or modernise this copy —
+ * its whole value is being the old behavior.
+ */
+const LEGACY_REGEX = /\{\{(\w+)\}\}/g;
+function legacyInterpolate(
+  template: string,
+  variables: Record<string, string>,
+): string {
+  return template.replace(LEGACY_REGEX, (match, key) =>
+    key in variables ? variables[key] : match,
+  );
+}
+
+/** Deterministic PRNG so a failure is reproducible from the seed alone. */
+function makeRandom(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+const NAMES = ["name", "email", "feature", "date", "time", "url", "x", "y"];
+// HTML-free values only: where the two implementations intentionally diverge
+// (values containing markup) is covered by the escaping tests, not here.
+const VALUES = ["Alice", "", "hi there", "10:00 GMT", "Ada Lovelace", "42"];
+const LITERALS = [
+  "<p>",
+  "</p>",
+  " and ",
+  "\n",
+  "{{",
+  "}}",
+  "{{not-a-var}}",
+  "{{ spaced }}",
+  "text",
+  "<br/>",
+];
+
+function randomTemplate(rand: () => number): string {
+  const parts: string[] = [];
+  const n = 1 + Math.floor(rand() * 12);
+  for (let i = 0; i < n; i++) {
+    if (rand() < 0.5) {
+      parts.push(LITERALS[Math.floor(rand() * LITERALS.length)]);
+    } else {
+      parts.push(`{{${NAMES[Math.floor(rand() * NAMES.length)]}}}`);
+    }
+  }
+  return parts.join("");
+}
+
+function randomVariables(rand: () => number): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const name of NAMES) {
+    // Some names deliberately left unsupplied so unmatched tags are exercised.
+    if (rand() < 0.7) vars[name] = VALUES[Math.floor(rand() * VALUES.length)];
+  }
+  return vars;
+}
+
+describe("interpolate — differential against frozen legacy implementation", () => {
+  it("agrees with the legacy renderer on 5000 random flat templates", () => {
+    const rand = makeRandom(20260803);
+    const mismatches: Array<{ template: string; vars: unknown }> = [];
+    for (let i = 0; i < 5000; i++) {
+      const template = randomTemplate(rand);
+      const vars = randomVariables(rand);
+      if (interpolate(template, vars) !== legacyInterpolate(template, vars)) {
+        mismatches.push({ template, vars });
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+});
+
+/**
+ * The seven templates seeded by `seeds/generate-demo.ts`, rendered with
+ * plain-text values. Expected strings were generated from the pre-rewrite
+ * implementation. These are what a real deployed instance sends.
+ */
+const CORPUS_VARS = {
+  name: "Ada Lovelace",
+  feature: "Scheduled sends",
+  date: "Tuesday",
+  time: "10:00 GMT",
+};
+
+/*
+ * Expected strings were captured from the pre-rewrite implementation and are
+ * pinned here as literals rather than recomputed from `legacyInterpolate`.
+ * Comparing the renderer against a copy of itself would pass even if both were
+ * wrong; a literal is an independent check.
+ */
+const CORPUS: Array<{
+  slug: string;
+  subject: string;
+  body: string;
+  expectedSubject: string;
+  expectedBody: string;
+}> = [
+  {
+    slug: "intro-followup",
+    subject: "Following up on our chat",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Wanted to follow up on what we discussed and see if you had a chance to think it over.</p>" +
+      "<p>Happy to dive deeper into anything that caught your eye — or just answer questions.</p>" +
+      "<p>Cheers,<br/>The team</p>",
+    expectedSubject: "Following up on our chat",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Wanted to follow up on what we discussed and see if you had a chance to think it over.</p>" +
+      "<p>Happy to dive deeper into anything that caught your eye — or just answer questions.</p>" +
+      "<p>Cheers,<br/>The team</p>",
+  },
+  {
+    slug: "re-engagement",
+    subject: "Long time no see, {{name}}",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>It's been a while! Things have moved a lot on our end and I thought you might be interested in what we've shipped recently.</p>" +
+      "<p>If now's a better time to chat, just hit reply.</p>",
+    expectedSubject: "Long time no see, Ada Lovelace",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>It's been a while! Things have moved a lot on our end and I thought you might be interested in what we've shipped recently.</p>" +
+      "<p>If now's a better time to chat, just hit reply.</p>",
+  },
+  {
+    slug: "pricing-info",
+    subject: "Pricing details for {{name}}",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Putting together the plan options we discussed. Three tiers depending on volume — happy to walk through which makes sense for your team.</p>" +
+      "<p>Quick call this week?</p>",
+    expectedSubject: "Pricing details for Ada Lovelace",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Putting together the plan options we discussed. Three tiers depending on volume — happy to walk through which makes sense for your team.</p>" +
+      "<p>Quick call this week?</p>",
+  },
+  {
+    slug: "welcome-onboarding",
+    subject: "Welcome to the team, {{name}}",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Welcome aboard! We're thrilled to have you using the platform.</p>" +
+      "<p>A few things to get you started:</p>" +
+      "<ul><li>Set up your first inbox under Settings</li>" +
+      "<li>Invite your team members</li>" +
+      "<li>Connect your domain so DKIM/SPF check out</li></ul>" +
+      "<p>Reply if anything trips you up.</p>",
+    expectedSubject: "Welcome to the team, Ada Lovelace",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Welcome aboard! We're thrilled to have you using the platform.</p>" +
+      "<p>A few things to get you started:</p>" +
+      "<ul><li>Set up your first inbox under Settings</li>" +
+      "<li>Invite your team members</li>" +
+      "<li>Connect your domain so DKIM/SPF check out</li></ul>" +
+      "<p>Reply if anything trips you up.</p>",
+  },
+  {
+    slug: "feature-launch",
+    subject: "Just shipped: {{feature}}",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Quick heads up — we just shipped {{feature}}. You'll see it in your dashboard now.</p>" +
+      "<p>Full details on the changelog. Reply if you hit any issues.</p>",
+    expectedSubject: "Just shipped: Scheduled sends",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Quick heads up — we just shipped Scheduled sends. You'll see it in your dashboard now.</p>" +
+      "<p>Full details on the changelog. Reply if you hit any issues.</p>",
+  },
+  {
+    slug: "support-followup",
+    subject: "Following up on your support request",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Just checking in on the issue you flagged. Did our last reply resolve it on your end?</p>" +
+      "<p>If you're still stuck, ping back and we'll dig in further.</p>",
+    expectedSubject: "Following up on your support request",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Just checking in on the issue you flagged. Did our last reply resolve it on your end?</p>" +
+      "<p>If you're still stuck, ping back and we'll dig in further.</p>",
+  },
+  {
+    slug: "meeting-confirm",
+    subject: "Confirming our call on {{date}}",
+    body:
+      "<p>Hi {{name}},</p>" +
+      "<p>Confirming our call on {{date}} at {{time}}. Calendar invite is on the way.</p>" +
+      "<p>If anything changes, let me know — happy to reschedule.</p>",
+    expectedSubject: "Confirming our call on Tuesday",
+    expectedBody:
+      "<p>Hi Ada Lovelace,</p>" +
+      "<p>Confirming our call on Tuesday at 10:00 GMT. Calendar invite is on the way.</p>" +
+      "<p>If anything changes, let me know — happy to reschedule.</p>",
+  },
+];
+
+describe("interpolate — golden corpus from seeds/generate-demo.ts", () => {
+  it.each(CORPUS)(
+    "renders $slug byte-identically to the pinned pre-rewrite output",
+    ({ subject, body, expectedSubject, expectedBody }) => {
+      expect(interpolate(subject, CORPUS_VARS)).toBe(expectedSubject);
+      expect(interpolate(body, CORPUS_VARS)).toBe(expectedBody);
+    },
+  );
+
+  it("does not escape apostrophes in the template's own prose", () => {
+    // The seeded bodies contain "It's" / "you'll" as literal text. Escaping the
+    // output string rather than each substituted value would corrupt them.
+    const rendered = interpolate(CORPUS[1].body, CORPUS_VARS);
+    expect(rendered).toContain("It's been a while");
+    expect(rendered).not.toContain("&#39;");
+  });
+});

--- a/worker/src/__tests__/interpolate-compat.test.ts
+++ b/worker/src/__tests__/interpolate-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpolate } from "../lib/interpolate";
+import { interpolate, renderTemplate } from "../lib/interpolate";
 
 /**
  * The pre-rewrite implementation, frozen verbatim. The differential test below
@@ -26,7 +26,23 @@ function makeRandom(seed: number): () => number {
   };
 }
 
-const NAMES = ["name", "email", "feature", "date", "time", "url", "x", "y"];
+// "spaced" is here on purpose: `LITERALS` contains "{{ spaced }}", and unless
+// "spaced" is also a name the generator supplies a value for, both renderers
+// leave that literal alone for the same reason (nothing to substitute) and the
+// fuzz proves nothing about whitespace-padded tags. With it supplied, any
+// implementation that accepts `{{ spaced }}` as a tag substitutes where legacy
+// did not, and the differential fails.
+const NAMES = [
+  "name",
+  "email",
+  "feature",
+  "date",
+  "time",
+  "url",
+  "x",
+  "y",
+  "spaced",
+];
 // HTML-free values only: where the two implementations intentionally diverge
 // (values containing markup) is covered by the escaping tests, not here.
 const VALUES = ["Alice", "", "hi there", "10:00 GMT", "Ada Lovelace", "42"];
@@ -262,6 +278,28 @@ describe("interpolate — golden corpus from seeds/generate-demo.ts", () => {
       expect(interpolate(body, CORPUS_VARS)).toBe(expectedBody);
     },
   );
+
+  it("renders a seeded subject with an HTML-significant value exactly as before", () => {
+    // The corpus above deliberately uses HTML-free values, which is precisely
+    // how subject escaping went unnoticed: a Subject header is PLAIN TEXT, so
+    // a recipient named O'Brien must not receive "O&#39;Brien". Five of the
+    // seeded demo templates put {{name}} in the subject, so this is a stock
+    // install's behavior, not an exotic case. The body of the same render
+    // stays escaped — it really is HTML.
+    const vars = { name: `O'Brien & Sons <VIP> "Ltd"` };
+    const r = renderTemplate(
+      { subject: CORPUS[1].subject, bodyHtml: "<p>Hi {{name}},</p>" },
+      vars,
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.subject).toBe(`Long time no see, O'Brien & Sons <VIP> "Ltd"`);
+    // Byte-identical to what the pre-rewrite renderer produced for a subject.
+    expect(r.subject).toBe(legacyInterpolate(CORPUS[1].subject, vars));
+    expect(r.bodyHtml).toBe(
+      "<p>Hi O&#39;Brien &amp; Sons &lt;VIP&gt; &quot;Ltd&quot;,</p>",
+    );
+  });
 
   it("does not escape apostrophes in the template's own prose", () => {
     // The seeded bodies contain "It's" / "you'll" as literal text. Escaping the

--- a/worker/src/__tests__/interpolate-compat.test.ts
+++ b/worker/src/__tests__/interpolate-compat.test.ts
@@ -65,18 +65,64 @@ function randomVariables(rand: () => number): Record<string, string> {
   return vars;
 }
 
+/**
+ * True if the template contains a run of 3+ consecutive `{` or `}`.
+ *
+ * The legacy renderer had no raw syntax, so it read `{{{name}}}` as literal
+ * `{` + tag `{{name}}` + literal `}`. Supporting `{{{raw}}}` means the new
+ * tokenizer reads that same input as a single raw tag instead — the two
+ * readings are mutually exclusive by construction. `LITERALS` below includes
+ * bare `"{{"` and `"}}"`, which the generator concatenates with real
+ * `{{name}}` tags to produce exactly these 3+ brace runs (e.g. `"{{" +
+ * "{{name}}"` = `"{{{{name}}"`). Asserting byte-identical output there would
+ * be asserting a property the feature deliberately breaks, not a regression.
+ * New, deliberate behavior on brace runs is pinned explicitly below instead
+ * of excluded silently.
+ */
+function hasLongBraceRun(template: string): boolean {
+  return /\{{3,}|\}{3,}/.test(template);
+}
+
 describe("interpolate — differential against frozen legacy implementation", () => {
-  it("agrees with the legacy renderer on 5000 random flat templates", () => {
+  it("agrees with the legacy renderer on 5000 random flat templates without 3+ brace runs", () => {
     const rand = makeRandom(20260803);
     const mismatches: Array<{ template: string; vars: unknown }> = [];
-    for (let i = 0; i < 5000; i++) {
-      const template = randomTemplate(rand);
+    let asserted = 0;
+    while (asserted < 5000) {
+      let template = randomTemplate(rand);
+      while (hasLongBraceRun(template)) {
+        template = randomTemplate(rand);
+      }
       const vars = randomVariables(rand);
       if (interpolate(template, vars) !== legacyInterpolate(template, vars)) {
         mismatches.push({ template, vars });
       }
+      asserted++;
     }
+    expect(asserted).toBe(5000);
     expect(mismatches).toEqual([]);
+  });
+});
+
+/**
+ * `{{{raw}}}` necessarily changes what 3+ consecutive braces mean (see
+ * `hasLongBraceRun` above for why). These pin the new tokenizer's actual,
+ * accepted behavior on such inputs so the divergence from legacy is covered
+ * by a test instead of merely excluded from the fuzz.
+ */
+describe("interpolate — brace-run behavior (accepted break from legacy)", () => {
+  it("reads a clean triple-brace run as one raw tag", () => {
+    // Legacy (no raw syntax) would have read this as literal "{" + tag
+    // "{{name}}" + literal "}", rendering "{Alice}". The new tokenizer reads
+    // the whole thing as a single raw `{{{name}}}` tag instead.
+    expect(interpolate("{{{name}}}", { name: "Alice" })).toBe("Alice");
+  });
+
+  it("reads a quadruple-brace run as a raw tag plus one leftover literal brace on each side", () => {
+    // The two extra braces (one leading, one trailing) beyond the raw tag's
+    // own three-and-three aren't consumed by any tag and pass through as
+    // literal text, giving "{Alice}" rather than legacy's flat-regex reading.
+    expect(interpolate("{{{{name}}}}", { name: "Alice" })).toBe("{Alice}");
   });
 });
 

--- a/worker/src/__tests__/interpolate-fuzz.test.ts
+++ b/worker/src/__tests__/interpolate-fuzz.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { interpolate, TemplateParseError } from "../lib/interpolate";
+
+const CHUNKS = [
+  "{{",
+  "}}",
+  "{{{",
+  "}}}",
+  "{{#a}}",
+  "{{/a}}",
+  "{{/b}}",
+  "{{^a}}",
+  "{{a}}",
+  "{{a?}}",
+  "{{a|nl2br}}",
+  "{{.}}",
+  "text",
+  "<p>",
+  "\n",
+  "{",
+  "}",
+  "{{}}",
+];
+
+function makeRandom(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+describe("interpolate — robustness", () => {
+  it("never throws anything but TemplateParseError on arbitrary input", () => {
+    const rand = makeRandom(7);
+    for (let i = 0; i < 5000; i++) {
+      const n = 1 + Math.floor(rand() * 10);
+      const template = Array.from(
+        { length: n },
+        () => CHUNKS[Math.floor(rand() * CHUNKS.length)],
+      ).join("");
+      try {
+        interpolate(template, { a: "x" });
+      } catch (err) {
+        expect(err).toBeInstanceOf(TemplateParseError);
+      }
+    }
+  });
+
+  it("handles deeply nested sections without blowing the stack", () => {
+    const depth = 200;
+    const template = "{{#a}}".repeat(depth) + "x" + "{{/a}}".repeat(depth);
+    expect(interpolate(template, { a: true })).toBe("x");
+  });
+
+  it("handles a very long template", () => {
+    const template = "<p>{{name}}</p>".repeat(20000);
+    expect(interpolate(template, { name: "Ada" })).toContain("<p>Ada</p>");
+  });
+});

--- a/worker/src/__tests__/interpolate-fuzz.test.ts
+++ b/worker/src/__tests__/interpolate-fuzz.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { interpolate, TemplateParseError } from "../lib/interpolate";
+import {
+  analyzeTemplate,
+  interpolate,
+  MAX_SECTION_DEPTH,
+  TemplateParseError,
+} from "../lib/interpolate";
 
 const CHUNKS = [
   "{{",
@@ -47,10 +52,33 @@ describe("interpolate — robustness", () => {
     }
   });
 
-  it("handles deeply nested sections without blowing the stack", () => {
-    const depth = 200;
-    const template = "{{#a}}".repeat(depth) + "x" + "{{/a}}".repeat(depth);
+  it("renders sections nested to exactly the depth limit", () => {
+    const template =
+      "{{#a}}".repeat(MAX_SECTION_DEPTH) +
+      "x" +
+      "{{/a}}".repeat(MAX_SECTION_DEPTH);
     expect(interpolate(template, { a: true })).toBe("x");
+  });
+
+  it("rejects nesting past the limit with a parse error, not a RangeError", () => {
+    // Rendering and analyzeTemplate's inner collection both recurse per level,
+    // so unbounded depth would overflow the stack and escape as an unhandled
+    // 500 (workerd's stack is smaller than Node's). The cap converts that into
+    // a TemplateParseError, which every caller already handles as a 400.
+    const depth = MAX_SECTION_DEPTH + 1;
+    const template = "{{#a}}".repeat(depth) + "x" + "{{/a}}".repeat(depth);
+    expect(() => interpolate(template, { a: true })).toThrow(
+      TemplateParseError,
+    );
+    expect(() => interpolate(template, { a: true })).toThrow(
+      /nested too deeply/i,
+    );
+  });
+
+  it("caps analyzeTemplate the same way, since it recurses too", () => {
+    const depth = MAX_SECTION_DEPTH + 1;
+    const template = "{{#a}}".repeat(depth) + "{{x}}" + "{{/a}}".repeat(depth);
+    expect(() => analyzeTemplate(template)).toThrow(TemplateParseError);
   });
 
   it("handles a very long template", () => {

--- a/worker/src/__tests__/interpolate-guards.test.ts
+++ b/worker/src/__tests__/interpolate-guards.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  interpolate,
+  renderTemplate,
+  TemplateParseError,
+  TemplateRenderError,
+  MAX_SECTION_RENDERS,
+} from "../lib/interpolate";
+
+/**
+ * Two classes of silent failure that the section rewrite introduced, both
+ * found in review of the stack. Neither is about parsing — a template can be
+ * perfectly well-formed and still hit them — so they live apart from the
+ * tokenizer/parser suites.
+ */
+
+describe("render work budget", () => {
+  /**
+   * Nesting a section inside itself is the pathological case: the inner
+   * `{{#items}}` cannot resolve against the item frame, so `lookup` falls back
+   * to the top-level array and iterates it again. Work grows as N^depth while
+   * both the template and the payload stay tiny, so neither MAX_SECTION_DEPTH
+   * (which bounds nesting) nor MAX_VARIABLE_DEPTH (which bounds the payload)
+   * sees anything wrong.
+   */
+  it("rejects a self-nested section instead of expanding it exponentially", () => {
+    const depth = 6;
+    const body = "{{#items}}".repeat(depth) + "x" + "{{/items}}".repeat(depth);
+    const items = Array.from({ length: 20 }, (_, i) => ({ i }));
+
+    // 20^6 = 64,000,000 renders if unbounded.
+    expect(() => interpolate(body, { items })).toThrow(TemplateRenderError);
+  });
+
+  it("names the budget in the error so the author can see what happened", () => {
+    const body =
+      "{{#items}}{{#items}}{{#items}}x{{/items}}{{/items}}{{/items}}";
+    const items = Array.from({ length: 40 }, (_, i) => ({ i }));
+    expect(() => interpolate(body, { items })).toThrow(
+      new RegExp(String(MAX_SECTION_RENDERS)),
+    );
+  });
+
+  it("is a TemplateParseError subclass, so every existing caller still catches it", () => {
+    const body =
+      "{{#items}}{{#items}}{{#items}}x{{/items}}{{/items}}{{/items}}";
+    const items = Array.from({ length: 40 }, (_, i) => ({ i }));
+    expect(() => interpolate(body, { items })).toThrow(TemplateParseError);
+  });
+
+  it("leaves ordinary templates well clear of the budget", () => {
+    const body = "{{#rows}}<tr><td>{{label}}</td></tr>{{/rows}}";
+    const rows = Array.from({ length: 500 }, (_, i) => ({ label: `r${i}` }));
+    const out = interpolate(body, { rows });
+    expect(out.match(/<tr>/g)).toHaveLength(500);
+  });
+
+  it("budgets the whole render, not each section separately", () => {
+    // Many sibling sections, each individually small, summing past the cap.
+    const one = "{{#rows}}x{{/rows}}";
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ i }));
+    const body = one.repeat(MAX_SECTION_RENDERS / 1000 + 5);
+    expect(() => interpolate(body, { rows })).toThrow(TemplateRenderError);
+  });
+});
+
+describe("unresolved names in a section that pushes no scope", () => {
+  /**
+   * An inverted section never pushes a frame, and a truthy *scalar* section
+   * renders its body against the unchanged stack. So a name inside either one
+   * is an ordinary top-level lookup — not something that resolves per item —
+   * and blanking it hides a caller error rather than tolerating a per-item gap.
+   */
+  it("reports a missing name inside an inverted section", () => {
+    const result = renderTemplate(
+      {
+        subject: "s",
+        bodyHtml:
+          "{{^has_orders}}<p>Hi {{first_name}}, nothing yet.</p>{{/has_orders}}",
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.missingVariables).toContain("first_name");
+  });
+
+  it("reports a missing name inside a boolean-guarded section", () => {
+    const result = renderTemplate(
+      {
+        subject: "Order {{order_id}}",
+        bodyHtml:
+          "{{#has_discount}}<p>Your code is {{discount_code}}!</p>{{/has_discount}}",
+      },
+      { order_id: "1", has_discount: true },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.missingVariables).toContain("discount_code");
+  });
+
+  it("still tolerates a per-item gap inside an iterating section", () => {
+    // `note` is genuinely per-item here: some items have it, some do not.
+    // That must keep rendering empty rather than failing the send.
+    const result = renderTemplate(
+      {
+        subject: "s",
+        bodyHtml: "{{#items}}<li>{{label}}{{note}}</li>{{/items}}",
+      },
+      { items: [{ label: "a", note: "!" }, { label: "b" }] },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.bodyHtml).toBe("<li>a!</li><li>b</li>");
+  });
+
+  it("does not report a name the section body resolves from an outer scope", () => {
+    const result = renderTemplate(
+      {
+        subject: "s",
+        bodyHtml: "{{^empty}}<p>{{greeting}}</p>{{/empty}}",
+      },
+      { greeting: "Hi" },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("respects the optional marker inside a scope-less section", () => {
+    const result = renderTemplate(
+      { subject: "s", bodyHtml: "{{^empty}}<p>{{note?}}</p>{{/empty}}" },
+      {},
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.bodyHtml).toBe("<p></p>");
+  });
+
+  it("keeps the sequence path lax — interpolate alone never throws for a missing name", () => {
+    // sequence-processor renders with `interpolate` directly and has no
+    // failure channel; it must keep its existing behavior.
+    expect(() => interpolate("{{^x}}Hi {{name}}{{/x}}", {})).not.toThrow();
+  });
+});
+
+describe("value shape", () => {
+  /**
+   * `variables` accepts any JSON value since the API widened, but a name used
+   * in scalar position renders `""` for an object or array — the send succeeds
+   * and the email is silently wrong. Analysis already knows which names are
+   * only ever used as `{{name}}`.
+   */
+  it("rejects an object supplied for a scalar variable", () => {
+    const result = renderTemplate(
+      { subject: "Hi {{name}}", bodyHtml: "<p>{{name}}</p>" },
+      { name: { first: "a" } },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an array supplied for a scalar variable", () => {
+    const result = renderTemplate(
+      { subject: "s", bodyHtml: "<p>{{tags}}</p>" },
+      { tags: ["a", "b"] },
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts a scalar for a name used as a section", () => {
+    // A boolean conditional section is a documented, supported pattern.
+    const result = renderTemplate(
+      { subject: "s", bodyHtml: "{{#isTrial}}<p>Trial</p>{{/isTrial}}" },
+      { isTrial: true },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.bodyHtml).toBe("<p>Trial</p>");
+  });
+
+  it("catches a scalar sent where a section body needs item fields", () => {
+    // `{"items": "yes"}` used to render `<li></li>` and return 201.
+    const result = renderTemplate(
+      { subject: "s", bodyHtml: "{{#items}}<li>{{label}}</li>{{/items}}" },
+      { items: "yes" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.missingVariables).toContain("label");
+  });
+
+  it("leaves numbers and booleans alone in scalar position", () => {
+    const result = renderTemplate(
+      { subject: "s", bodyHtml: "<p>{{count}}{{flag}}</p>" },
+      { count: 0, flag: false },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.bodyHtml).toBe("<p>0false</p>");
+  });
+});

--- a/worker/src/__tests__/interpolate-parser.test.ts
+++ b/worker/src/__tests__/interpolate-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../lib/interpolate";
+
+describe("parse", () => {
+  it("nests section children under the section node", () => {
+    expect(parse("a{{#items}}b{{/items}}c")).toEqual([
+      { kind: "text", value: "a" },
+      {
+        kind: "section",
+        name: "items",
+        inverted: false,
+        optional: false,
+        children: [{ kind: "text", value: "b" }],
+      },
+      { kind: "text", value: "c" },
+    ]);
+  });
+
+  it("nests sections inside sections", () => {
+    const ast = parse("{{#a}}{{#b}}x{{/b}}{{/a}}");
+    expect(ast).toHaveLength(1);
+    const outer = ast[0];
+    if (outer.kind !== "section") throw new Error("expected section");
+    expect(outer.name).toBe("a");
+    expect(outer.children).toHaveLength(1);
+    const inner = outer.children[0];
+    if (inner.kind !== "section") throw new Error("expected nested section");
+    expect(inner.name).toBe("b");
+  });
+
+  it("throws when a section is never closed", () => {
+    expect(() => parse("{{#a}}x")).toThrow(/unclosed section .*\{\{#a\}\}/i);
+  });
+
+  it("throws when a close tag does not match the open tag", () => {
+    expect(() => parse("{{#a}}x{{/b}}")).toThrow(
+      /\{\{\/b\}\} does not match .*\{\{#a\}\}/i,
+    );
+  });
+
+  it("throws on a close tag with no open section", () => {
+    expect(() => parse("x{{/a}}")).toThrow(/unexpected \{\{\/a\}\}/i);
+  });
+});

--- a/worker/src/__tests__/interpolate-render.test.ts
+++ b/worker/src/__tests__/interpolate-render.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { interpolate } from "../lib/interpolate";
+
+describe("interpolate — escaping", () => {
+  it("escapes markup in a substituted value", () => {
+    expect(
+      interpolate("<p>{{msg}}</p>", { msg: `<a href="http://evil">click</a>` }),
+    ).toBe("<p>&lt;a href=&quot;http://evil&quot;&gt;click&lt;/a&gt;</p>");
+  });
+
+  it("escapes a script tag", () => {
+    expect(interpolate("{{v}}", { v: "<script>alert(1)</script>" })).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;",
+    );
+  });
+
+  it("escapes a single-quoted attribute breakout", () => {
+    expect(interpolate("<img alt='{{v}}'>", { v: "' onerror='alert(1)" })).toBe(
+      "<img alt='&#39; onerror=&#39;alert(1)'>",
+    );
+  });
+
+  it("leaves the template's own text unescaped", () => {
+    expect(interpolate("<p>It's {{v}}</p>", { v: "fine" })).toBe(
+      "<p>It's fine</p>",
+    );
+  });
+
+  it("passes a triple-brace value through unescaped", () => {
+    expect(interpolate("{{{v}}}", { v: "<b>bold</b>" })).toBe("<b>bold</b>");
+  });
+});
+
+describe("interpolate — optional variables", () => {
+  it("renders an optional missing variable as empty", () => {
+    expect(interpolate("a{{v?}}b", {})).toBe("ab");
+  });
+
+  it("still leaves a required missing variable verbatim", () => {
+    expect(interpolate("a{{v}}b", {})).toBe("a{{v}}b");
+  });
+});
+
+describe("interpolate — nl2br filter", () => {
+  it("converts newlines after escaping, not before", () => {
+    expect(interpolate("{{v|nl2br}}", { v: "line one\n<b>two</b>" })).toBe(
+      "line one<br>&lt;b&gt;two&lt;/b&gt;",
+    );
+  });
+
+  it("handles CRLF and bare CR", () => {
+    expect(interpolate("{{v|nl2br}}", { v: "a\r\nb\rc" })).toBe("a<br>b<br>c");
+  });
+
+  it("composes with raw and optional", () => {
+    expect(interpolate("{{{v?|nl2br}}}", { v: "<b>a</b>\nb" })).toBe(
+      "<b>a</b><br>b",
+    );
+    expect(interpolate("{{{v?|nl2br}}}", {})).toBe("");
+  });
+});
+
+describe("interpolate — non-string values", () => {
+  it("stringifies numbers and booleans", () => {
+    expect(interpolate("{{a}} {{b}}", { a: 42, b: true })).toBe("42 true");
+  });
+
+  it("renders null and undefined as empty", () => {
+    expect(interpolate("[{{a}}][{{b}}]", { a: null, b: undefined })).toBe(
+      "[][]",
+    );
+  });
+});

--- a/worker/src/__tests__/interpolate-render.test.ts
+++ b/worker/src/__tests__/interpolate-render.test.ts
@@ -60,6 +60,91 @@ describe("interpolate — nl2br filter", () => {
   });
 });
 
+describe("interpolate — plain-text mode ({ escape: false })", () => {
+  it("emits HTML-significant characters literally", () => {
+    expect(
+      interpolate(
+        "Hi {{v}}",
+        { v: `O'Brien & Sons <VIP> "Ltd"` },
+        {
+          escape: false,
+        },
+      ),
+    ).toBe(`Hi O'Brien & Sons <VIP> "Ltd"`);
+  });
+
+  it.each([
+    ["&", "&"],
+    ["'", "'"],
+    ['"', '"'],
+    ["<", "<"],
+    [">", ">"],
+  ])("passes %s through unchanged", (value) => {
+    expect(interpolate("{{v}}", { v: value }, { escape: false })).toBe(value);
+  });
+
+  it("still escapes the same values when escaping is on (the HTML body path)", () => {
+    expect(interpolate("{{v}}", { v: `&'"<>` })).toBe(
+      "&amp;&#39;&quot;&lt;&gt;",
+    );
+  });
+
+  it("treats a raw tag the same as a plain one", () => {
+    expect(interpolate("{{{v}}}", { v: "<b>x</b>" }, { escape: false })).toBe(
+      "<b>x</b>",
+    );
+  });
+
+  it("skips nl2br rather than injecting a literal <br> into plain text", () => {
+    // nl2br's whole purpose is producing HTML. In a Subject header there is no
+    // HTML to produce, so it is a no-op and the value's newlines survive
+    // untouched — a visible "<br>" in a subject line would be worse.
+    expect(interpolate("{{v|nl2br}}", { v: "a\nb" }, { escape: false })).toBe(
+      "a\nb",
+    );
+    expect(interpolate("{{v|nl2br}}", { v: "a\nb" })).toBe("a<br>b");
+  });
+
+  it("defaults to escaping when no options are passed", () => {
+    expect(interpolate("{{v}}", { v: "<b>" })).toBe("&lt;b&gt;");
+    expect(interpolate("{{v}}", { v: "<b>" }, {})).toBe("&lt;b&gt;");
+  });
+});
+
+describe("interpolate — inherited object members are not variables", () => {
+  it.each([
+    "constructor",
+    "toString",
+    "valueOf",
+    "hasOwnProperty",
+    "__proto__",
+  ])("does not resolve %s from the prototype chain", (name) => {
+    // `name in frame` would find these and render e.g. the source of
+    // Object's constructor into an email.
+    expect(interpolate(`{{${name}}}`, {})).toBe(`{{${name}}}`);
+  });
+
+  it("does not resolve an inherited member from a section item either", () => {
+    // Section frames come straight from caller-supplied JSON.
+    expect(
+      interpolate("{{#items}}{{toString}}{{/items}}", { items: [{}] }),
+    ).toBe("");
+  });
+
+  it("still resolves an own property that shadows a prototype member", () => {
+    expect(interpolate("{{toString}}", { toString: "mine" })).toBe("mine");
+  });
+});
+
+describe("interpolate — tag names match the legacy grammar exactly", () => {
+  it.each(["{{ spaced }}", "{{ name }}", "{{example.com}}", "{{user.name}}"])(
+    "leaves %s as literal text",
+    (template) => {
+      expect(interpolate(template, { spaced: "S", name: "N" })).toBe(template);
+    },
+  );
+});
+
 describe("interpolate — non-string values", () => {
   it("stringifies numbers and booleans", () => {
     expect(interpolate("{{a}} {{b}}", { a: 42, b: true })).toBe("42 true");

--- a/worker/src/__tests__/interpolate-sections.test.ts
+++ b/worker/src/__tests__/interpolate-sections.test.ts
@@ -141,13 +141,41 @@ describe("interpolate — context stack isolation", () => {
     // If the renderer pushed each item onto a SHARED stack array without
     // popping between iterations, `lookup`'s innermost-first search would
     // still find `extra` from item A's leaked frame while rendering item B.
-    // Item B has no `extra` of its own, so the correct result is that its
-    // `{{extra}}` tag is unresolved and survives verbatim as source text.
+    // Item B has no `extra` of its own, so its `{{extra}}` must not resolve;
+    // inside a section an unresolved name renders empty, giving "leak".
+    //
+    // The test still detects a leak: a leaking implementation would find item
+    // A's value again and produce "leakleak", which "leak" distinguishes.
     expect(
       interpolate("{{#items}}{{extra}}{{/items}}", {
         items: [{ extra: "leak" }, {}],
       }),
-    ).toBe("leak{{extra}}");
+    ).toBe("leak");
+  });
+});
+
+describe("interpolate — unresolved names inside a section", () => {
+  it("renders an unfound section-body name as empty, not as its source text", () => {
+    // Section-body names are deliberately never `required` (they resolve per
+    // item), so nothing upstream catches a missing one. Emitting the source
+    // would mail a literal "{{empty_msg}}" to a customer — the README's own
+    // advertised empty-state pattern doing exactly the wrong thing.
+    expect(interpolate("{{^items}}{{empty_msg}}{{/items}}", {})).toBe("");
+    expect(
+      interpolate("{{#items}}{{missing}}{{/items}}", { items: [{}, {}] }),
+    ).toBe("");
+  });
+
+  it("still emits source text for an unfound name at top level", () => {
+    // Top-level required names are caught by renderTemplate before a send, so
+    // the verbatim token stays as the debugging signal.
+    expect(interpolate("{{missing}}", {})).toBe("{{missing}}");
+  });
+
+  it("keeps the section-body rule at every nesting depth", () => {
+    expect(
+      interpolate("{{#a}}{{#b}}{{gone}}{{/b}}{{/a}}", { a: true, b: true }),
+    ).toBe("");
   });
 });
 

--- a/worker/src/__tests__/interpolate-sections.test.ts
+++ b/worker/src/__tests__/interpolate-sections.test.ts
@@ -117,10 +117,42 @@ describe("interpolate — sibling and nested inverted sections", () => {
   });
 
   it("renders an inverted section nested inside a regular section, per item", () => {
+    // Asserted per-item (not on the concatenation of a multi-item array) so
+    // that a flipped inverted-condition bug can't cancel out: with items
+    // [{tags:[]}, {tags:["x"]}] concatenated into one string, a correctly
+    // inverted implementation and one with `^` treated as `#` both produce
+    // "none" overall (just from different items), so a single combined
+    // assertion would pass either way.
     expect(
       interpolate("{{#items}}{{^tags}}none{{/tags}}{{/items}}", {
-        items: [{ tags: [] }, { tags: ["x"] }],
+        items: [{ tags: [] }],
       }),
     ).toBe("none");
+    expect(
+      interpolate("{{#items}}{{^tags}}none{{/tags}}{{/items}}", {
+        items: [{ tags: ["x"] }],
+      }),
+    ).toBe("");
+  });
+});
+
+describe("interpolate — context stack isolation", () => {
+  it("does not leak a field from one item's scope into the next item's lookup", () => {
+    // If the renderer pushed each item onto a SHARED stack array without
+    // popping between iterations, `lookup`'s innermost-first search would
+    // still find `extra` from item A's leaked frame while rendering item B.
+    // Item B has no `extra` of its own, so the correct result is that its
+    // `{{extra}}` tag is unresolved and survives verbatim as source text.
+    expect(
+      interpolate("{{#items}}{{extra}}{{/items}}", {
+        items: [{ extra: "leak" }, {}],
+      }),
+    ).toBe("leak{{extra}}");
+  });
+});
+
+describe("interpolate — isTruthy edge cases", () => {
+  it("treats an empty object as truthy and renders its section body once", () => {
+    expect(interpolate("{{#obj}}yes{{/obj}}", { obj: {} })).toBe("yes");
   });
 });

--- a/worker/src/__tests__/interpolate-sections.test.ts
+++ b/worker/src/__tests__/interpolate-sections.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { interpolate } from "../lib/interpolate";
+
+describe("interpolate — conditional sections", () => {
+  it("renders the body when the value is truthy", () => {
+    expect(interpolate("{{#on}}yes{{/on}}", { on: true })).toBe("yes");
+  });
+
+  it.each([
+    ["false", false],
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["zero", 0],
+    ["empty array", [] as unknown[]],
+  ])("skips the body when the value is %s", (_label, value) => {
+    expect(interpolate("{{#on}}yes{{/on}}", { on: value as never })).toBe("");
+  });
+
+  it("skips the body when the value is absent entirely", () => {
+    expect(interpolate("{{#on}}yes{{/on}}", {})).toBe("");
+  });
+});
+
+describe("interpolate — inverted sections", () => {
+  it("renders when the value is falsy or absent", () => {
+    expect(interpolate("{{^f}}none{{/f}}", { f: [] })).toBe("none");
+    expect(interpolate("{{^f}}none{{/f}}", {})).toBe("none");
+  });
+
+  it("skips when the value is truthy", () => {
+    expect(interpolate("{{^f}}none{{/f}}", { f: ["a"] })).toBe("");
+  });
+});
+
+describe("interpolate — iteration", () => {
+  it("renders once per item for an array of objects", () => {
+    expect(
+      interpolate("{{#items}}<li>{{label}}</li>{{/items}}", {
+        items: [{ label: "one" }, { label: "two" }],
+      }),
+    ).toBe("<li>one</li><li>two</li>");
+  });
+
+  it("uses {{.}} for an array of strings", () => {
+    expect(interpolate("{{#tags}}[{{.}}]{{/tags}}", { tags: ["a", "b"] })).toBe(
+      "[a][b]",
+    );
+  });
+
+  it("escapes item values", () => {
+    expect(
+      interpolate("{{#items}}{{label}}{{/items}}", {
+        items: [{ label: "<b>x</b>" }],
+      }),
+    ).toBe("&lt;b&gt;x&lt;/b&gt;");
+  });
+
+  it("falls through to the outer scope for names the item lacks", () => {
+    expect(
+      interpolate("{{#items}}{{currency}}{{price}} {{/items}}", {
+        currency: "$",
+        items: [{ price: "10" }, { price: "20" }],
+      }),
+    ).toBe("$10 $20 ");
+  });
+
+  it("lets an item shadow an outer name", () => {
+    expect(
+      interpolate("{{#items}}{{name}}{{/items}}", {
+        name: "outer",
+        items: [{ name: "inner" }],
+      }),
+    ).toBe("inner");
+  });
+
+  it("nests sections", () => {
+    expect(
+      interpolate(
+        "{{#orders}}{{id}}:{{#lines}}{{sku}},{{/lines}};{{/orders}}",
+        {
+          orders: [
+            { id: "A", lines: [{ sku: "x" }, { sku: "y" }] },
+            { id: "B", lines: [] },
+          ],
+        },
+      ),
+    ).toBe("A:x,y,;B:;");
+  });
+
+  it("pushes a plain object as scope without iterating", () => {
+    expect(
+      interpolate("{{#user}}{{name}}{{/user}}", { user: { name: "Ada" } }),
+    ).toBe("Ada");
+  });
+});
+
+describe("interpolate — sibling and nested inverted sections", () => {
+  it("renders sibling sections at the same nesting level independently", () => {
+    expect(
+      interpolate("{{#a}}{{#b}}x{{/b}}{{#c}}y{{/c}}{{/a}}", {
+        a: true,
+        b: true,
+        c: true,
+      }),
+    ).toBe("xy");
+  });
+
+  it("skips a sibling section whose own value is falsy while its neighbor still renders", () => {
+    expect(
+      interpolate("{{#a}}{{#b}}x{{/b}}{{#c}}y{{/c}}{{/a}}", {
+        a: true,
+        b: false,
+        c: true,
+      }),
+    ).toBe("y");
+  });
+
+  it("renders an inverted section nested inside a regular section, per item", () => {
+    expect(
+      interpolate("{{#items}}{{^tags}}none{{/tags}}{{/items}}", {
+        items: [{ tags: [] }, { tags: ["x"] }],
+      }),
+    ).toBe("none");
+  });
+});

--- a/worker/src/__tests__/interpolate-tokenizer.test.ts
+++ b/worker/src/__tests__/interpolate-tokenizer.test.ts
@@ -115,21 +115,48 @@ describe("tokenize", () => {
     ]);
   });
 
-  it("leaves non-matching brace runs as literal text", () => {
-    // Preserves the existing "{{not-a-var}} stays verbatim" behavior, plus the
-    // half-raw case where the opening and closing brace counts disagree.
-    for (const input of [
-      "{{not-a-var}}",
-      "{{}}",
-      "{{ }}",
-      "{{{name}}",
-      "{{name}}}",
-    ]) {
+  it("leaves a run with no valid name as literal text", () => {
+    // Preserves the existing "{{not-a-var}} stays verbatim" behavior: none of
+    // these contain a `[\w.]+` name for either brace form to match against,
+    // so no tag is found anywhere and the whole input is literal text.
+    for (const input of ["{{not-a-var}}", "{{}}", "{{ }}"]) {
       const tokens = tokenize(input);
       expect(
         tokens.map((t) => (t.kind === "text" ? t.value : "")).join(""),
       ).toContain("{{");
     }
+  });
+
+  it("resolves an incomplete raw brace against a real tag, leaving the odd brace as text", () => {
+    // "{{{name}}" is one closing brace short of a raw tag. The raw and plain
+    // forms are matched as fully separate alternatives (see the TAG comment
+    // in interpolate.ts), so this is not read as a malformed raw tag; it is
+    // read as a lone literal "{" immediately followed by the plain tag
+    // "{{name}}". Symmetrically, "{{name}}}" is a plain tag followed by one
+    // leftover literal "}". This is the same brace-run divergence from the
+    // legacy flat regex documented and asserted in interpolate-compat.test.ts.
+    expect(tokenize("{{{name}}")).toEqual([
+      { kind: "text", value: "{" },
+      {
+        kind: "var",
+        name: "name",
+        raw: false,
+        optional: false,
+        filters: [],
+        source: "{{name}}",
+      },
+    ]);
+    expect(tokenize("{{name}}}")).toEqual([
+      {
+        kind: "var",
+        name: "name",
+        raw: false,
+        optional: false,
+        filters: [],
+        source: "{{name}}",
+      },
+      { kind: "text", value: "}" },
+    ]);
   });
 
   it("rejects an unknown filter", () => {

--- a/worker/src/__tests__/interpolate-tokenizer.test.ts
+++ b/worker/src/__tests__/interpolate-tokenizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { escapeHtml, tokenize } from "../lib/interpolate";
+import { escapeHtml, tokenize, TemplateParseError } from "../lib/interpolate";
 
 describe("escapeHtml", () => {
   it("escapes the five HTML-significant characters", () => {
@@ -113,6 +113,25 @@ describe("tokenize", () => {
         source: "{{.}}",
       },
     ]);
+  });
+
+  it("rejects an inherited Object.prototype member as a filter name", () => {
+    // Membership must be `hasOwn`, not `in`. With `in`, these names pass
+    // validation and are then invoked as filters: `|toString` renders
+    // "[object Object]" into the email, and `|__defineGetter__` throws a
+    // TypeError from applyFilters — which no caller's TemplateParseError
+    // handling catches, so it escapes as an unhandled 500 and, on the
+    // sequence path, an infinite queue retry.
+    for (const name of [
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+      "constructor",
+      "__defineGetter__",
+    ]) {
+      expect(() => tokenize(`{{name|${name}}}`)).toThrow(TemplateParseError);
+      expect(() => tokenize(`{{name|${name}}}`)).toThrow(/Unknown filter/);
+    }
   });
 
   it("leaves a run with no valid name as literal text", () => {

--- a/worker/src/__tests__/interpolate-tokenizer.test.ts
+++ b/worker/src/__tests__/interpolate-tokenizer.test.ts
@@ -117,13 +117,30 @@ describe("tokenize", () => {
 
   it("leaves a run with no valid name as literal text", () => {
     // Preserves the existing "{{not-a-var}} stays verbatim" behavior: none of
-    // these contain a `[\w.]+` name for either brace form to match against,
-    // so no tag is found anywhere and the whole input is literal text.
+    // these contain a `\w+` (or bare `.`) name for either brace form to match
+    // against, so no tag is found anywhere and the input is one text token.
     for (const input of ["{{not-a-var}}", "{{}}", "{{ }}"]) {
-      const tokens = tokenize(input);
-      expect(
-        tokens.map((t) => (t.kind === "text" ? t.value : "")).join(""),
-      ).toContain("{{");
+      expect(tokenize(input)).toEqual([{ kind: "text", value: input }]);
+    }
+  });
+
+  it("does not treat a padded, dotted, or hyphenated name as a tag", () => {
+    // Tag names match legacy exactly: `\w+` (or a bare `.`), with no
+    // whitespace anywhere inside the tag. Anything laxer would turn prose
+    // like `{{ note }}` in a stored template into a REQUIRED variable and
+    // start rejecting sends, and would read `{{user.name}}` as a flat key
+    // literally named "user.name" rather than the path it resembles.
+    for (const input of [
+      "{{ spaced }}",
+      "{{ name }}",
+      "{{name }}",
+      "{{ name}}",
+      "{{example.com}}",
+      "{{user.name}}",
+      "{{name ?}}",
+      "{{name| nl2br}}",
+    ]) {
+      expect(tokenize(input)).toEqual([{ kind: "text", value: input }]);
     }
   });
 
@@ -133,8 +150,11 @@ describe("tokenize", () => {
     // in interpolate.ts), so this is not read as a malformed raw tag; it is
     // read as a lone literal "{" immediately followed by the plain tag
     // "{{name}}". Symmetrically, "{{name}}}" is a plain tag followed by one
-    // leftover literal "}". This is the same brace-run divergence from the
-    // legacy flat regex documented and asserted in interpolate-compat.test.ts.
+    // leftover literal "}". Note these two inputs do NOT diverge from the
+    // legacy flat regex — it read them the same way, as "{" + tag and tag +
+    // "}" — so a change in what they render is a real regression, not an
+    // accepted break. The genuine brace-run divergence is the clean 3+ run
+    // ("{{{name}}}"), pinned separately in interpolate-compat.test.ts.
     expect(tokenize("{{{name}}")).toEqual([
       { kind: "text", value: "{" },
       {

--- a/worker/src/__tests__/interpolate-tokenizer.test.ts
+++ b/worker/src/__tests__/interpolate-tokenizer.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml, tokenize } from "../lib/interpolate";
+
+describe("escapeHtml", () => {
+  it("escapes the five HTML-significant characters", () => {
+    expect(escapeHtml(`<a href="x" title='y'>&</a>`)).toBe(
+      "&lt;a href=&quot;x&quot; title=&#39;y&#39;&gt;&amp;&lt;/a&gt;",
+    );
+  });
+
+  it("escapes ampersands exactly once", () => {
+    expect(escapeHtml("a &amp; b")).toBe("a &amp;amp; b");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(escapeHtml("Ada Lovelace")).toBe("Ada Lovelace");
+  });
+});
+
+describe("tokenize", () => {
+  it("splits text and a simple variable", () => {
+    expect(tokenize("Hi {{name}}!")).toEqual([
+      { kind: "text", value: "Hi " },
+      {
+        kind: "var",
+        name: "name",
+        raw: false,
+        optional: false,
+        filters: [],
+        source: "{{name}}",
+      },
+      { kind: "text", value: "!" },
+    ]);
+  });
+
+  it("recognises a triple-brace raw tag", () => {
+    expect(tokenize("{{{block}}}")).toEqual([
+      {
+        kind: "var",
+        name: "block",
+        raw: true,
+        optional: false,
+        filters: [],
+        source: "{{{block}}}",
+      },
+    ]);
+  });
+
+  it("recognises optional and filtered tags, and both together", () => {
+    expect(tokenize("{{a?}}{{b|nl2br}}{{{c?|nl2br}}}")).toEqual([
+      {
+        kind: "var",
+        name: "a",
+        raw: false,
+        optional: true,
+        filters: [],
+        source: "{{a?}}",
+      },
+      {
+        kind: "var",
+        name: "b",
+        raw: false,
+        optional: false,
+        filters: ["nl2br"],
+        source: "{{b|nl2br}}",
+      },
+      {
+        kind: "var",
+        name: "c",
+        raw: true,
+        optional: true,
+        filters: ["nl2br"],
+        source: "{{{c?|nl2br}}}",
+      },
+    ]);
+  });
+
+  it("recognises section open, inverted open, optional section, and close", () => {
+    expect(tokenize("{{#a}}{{^b}}{{#c?}}{{/a}}")).toEqual([
+      {
+        kind: "open",
+        name: "a",
+        inverted: false,
+        optional: false,
+        source: "{{#a}}",
+      },
+      {
+        kind: "open",
+        name: "b",
+        inverted: true,
+        optional: false,
+        source: "{{^b}}",
+      },
+      {
+        kind: "open",
+        name: "c",
+        inverted: false,
+        optional: true,
+        source: "{{#c?}}",
+      },
+      { kind: "close", name: "a", source: "{{/a}}" },
+    ]);
+  });
+
+  it("recognises the dot tag for array-of-string iteration", () => {
+    expect(tokenize("{{.}}")).toEqual([
+      {
+        kind: "var",
+        name: ".",
+        raw: false,
+        optional: false,
+        filters: [],
+        source: "{{.}}",
+      },
+    ]);
+  });
+
+  it("leaves non-matching brace runs as literal text", () => {
+    // Preserves the existing "{{not-a-var}} stays verbatim" behavior, plus the
+    // half-raw case where the opening and closing brace counts disagree.
+    for (const input of [
+      "{{not-a-var}}",
+      "{{}}",
+      "{{ }}",
+      "{{{name}}",
+      "{{name}}}",
+    ]) {
+      const tokens = tokenize(input);
+      expect(
+        tokens.map((t) => (t.kind === "text" ? t.value : "")).join(""),
+      ).toContain("{{");
+    }
+  });
+
+  it("rejects an unknown filter", () => {
+    expect(() => tokenize("{{a|shout}}")).toThrow(/unknown filter "shout"/i);
+  });
+});

--- a/worker/src/__tests__/send-router.test.ts
+++ b/worker/src/__tests__/send-router.test.ts
@@ -7,6 +7,7 @@ import {
   createTestUser,
   createTestPerson,
   createTestEmail,
+  createTestTemplate,
   authFetch,
   getDb,
   buildSendForm,
@@ -289,6 +290,41 @@ describe("send router", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0].kind).toBe("sent");
       expect(rows[0].filename).toBe("evidence.png");
+    });
+
+    it("returns TEMPLATE_PARSE_ERROR with the parse diagnostic for an unbalanced template", async () => {
+      const person = await createTestPerson({
+        id: "p-parse",
+        email: "c@example.com",
+      });
+      await createTestEmail({
+        id: "rcv-parse",
+        personId: person.id,
+        recipient: "me@saasmail.test",
+        subject: "hi",
+        messageId: "parse@example.com",
+      });
+      await createTestTemplate({
+        slug: "broken",
+        subject: "Hi",
+        bodyHtml: "{{#a}}oops",
+      });
+
+      const res = await authFetch("/api/send/reply/rcv-parse", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: "me@saasmail.test",
+          templateSlug: "broken",
+          variables: {},
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toMatch(/\{\{#a\}\}/);
+      expect(data).not.toHaveProperty("missingVariables");
+      expect(data).not.toHaveProperty("requiredVariables");
     });
   });
 

--- a/worker/src/__tests__/sequence-processor.test.ts
+++ b/worker/src/__tests__/sequence-processor.test.ts
@@ -556,3 +556,118 @@ describe("sequence processor - crash-redelivery idempotency", () => {
     expect(outbox).toHaveLength(1);
   });
 });
+
+describe("sequence processor - template rendering", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    await createTestUser();
+  });
+
+  /** Seed a sequence, enrollment, and one queued step for `slug`. */
+  async function seedStep(slug: string, personEmail = "a@test.com") {
+    const db = getDb();
+    const now = Math.floor(Date.now() / 1000);
+    await createTestPerson({ id: "p1", email: personEmail, name: "O'Brien" });
+    await db.insert(sequences).values({
+      id: "seq-1",
+      name: "Test",
+      steps: JSON.stringify([{ order: 1, templateSlug: slug, delayHours: 0 }]),
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(sequenceEnrollments).values({
+      id: "enr-1",
+      sequenceId: "seq-1",
+      personId: "p1",
+      status: "active",
+      variables: "{}",
+      fromAddress: "test@test.com",
+      enrolledAt: now,
+    });
+    await db.insert(sequenceEmails).values({
+      id: "se-1",
+      enrollmentId: "enr-1",
+      stepOrder: 1,
+      templateSlug: slug,
+      scheduledAt: now - 100,
+      status: "queued",
+    });
+    return db;
+  }
+
+  it("marks the row failed on a malformed template instead of leaving it queued", async () => {
+    // interpolate throws TemplateParseError on an unbalanced template. Without
+    // a catch here the throw reaches the queue handler, which retries forever
+    // while the row stays "queued" and the enrollment never resolves.
+    const db = await seedStep("broken");
+    await createTestTemplate({
+      slug: "broken",
+      subject: "Hi {{name}}",
+      bodyHtml: "<p>{{#items}}oops</p>",
+    });
+
+    const fakeSender: EmailSender = {
+      provider: "none",
+      maxAttachmentBytes: () => 25_000_000,
+      send: vi.fn(async (_params: SendEmailParams) => ({
+        id: "should-not-be-called",
+        error: null,
+      })),
+    };
+
+    // Must not throw — a parse error is final, not retryable.
+    await processSequenceEmail(
+      db,
+      fakeSender,
+      env as unknown as CloudflareBindings,
+      "se-1",
+    );
+
+    expect(fakeSender.send).not.toHaveBeenCalled();
+
+    const row = await db
+      .select()
+      .from(sequenceEmails)
+      .where(eq(sequenceEmails.id, "se-1"))
+      .limit(1);
+    expect(row[0].status).toBe("failed");
+
+    expect(await db.select().from(sentEmails)).toHaveLength(0);
+  });
+
+  it("does not HTML-escape the subject, but still escapes the body", async () => {
+    // A Subject header is plain text: the recipient must see O'Brien, not
+    // O&#39;Brien. The body is HTML and stays escaped.
+    const db = await seedStep("greet");
+    await createTestTemplate({
+      slug: "greet",
+      subject: "Hi {{name}} & friends",
+      bodyHtml: "<p>Hi {{name}}</p>",
+    });
+
+    const fakeSender: EmailSender = {
+      provider: "none",
+      maxAttachmentBytes: () => 25_000_000,
+      send: vi.fn(async (_params: SendEmailParams) => ({
+        id: "fake-id",
+        error: null,
+      })),
+    };
+
+    await processSequenceEmail(
+      db,
+      fakeSender,
+      env as unknown as CloudflareBindings,
+      "se-1",
+    );
+
+    const sent = await db.select().from(sentEmails);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toBe("Hi O'Brien & friends");
+    expect(sent[0].bodyHtml).toContain("Hi O&#39;Brien");
+  });
+});

--- a/worker/src/__tests__/sequence-processor.test.ts
+++ b/worker/src/__tests__/sequence-processor.test.ts
@@ -637,6 +637,17 @@ describe("sequence processor - template rendering", () => {
     expect(row[0].status).toBe("failed");
 
     expect(await db.select().from(sentEmails)).toHaveLength(0);
+
+    // The enrollment must not be left `active`. `enrollPersonInSequence`
+    // rejects anyone with an active enrollment, so a drip whose last step has
+    // a broken template would otherwise lock that contact out of every future
+    // sequence, permanently, with one console.error as the only trace.
+    const enr = await db
+      .select()
+      .from(sequenceEnrollments)
+      .where(eq(sequenceEnrollments.id, "enr-1"))
+      .limit(1);
+    expect(enr[0].status).toBe("completed");
   });
 
   it("does not HTML-escape the subject, but still escapes the body", async () => {

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -67,14 +67,23 @@ export type Token =
  * name (word characters, or a bare `.` for the current item), an optional
  * `?` marking it optional, and zero or more `|filter` clauses.
  *
- * Keeping the two forms from sharing a group is deliberate: an earlier
- * single-pattern version let a lone extra `{` or `}` sitting next to a
- * *different* tag get folded into that tag's brace count (e.g. matching
- * `{{{` + `name` + `}}` as a bogus "almost raw" tag), which is exactly the
- * situation that arises when a literal `{{`/`}}` happens to sit next to a
- * real tag. With this form, `{{{{x}}` fails the raw alternative outright
- * (only 2 of the 3 required opening braces belong to it) and falls through
- * to the plain alternative, which finds `{{x}}` starting two characters in.
+ * Keeping the two forms from sharing a group means a lone extra `{` or `}`
+ * sitting next to a *different* tag can no longer get folded into that
+ * tag's brace count (an earlier single-pattern version did this, matching
+ * `{{{` + `name` + `}}` as a bogus "almost raw" tag).
+ *
+ * This does NOT reproduce the legacy flat-regex reading of 3+ consecutive
+ * braces, and cannot: the legacy renderer had no raw syntax, so it read
+ * `{{{name}}}` as literal `{` + tag `{{name}}` + literal `}`. Supporting
+ * `{{{raw}}}` means this tokenizer reads the same input as one raw tag
+ * instead. Those two readings are mutually exclusive by construction —
+ * any template with a 3+ brace run necessarily changes meaning under the
+ * new syntax. That divergence is intentional and documented; see the
+ * "brace-run behavior" tests in interpolate-compat.test.ts for exactly
+ * what the new tokenizer does on inputs like `{{{name}}}` and
+ * `{{{{name}}}}`, and the differential fuzz in the same file for why it
+ * excludes 3+ brace runs from the legacy-identity check instead of
+ * asserting a property the feature deliberately breaks.
  *
  * Names are `[\w.]+`, so `{{not-a-var}}` does not match and survives as literal
  * text — the pre-rewrite behavior, which an existing test pins.
@@ -106,36 +115,6 @@ export function tokenize(template: string): Token[] {
     const name = raw ? rawName : plainName;
     const optional = raw ? rawOptional : plainOptional;
     const filterClause = raw ? rawFilterClause : plainFilterClause;
-
-    // Even with the two brace forms kept separate, a tag can still sit
-    // directly against *extra* braces that belong to neither alternative —
-    // e.g. the `{{` in `{{{{x}}` that isn't part of `{{x}}`, or the trailing
-    // `}}` in `{{date}}}}`. An even run of those pairs off into its own
-    // literal `{{`/`}}` text, exactly as the legacy regex would leave it.
-    // An odd leftover (as in `{{{name}}`, one brace short of a raw close)
-    // means the tag boundary itself is ambiguous, so the whole run —
-    // leftover braces and the tag content alike — is left as literal text
-    // rather than guessing which tag was meant.
-    let leadStart = match.index;
-    while (leadStart > 0 && template[leadStart - 1] === "{") leadStart--;
-    const leadingExtra = match.index - leadStart;
-
-    const matchEnd = match.index + source.length;
-    let trailEnd = matchEnd;
-    while (trailEnd < template.length && template[trailEnd] === "}") {
-      trailEnd++;
-    }
-    const trailingExtra = trailEnd - matchEnd;
-
-    if (leadingExtra % 2 !== 0 || trailingExtra % 2 !== 0) {
-      // Retry from just past this match's own start — not `trailEnd` —
-      // so a smaller, valid match nested inside the same brace run still
-      // gets a chance. E.g. `{{{{url}}}}` rejects the 3-brace raw reading
-      // (one stray `{` and one stray `}` outside it, both odd) but must
-      // still find the plain `{{url}}` starting two characters later.
-      TAG.lastIndex = match.index + 1;
-      continue;
-    }
 
     if (match.index > lastIndex) {
       tokens.push({

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -249,12 +249,37 @@ function renderNodes(nodes: Node[], stack: Frame[]): string {
   return out;
 }
 
-/** Placeholder until Task 5 — sections render as nothing. */
+/**
+ * A section's value decides whether its body renders, and how many times.
+ * Arrays are the interesting case: non-empty arrays iterate, empty arrays are
+ * falsy — which is what makes `{{^items}}` a usable "nothing here yet" branch.
+ */
+function isTruthy(value: TemplateValue): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  if (value === null || value === undefined) return false;
+  if (typeof value === "object") return true;
+  return Boolean(value);
+}
+
 function renderSection(
-  _node: Extract<Node, { kind: "section" }>,
-  _stack: Frame[],
+  node: Extract<Node, { kind: "section" }>,
+  stack: Frame[],
 ): string {
-  return "";
+  const { value } = lookup(stack, node.name);
+  const truthy = isTruthy(value);
+
+  if (node.inverted) return truthy ? "" : renderNodes(node.children, stack);
+  if (!truthy) return "";
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => renderNodes(node.children, [...stack, item]))
+      .join("");
+  }
+  if (value && typeof value === "object") {
+    return renderNodes(node.children, [...stack, value]);
+  }
+  return renderNodes(node.children, stack);
 }
 
 /**

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -160,7 +160,12 @@ export function tokenize(template: string): Token[] {
     // enough; the leading empty segment is what `filter(Boolean)` drops.
     const filters = (filterClause ?? "").split("|").filter(Boolean);
     for (const f of filters) {
-      if (!(f in FILTERS)) {
+      // `hasOwn`, not `in`: `in` walks the prototype chain, so `|toString` or
+      // `|__defineGetter__` would pass validation and then be CALLED as a
+      // filter — rendering `[object Object]` into an email, or throwing a
+      // TypeError from `applyFilters`, which is outside every caller's
+      // TemplateParseError handling and escapes as an unhandled 500.
+      if (!hasOwn(FILTERS, f)) {
         throw new TemplateParseError(
           `Unknown filter "${f}" in ${source}. Available filters: ${Object.keys(FILTERS).join(", ")}.`,
         );
@@ -426,6 +431,12 @@ export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
 
       const existing = sectionsByName.get(node.name);
       if (existing) {
+        // A name used as both `{{^items}}` and `{{#items}}` is only an
+        // absence branch if EVERY occurrence is inverted — mirroring the way
+        // `required` wins over `optional` below. Keeping the first-seen flag
+        // would report a required section as an optional empty-state branch
+        // whenever the author wrote the empty-state half first.
+        existing.inverted = existing.inverted && node.inverted;
         for (const v of inner) {
           if (!existing.variables.includes(v)) existing.variables.push(v);
         }

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -198,3 +198,82 @@ export function renderTemplate(
     bodyHtml: interpolate(template.bodyHtml, variables),
   };
 }
+
+export type Node =
+  | { kind: "text"; value: string }
+  | {
+      kind: "var";
+      name: string;
+      raw: boolean;
+      optional: boolean;
+      filters: string[];
+      source: string;
+    }
+  | {
+      kind: "section";
+      name: string;
+      inverted: boolean;
+      optional: boolean;
+      children: Node[];
+    };
+
+/**
+ * Fold the token stream into a tree.
+ *
+ * Unbalanced or mismatched section tags are a parse error rather than a
+ * best-effort render: silently mis-nesting would produce a plausible-looking
+ * email with the wrong content, which is worse than a failed send.
+ */
+export function parse(template: string): Node[] {
+  const root: Node[] = [];
+  const stack: Array<{
+    node: Extract<Node, { kind: "section" }>;
+    source: string;
+  }> = [];
+
+  const currentChildren = () =>
+    stack.length === 0 ? root : stack[stack.length - 1].node.children;
+
+  for (const token of tokenize(template)) {
+    switch (token.kind) {
+      case "text":
+      case "var":
+        currentChildren().push(token);
+        break;
+      case "open": {
+        const node: Extract<Node, { kind: "section" }> = {
+          kind: "section",
+          name: token.name,
+          inverted: token.inverted,
+          optional: token.optional,
+          children: [],
+        };
+        currentChildren().push(node);
+        stack.push({ node, source: token.source });
+        break;
+      }
+      case "close": {
+        const open = stack.pop();
+        if (!open) {
+          throw new TemplateParseError(
+            `Unexpected ${token.source} — no section is open here.`,
+          );
+        }
+        if (open.node.name !== token.name) {
+          throw new TemplateParseError(
+            `${token.source} does not match the open section ${open.source}.`,
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  if (stack.length > 0) {
+    throw new TemplateParseError(
+      `Unclosed section ${stack[stack.length - 1].source} — add a matching {{/${stack[stack.length - 1].node.name}}}.`,
+    );
+  }
+
+  return root;
+}

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -305,7 +305,14 @@ export interface TemplateAnalysis {
 export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
   const required = new Set<string>();
   const optional = new Set<string>();
-  const sections: TemplateAnalysis["sections"] = [];
+  // Keyed by name so the same section appearing in multiple sources (e.g. a
+  // subject and body both using {{#items}}) merges into one entry instead of
+  // being reported twice. A Map preserves insertion order, so output stays
+  // stable by first appearance.
+  const sectionsByName = new Map<
+    string,
+    TemplateAnalysis["sections"][number]
+  >();
 
   /** Collect names referenced anywhere beneath a section, at any depth. */
   function collectInner(nodes: Node[], into: Set<string>): void {
@@ -330,11 +337,19 @@ export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
       (node.inverted || node.optional ? optional : required).add(node.name);
       const inner = new Set<string>();
       collectInner(node.children, inner);
-      sections.push({
-        name: node.name,
-        inverted: node.inverted,
-        variables: Array.from(inner),
-      });
+
+      const existing = sectionsByName.get(node.name);
+      if (existing) {
+        for (const v of inner) {
+          if (!existing.variables.includes(v)) existing.variables.push(v);
+        }
+      } else {
+        sectionsByName.set(node.name, {
+          name: node.name,
+          inverted: node.inverted,
+          variables: Array.from(inner),
+        });
+      }
     }
   }
 
@@ -346,7 +361,7 @@ export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
   return {
     required: Array.from(required),
     optional: Array.from(optional),
-    sections,
+    sections: Array.from(sectionsByName.values()),
   };
 }
 

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -1,3 +1,146 @@
+/** Any value a template variable can carry. */
+export type TemplateValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | TemplateValue[]
+  | { [key: string]: TemplateValue };
+
+export type TemplateVariables = Record<string, TemplateValue>;
+
+/** Thrown when a template's section tags are unbalanced or a filter is unknown. */
+export class TemplateParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TemplateParseError";
+  }
+}
+
+/**
+ * Escape the five characters that are significant in HTML text and in both
+ * quoting styles for attribute values.
+ *
+ * This is one character stricter than the helper in `inbound-forward.ts`,
+ * which omits `'` — single-quoted attributes are a real escape context in
+ * email HTML, so a value landing in one must not be able to close it.
+ */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Value filters. Deliberately a fixed one-entry registry, not a pipeline. */
+const FILTERS: Record<string, (s: string) => string> = {
+  nl2br: (s) => s.replace(/\r\n|\r|\n/g, "<br>"),
+};
+
+export type Token =
+  | { kind: "text"; value: string }
+  | {
+      kind: "var";
+      name: string;
+      raw: boolean;
+      optional: boolean;
+      filters: string[];
+      source: string;
+    }
+  | {
+      kind: "open";
+      name: string;
+      inverted: boolean;
+      optional: boolean;
+      source: string;
+    }
+  | { kind: "close"; name: string; source: string };
+
+/*
+ * Tag grammar, in order: optional third `{` for raw output, an optional
+ * `#`/`^`/`/` sigil, the name (word characters, or a bare `.` for the current
+ * item), an optional `?` marking it optional, zero or more `|filter` clauses,
+ * and a matching third `}` when the tag opened with one.
+ *
+ * Names are `[\w.]+`, so `{{not-a-var}}` does not match and survives as literal
+ * text — the pre-rewrite behavior, which an existing test pins.
+ */
+const TAG =
+  /\{\{(\{)?\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)(\})?\}\}/g;
+
+export function tokenize(template: string): Token[] {
+  const tokens: Token[] = [];
+  let lastIndex = 0;
+  TAG.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = TAG.exec(template)) !== null) {
+    const [source, rawOpen, sigil, name, optional, filterClause, rawClose] =
+      match;
+
+    // A tag that opened with `{{{` must close with `}}}`. When the brace counts
+    // disagree it is not a tag at all — emit it as text.
+    if (Boolean(rawOpen) !== Boolean(rawClose)) continue;
+
+    if (match.index > lastIndex) {
+      tokens.push({
+        kind: "text",
+        value: template.slice(lastIndex, match.index),
+      });
+    }
+    lastIndex = match.index + source.length;
+
+    if (sigil === "/") {
+      tokens.push({ kind: "close", name, source });
+      continue;
+    }
+    if (sigil === "#" || sigil === "^") {
+      tokens.push({
+        kind: "open",
+        name,
+        inverted: sigil === "^",
+        optional: Boolean(optional),
+        source,
+      });
+      continue;
+    }
+
+    const filters = (filterClause ?? "")
+      .split("|")
+      .map((f) => f.trim())
+      .filter(Boolean);
+    for (const f of filters) {
+      if (!(f in FILTERS)) {
+        throw new TemplateParseError(
+          `Unknown filter "${f}" in ${source}. Available filters: ${Object.keys(FILTERS).join(", ")}.`,
+        );
+      }
+    }
+
+    tokens.push({
+      kind: "var",
+      name,
+      raw: Boolean(rawOpen),
+      optional: Boolean(optional),
+      filters,
+      source,
+    });
+  }
+
+  if (lastIndex < template.length) {
+    tokens.push({ kind: "text", value: template.slice(lastIndex) });
+  }
+  return tokens;
+}
+
+/** Apply a tag's filters to an already-escaped (or deliberately raw) value. */
+function applyFilters(value: string, filters: string[]): string {
+  return filters.reduce((acc, f) => FILTERS[f](acc), value);
+}
+
 const VARIABLE_REGEX = /\{\{(\w+)\}\}/g;
 
 /**

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -19,6 +19,22 @@ export class TemplateParseError extends Error {
 }
 
 /**
+ * Thrown when a well-formed template asks for more expansion than the budget
+ * allows (see `MAX_SECTION_RENDERS`).
+ *
+ * Deliberately a subclass of `TemplateParseError`: every caller in the app
+ * already catches that type and turns it into a 400 (or a `failed` sequence
+ * step). A sibling type would escape all of them as an unhandled 500 — the
+ * exact failure mode the depth caps exist to prevent.
+ */
+export class TemplateRenderError extends TemplateParseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "TemplateRenderError";
+  }
+}
+
+/**
  * Escape the five characters that are significant in HTML text and in both
  * quoting styles for attribute values.
  *
@@ -248,22 +264,59 @@ function stringify(value: TemplateValue): string {
   return String(value);
 }
 
+/**
+ * Maximum number of section-body renders in one `interpolate` call.
+ *
+ * `MAX_SECTION_DEPTH` bounds how deeply a template nests and
+ * `MAX_VARIABLE_DEPTH` bounds how deeply the payload nests, but neither
+ * bounds the *product* of the two. Nesting a section inside itself is the
+ * pathological case: the inner `{{#items}}` cannot resolve against the item
+ * frame, so `lookup` falls back to the same top-level array and iterates it
+ * again — work grows as N^depth while the template stays a few hundred bytes
+ * and the payload stays flat. A 20-element array nested 8 deep asks for
+ * 2.6e10 renders; the isolate dies well before that, and on the sequence path
+ * the queue retries and burns the CPU again.
+ *
+ * The cap is on total body renders across the whole call rather than per
+ * section, since a template can also blow up by breadth. 20,000 is far above
+ * anything real — a 1,000-row invoice table is 1,000 — and costs about a
+ * millisecond when legitimately reached.
+ */
+export const MAX_SECTION_RENDERS = 20_000;
+
 /** Render-time settings threaded down the tree. */
 interface RenderContext {
   /** HTML-escape substituted values. False for plain-text output. */
   escape: boolean;
-  /**
-   * True while rendering a section body.
-   *
-   * It changes what an unresolved variable does. At top level, an unfound name
-   * survives as its own source text because `renderTemplate` refuses to send
-   * such a template at all — the verbatim `{{token}}` is a debugging signal
-   * that never reaches a recipient. Inside a section it is the opposite: those
-   * names resolve per item and are deliberately never `required`, so nothing
-   * upstream catches them, and emitting the source would mail a literal
-   * `{{empty_msg}}` to a customer. Inside a section, unfound renders empty.
-   */
+  /** True while rendering any section body; governs what an unresolved name RENDERS. */
   inSection: boolean;
+  /**
+   * True once an enclosing section has pushed a new scope frame — that is,
+   * once names are being resolved against a per-item context.
+   *
+   * It changes what an unresolved variable does. Where no frame has been
+   * pushed, an unfound name survives as its own source text and is recorded
+   * in `missing`, because it can only ever have come from the top level and
+   * a caller simply failed to supply it. Under a pushed frame it is the
+   * opposite: the name resolves per item, items legitimately differ in which
+   * optional fields they carry, and emitting the source would mail a literal
+   * `{{note}}` to a customer. There, unfound renders empty.
+   *
+   * This is deliberately *not* "are we inside a section". An inverted section
+   * pushes no frame, and neither does a truthy scalar one, so their bodies
+   * are plain top-level lookups; treating them as per-item was how
+   * `{{^has_orders}}Hi {{first_name}}{{/has_orders}}` came to mail "Hi ,"
+   * with the send reported successful.
+   */
+  scoped: boolean;
+  /**
+   * Names that resolved nowhere while no frame was pushed. `renderTemplate`
+   * turns a non-empty set into a failed send; `interpolate` on its own leaves
+   * it unread, which is what keeps the sequence path's lax behavior intact.
+   */
+  missing: Set<string>;
+  /** Remaining section-body renders; shared across the whole call. */
+  budget: { left: number };
 }
 
 function renderNodes(
@@ -280,10 +333,19 @@ function renderNodes(
     if (node.kind === "var") {
       const { found, value } = lookup(stack, node.name);
       if (!found) {
-        // Optional tags collapse to nothing; so do section-body tags (see
-        // `RenderContext.inSection`). A required top-level one survives
-        // verbatim so `renderTemplate`'s check fails the send rather than
-        // mailing a silent blank.
+        // Two separate decisions, deliberately kept apart.
+        //
+        // What to RENDER is unchanged: optional tags and anything inside a
+        // section collapse to nothing, so the empty-state pattern never mails
+        // a literal `{{empty_msg}}`; a top-level name survives as its source
+        // as the debugging signal it has always been.
+        //
+        // Whether it is a caller ERROR is the new part, and turns on
+        // `scoped` rather than `inSection` — see `RenderContext.scoped`. A
+        // name under an inverted or truthy-scalar section resolved against
+        // the top level and simply was not supplied, so it is recorded even
+        // though it still renders empty.
+        if (!node.optional && !ctx.scoped) ctx.missing.add(node.name);
         out += node.optional || ctx.inSection ? "" : node.source;
         continue;
       }
@@ -318,22 +380,47 @@ function renderSection(
 ): string {
   const { value } = lookup(stack, node.name);
   const truthy = isTruthy(value);
+
+  /** Charge one body render against the shared budget. */
+  const spend = () => {
+    if (--ctx.budget.left < 0) {
+      throw new TemplateRenderError(
+        `Template expanded past the ${MAX_SECTION_RENDERS}-render limit at {{#${node.name}}} — a section nested inside itself re-iterates the same value at every level.`,
+      );
+    }
+  };
+
+  // Inside a section for rendering purposes (unresolved names collapse to
+  // nothing) but NOT scoped, which stays false until a frame is actually
+  // pushed. Inverted and truthy-scalar sections render against the unchanged
+  // stack, so their bodies are plain top-level lookups.
   const inner: RenderContext = ctx.inSection
     ? ctx
     : { ...ctx, inSection: true };
+  const scopedInner: RenderContext = inner.scoped
+    ? inner
+    : { ...inner, scoped: true };
 
-  if (node.inverted)
-    return truthy ? "" : renderNodes(node.children, stack, inner);
+  if (node.inverted) {
+    if (truthy) return "";
+    spend();
+    return renderNodes(node.children, stack, inner);
+  }
   if (!truthy) return "";
 
   if (Array.isArray(value)) {
     return value
-      .map((item) => renderNodes(node.children, [...stack, item], inner))
+      .map((item) => {
+        spend();
+        return renderNodes(node.children, [...stack, item], scopedInner);
+      })
       .join("");
   }
   if (value && typeof value === "object") {
-    return renderNodes(node.children, [...stack, value], inner);
+    spend();
+    return renderNodes(node.children, [...stack, value], scopedInner);
   }
+  spend();
   return renderNodes(node.children, stack, inner);
 }
 
@@ -347,6 +434,17 @@ export interface InterpolateOptions {
    * equivalent, and HTML-emitting filters such as `nl2br` are skipped.
    */
   escape?: boolean;
+  /**
+   * Collects names that resolved nowhere outside a per-item frame. Supplied
+   * by `renderTemplate` so it can fail the send; callers that want the lax
+   * render (the sequence path) simply omit it.
+   */
+  collectMissing?: Set<string>;
+  /**
+   * Shares one render budget across several `interpolate` calls, so a subject
+   * and body rendered for the same send cannot each spend the full cap.
+   */
+  budget?: { left: number };
 }
 
 /**
@@ -365,6 +463,9 @@ export function interpolate(
   return renderNodes(parse(template), [variables], {
     escape: options.escape !== false,
     inSection: false,
+    scoped: false,
+    missing: options.collectMissing ?? new Set<string>(),
+    budget: options.budget ?? { left: MAX_SECTION_RENDERS },
   });
 }
 
@@ -514,13 +615,69 @@ export function renderTemplate(
     return { ok: false, missingVariables, requiredVariables };
   }
 
-  return {
-    ok: true,
+  // A name that is required and is never used as a section is only ever
+  // substituted as `{{name}}`, where `stringify` renders an object or array
+  // as "". Before the payload schema widened, the flat string record made
+  // that unrepresentable; now it parses cleanly and mails a blank, so the
+  // shape has to be checked here or not at all.
+  const sectionNames = new Set(analysis.sections.map((s) => s.name));
+  const wrongShape = requiredVariables.filter(
+    (v) =>
+      !sectionNames.has(v) &&
+      typeof variables[v] === "object" &&
+      variables[v] !== null,
+  );
+  if (wrongShape.length > 0) {
+    return {
+      ok: false,
+      missingVariables: [],
+      requiredVariables,
+      parseError: `${wrongShape.map((v) => `{{${v}}}`).join(", ")} ${wrongShape.length === 1 ? "expects" : "expect"} a text value, but an object or array was supplied — it would render as nothing.`,
+    };
+  }
+
+  // One budget for the pair: a send should not be able to spend the cap twice
+  // by splitting the work between subject and body.
+  const budget = { left: MAX_SECTION_RENDERS };
+  const collectMissing = new Set<string>();
+  let subject: string;
+  let bodyHtml: string;
+  try {
     // The subject is a plain-text header, not HTML — rendering it through the
     // escaping path would put `&amp;` and `&#39;` in front of a recipient.
-    subject: interpolate(template.subject, variables, { escape: false }),
-    bodyHtml: interpolate(template.bodyHtml, variables),
-  };
+    subject = interpolate(template.subject, variables, {
+      escape: false,
+      collectMissing,
+      budget,
+    });
+    bodyHtml = interpolate(template.bodyHtml, variables, {
+      collectMissing,
+      budget,
+    });
+  } catch (err) {
+    if (err instanceof TemplateParseError) {
+      return {
+        ok: false,
+        missingVariables: [],
+        requiredVariables,
+        parseError: err.message,
+      };
+    }
+    throw err;
+  }
+
+  // Names that resolved nowhere while no per-item frame was in scope. These
+  // are invisible to `analyzeTemplate` — it cannot tell statically whether a
+  // section will push a frame — so this is the only place they surface.
+  if (collectMissing.size > 0) {
+    return {
+      ok: false,
+      missingVariables: Array.from(collectMissing),
+      requiredVariables,
+    };
+  }
+
+  return { ok: true, subject, bodyHtml };
 }
 
 export type Node =

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -172,20 +172,6 @@ function applyFilters(value: string, filters: string[]): string {
   return filters.reduce((acc, f) => FILTERS[f](acc), value);
 }
 
-const VARIABLE_REGEX = /\{\{(\w+)\}\}/g;
-
-/**
- * Extract unique variable names from a template string.
- */
-export function extractVariables(template: string): string[] {
-  const vars = new Set<string>();
-  let match: RegExpExecArray | null;
-  while ((match = VARIABLE_REGEX.exec(template)) !== null) {
-    vars.add(match[1]);
-  }
-  return Array.from(vars);
-}
-
 /** A scope frame in the context stack. */
 type Frame = TemplateValue;
 
@@ -296,26 +282,118 @@ export function interpolate(
   return renderNodes(parse(template), [variables]);
 }
 
-export type RenderTemplateResult =
-  | { ok: true; subject: string; bodyHtml: string }
-  | { ok: false; missingVariables: string[]; requiredVariables: string[] };
+export interface TemplateAnalysis {
+  /** Names the caller must supply or the send fails. */
+  required: string[];
+  /** Names that render empty when absent. */
+  optional: string[];
+  /** Sections and the names their bodies reference, for the editor and API. */
+  sections: Array<{ name: string; inverted: boolean; variables: string[] }>;
+}
 
 /**
- * Validate that every variable a template references was supplied, then
- * interpolate its subject and body.
+ * Describe what a template needs.
  *
- * Missing variables are reported rather than silently left as `{{token}}`
- * so callers can fail the send instead of mailing a half-rendered template.
+ * The split matters: a name inside a section body resolves against the section
+ * item at render time, so it is NOT something the caller supplies at the top
+ * level. Reporting those as required would fail every send that uses a section.
+ *
+ * A regular `{{#items}}` IS required — absent, it renders nothing and a digest
+ * goes out silently empty. An inverted `{{^items}}` is not, since handling
+ * absence is its purpose. `{{#items?}}` opts a regular section out.
+ */
+export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
+  const required = new Set<string>();
+  const optional = new Set<string>();
+  const sections: TemplateAnalysis["sections"] = [];
+
+  /** Collect names referenced anywhere beneath a section, at any depth. */
+  function collectInner(nodes: Node[], into: Set<string>): void {
+    for (const node of nodes) {
+      if (node.kind === "var") {
+        if (node.name !== ".") into.add(node.name);
+      } else if (node.kind === "section") {
+        into.add(node.name);
+        collectInner(node.children, into);
+      }
+    }
+  }
+
+  function walkTopLevel(nodes: Node[]): void {
+    for (const node of nodes) {
+      if (node.kind === "text") continue;
+      if (node.kind === "var") {
+        if (node.name === ".") continue;
+        (node.optional ? optional : required).add(node.name);
+        continue;
+      }
+      (node.inverted || node.optional ? optional : required).add(node.name);
+      const inner = new Set<string>();
+      collectInner(node.children, inner);
+      sections.push({
+        name: node.name,
+        inverted: node.inverted,
+        variables: Array.from(inner),
+      });
+    }
+  }
+
+  for (const source of sources) walkTopLevel(parse(source));
+
+  // A name that is required somewhere is required overall.
+  for (const name of required) optional.delete(name);
+
+  return {
+    required: Array.from(required),
+    optional: Array.from(optional),
+    sections,
+  };
+}
+
+/**
+ * Names a caller must supply. Kept as the pre-rewrite entry point so existing
+ * call sites keep working; it is exactly the analysis's `required` set.
+ */
+export function extractVariables(template: string): string[] {
+  return analyzeTemplate(template).required;
+}
+
+export type RenderTemplateResult =
+  | { ok: true; subject: string; bodyHtml: string }
+  | {
+      ok: false;
+      missingVariables: string[];
+      requiredVariables: string[];
+      parseError?: string;
+    };
+
+/**
+ * Validate that every required variable was supplied, then render.
+ *
+ * Missing variables are reported rather than silently left as `{{token}}` so
+ * callers fail the send instead of mailing a half-rendered template.
  */
 export function renderTemplate(
   template: { subject: string; bodyHtml: string },
-  variables: Record<string, string>,
+  variables: TemplateVariables,
 ): RenderTemplateResult {
-  const subjectVars = extractVariables(template.subject);
-  const bodyVars = extractVariables(template.bodyHtml);
-  const requiredVariables = Array.from(new Set([...subjectVars, ...bodyVars]));
-  const missingVariables = requiredVariables.filter((v) => !(v in variables));
+  let analysis: TemplateAnalysis;
+  try {
+    analysis = analyzeTemplate(template.subject, template.bodyHtml);
+  } catch (err) {
+    if (err instanceof TemplateParseError) {
+      return {
+        ok: false,
+        missingVariables: [],
+        requiredVariables: [],
+        parseError: err.message,
+      };
+    }
+    throw err;
+  }
 
+  const requiredVariables = analysis.required;
+  const missingVariables = requiredVariables.filter((v) => !(v in variables));
   if (missingVariables.length > 0) {
     return { ok: false, missingVariables, requiredVariables };
   }

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -40,6 +40,15 @@ const FILTERS: Record<string, (s: string) => string> = {
   nl2br: (s) => s.replace(/\r\n|\r|\n/g, "<br>"),
 };
 
+/**
+ * Filters whose output is HTML and which are therefore skipped in plain-text
+ * render mode (see `InterpolateOptions.escape`). `nl2br` emits a `<br>` tag;
+ * running it while rendering a Subject header would put the literal characters
+ * `<br>` in front of the recipient. Skipping leaves the value's own newlines
+ * intact, which is the closest thing to "no formatting applied".
+ */
+const HTML_ONLY_FILTERS = new Set(["nl2br"]);
+
 export type Token =
   | { kind: "text"; value: string }
   | {
@@ -85,11 +94,19 @@ export type Token =
  * excludes 3+ brace runs from the legacy-identity check instead of
  * asserting a property the feature deliberately breaks.
  *
- * Names are `[\w.]+`, so `{{not-a-var}}` does not match and survives as literal
- * text — the pre-rewrite behavior, which an existing test pins.
+ * A name is `\w+` or a bare `.`, with NO whitespace anywhere inside the tag —
+ * not between the braces and the sigil, the sigil and the name, the name and
+ * `?`/`|`/the closing braces. That is deliberately as strict as the legacy
+ * `/\{\{(\w+)\}\}/g`, which left `{{ spaced }}`, `{{dotted.name}}`, and
+ * `{{not-a-var}}` alone as literal text. Being laxer would silently promote
+ * prose like `{{ note }}` in a stored template into a REQUIRED variable and
+ * start rejecting sends for a name the caller never heard of, and would read
+ * `{{user.name}}` as a flat key literally named `"user.name"` rather than the
+ * Mustache path it looks like. Neither is worth the convenience; anything
+ * that does not match survives as text exactly as it did before the rewrite.
  */
 const TAG =
-  /\{\{\{\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)\}\}\}|\{\{\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)\}\}/g;
+  /\{\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}\}|\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}/g;
 
 export function tokenize(template: string): Token[] {
   const tokens: Token[] = [];
@@ -139,10 +156,9 @@ export function tokenize(template: string): Token[] {
       continue;
     }
 
-    const filters = (filterClause ?? "")
-      .split("|")
-      .map((f) => f.trim())
-      .filter(Boolean);
+    // The clause is a run of `|name` with no whitespace, so splitting is
+    // enough; the leading empty segment is what `filter(Boolean)` drops.
+    const filters = (filterClause ?? "").split("|").filter(Boolean);
     for (const f of filters) {
       if (!(f in FILTERS)) {
         throw new TemplateParseError(
@@ -168,8 +184,15 @@ export function tokenize(template: string): Token[] {
 }
 
 /** Apply a tag's filters to an already-escaped (or deliberately raw) value. */
-function applyFilters(value: string, filters: string[]): string {
-  return filters.reduce((acc, f) => FILTERS[f](acc), value);
+function applyFilters(
+  value: string,
+  filters: string[],
+  escape: boolean,
+): string {
+  return filters.reduce(
+    (acc, f) => (!escape && HTML_ONLY_FILTERS.has(f) ? acc : FILTERS[f](acc)),
+    value,
+  );
 }
 
 /** A scope frame in the context stack. */
@@ -183,7 +206,16 @@ interface Lookup {
 /**
  * Resolve a name against the context stack, innermost frame first, so a
  * section body can reference both its own item's fields and top-level values.
+ *
+ * Membership is `hasOwn`, not `in`: `in` walks the prototype chain, so
+ * `{{constructor}}` / `{{toString}}` / `{{hasOwnProperty}}` would resolve to
+ * built-in functions nobody supplied. Section frames come straight from
+ * caller-supplied JSON, so this is the only line keeping inherited members out.
  */
+function hasOwn(obj: object, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, name);
+}
+
 function lookup(stack: Frame[], name: string): Lookup {
   if (name === ".") {
     return { found: stack.length > 0, value: stack[stack.length - 1] };
@@ -194,7 +226,7 @@ function lookup(stack: Frame[], name: string): Lookup {
       frame &&
       typeof frame === "object" &&
       !Array.isArray(frame) &&
-      name in frame
+      hasOwn(frame, name)
     ) {
       return {
         found: true,
@@ -211,7 +243,29 @@ function stringify(value: TemplateValue): string {
   return String(value);
 }
 
-function renderNodes(nodes: Node[], stack: Frame[]): string {
+/** Render-time settings threaded down the tree. */
+interface RenderContext {
+  /** HTML-escape substituted values. False for plain-text output. */
+  escape: boolean;
+  /**
+   * True while rendering a section body.
+   *
+   * It changes what an unresolved variable does. At top level, an unfound name
+   * survives as its own source text because `renderTemplate` refuses to send
+   * such a template at all — the verbatim `{{token}}` is a debugging signal
+   * that never reaches a recipient. Inside a section it is the opposite: those
+   * names resolve per item and are deliberately never `required`, so nothing
+   * upstream catches them, and emitting the source would mail a literal
+   * `{{empty_msg}}` to a customer. Inside a section, unfound renders empty.
+   */
+  inSection: boolean;
+}
+
+function renderNodes(
+  nodes: Node[],
+  stack: Frame[],
+  ctx: RenderContext,
+): string {
   let out = "";
   for (const node of nodes) {
     if (node.kind === "text") {
@@ -221,16 +275,21 @@ function renderNodes(nodes: Node[], stack: Frame[]): string {
     if (node.kind === "var") {
       const { found, value } = lookup(stack, node.name);
       if (!found) {
-        // Optional tags collapse to nothing; required ones survive verbatim so
-        // `renderTemplate`'s check is what fails the send, not a silent blank.
-        out += node.optional ? "" : node.source;
+        // Optional tags collapse to nothing; so do section-body tags (see
+        // `RenderContext.inSection`). A required top-level one survives
+        // verbatim so `renderTemplate`'s check fails the send rather than
+        // mailing a silent blank.
+        out += node.optional || ctx.inSection ? "" : node.source;
         continue;
       }
-      const text = node.raw ? stringify(value) : escapeHtml(stringify(value));
-      out += applyFilters(text, node.filters);
+      const text =
+        node.raw || !ctx.escape
+          ? stringify(value)
+          : escapeHtml(stringify(value));
+      out += applyFilters(text, node.filters, ctx.escape);
       continue;
     }
-    out += renderSection(node, stack);
+    out += renderSection(node, stack, ctx);
   }
   return out;
 }
@@ -250,36 +309,58 @@ function isTruthy(value: TemplateValue): boolean {
 function renderSection(
   node: Extract<Node, { kind: "section" }>,
   stack: Frame[],
+  ctx: RenderContext,
 ): string {
   const { value } = lookup(stack, node.name);
   const truthy = isTruthy(value);
+  const inner: RenderContext = ctx.inSection
+    ? ctx
+    : { ...ctx, inSection: true };
 
-  if (node.inverted) return truthy ? "" : renderNodes(node.children, stack);
+  if (node.inverted)
+    return truthy ? "" : renderNodes(node.children, stack, inner);
   if (!truthy) return "";
 
   if (Array.isArray(value)) {
     return value
-      .map((item) => renderNodes(node.children, [...stack, item]))
+      .map((item) => renderNodes(node.children, [...stack, item], inner))
       .join("");
   }
   if (value && typeof value === "object") {
-    return renderNodes(node.children, [...stack, value]);
+    return renderNodes(node.children, [...stack, value], inner);
   }
-  return renderNodes(node.children, stack);
+  return renderNodes(node.children, stack, inner);
+}
+
+export interface InterpolateOptions {
+  /**
+   * HTML-escape substituted values. Defaults to true.
+   *
+   * Set false for plain-text output. A Subject header is plain text, not
+   * HTML: escaping it would mail a literal `O&#39;Brien` to a recipient
+   * whose name is `O'Brien`. In this mode `{{key}}` and `{{{key}}}` are
+   * equivalent, and HTML-emitting filters such as `nl2br` are skipped.
+   */
+  escape?: boolean;
 }
 
 /**
  * Render a template against a set of variables.
  *
  * Values are HTML-escaped by default; `{{{name}}}` opts a value out for
- * pre-rendered HTML chunks. Escaping applies to substituted values only — the
- * template's own markup and prose pass through untouched.
+ * pre-rendered HTML chunks, and `{ escape: false }` opts the whole render out
+ * for plain-text destinations. Escaping applies to substituted values only —
+ * the template's own markup and prose pass through untouched.
  */
 export function interpolate(
   template: string,
   variables: TemplateVariables,
+  options: InterpolateOptions = {},
 ): string {
-  return renderNodes(parse(template), [variables]);
+  return renderNodes(parse(template), [variables], {
+    escape: options.escape !== false,
+    inSection: false,
+  });
 }
 
 export interface TemplateAnalysis {
@@ -334,7 +415,12 @@ export function analyzeTemplate(...sources: string[]): TemplateAnalysis {
         (node.optional ? optional : required).add(node.name);
         continue;
       }
-      (node.inverted || node.optional ? optional : required).add(node.name);
+      // `{{#.}}` iterates the current item, exactly as `{{.}}` renders it —
+      // there is no top-level name to supply, so requiring "." would make the
+      // template permanently unsendable.
+      if (node.name !== ".") {
+        (node.inverted || node.optional ? optional : required).add(node.name);
+      }
       const inner = new Set<string>();
       collectInner(node.children, inner);
 
@@ -408,14 +494,20 @@ export function renderTemplate(
   }
 
   const requiredVariables = analysis.required;
-  const missingVariables = requiredVariables.filter((v) => !(v in variables));
+  // `hasOwn`, not `in`: `in` would count inherited members like `constructor`
+  // as "supplied" and let a send proceed with a variable nobody passed.
+  const missingVariables = requiredVariables.filter(
+    (v) => !Object.prototype.hasOwnProperty.call(variables, v),
+  );
   if (missingVariables.length > 0) {
     return { ok: false, missingVariables, requiredVariables };
   }
 
   return {
     ok: true,
-    subject: interpolate(template.subject, variables),
+    // The subject is a plain-text header, not HTML — rendering it through the
+    // escaping path would put `&amp;` and `&#39;` in front of a recipient.
+    subject: interpolate(template.subject, variables, { escape: false }),
     bodyHtml: interpolate(template.bodyHtml, variables),
   };
 }
@@ -437,6 +529,20 @@ export type Node =
       optional: boolean;
       children: Node[];
     };
+
+/**
+ * Maximum section nesting depth.
+ *
+ * `parse` itself is iterative, but rendering and `analyzeTemplate`'s inner
+ * collection both recurse once per level, so an arbitrarily deep template
+ * would overflow the stack — a `RangeError` escaping as an unhandled 500 from
+ * `/variables` or a send, and workerd's stack is smaller than Node's. Nothing
+ * validates a template's balance at save time, so an admin can store one.
+ * Capping here turns that into a `TemplateParseError`, which every caller
+ * already handles. Real templates nest a handful of levels; 64 is far beyond
+ * anything hand-written.
+ */
+export const MAX_SECTION_DEPTH = 64;
 
 /**
  * Fold the token stream into a tree.
@@ -462,6 +568,11 @@ export function parse(template: string): Node[] {
         currentChildren().push(token);
         break;
       case "open": {
+        if (stack.length >= MAX_SECTION_DEPTH) {
+          throw new TemplateParseError(
+            `Sections nested too deeply at ${token.source} — the limit is ${MAX_SECTION_DEPTH} levels.`,
+          );
+        }
         const node: Extract<Node, { kind: "section" }> = {
           kind: "section",
           name: token.name,

--- a/worker/src/lib/interpolate.ts
+++ b/worker/src/lib/interpolate.ts
@@ -60,16 +60,27 @@ export type Token =
   | { kind: "close"; name: string; source: string };
 
 /*
- * Tag grammar, in order: optional third `{` for raw output, an optional
- * `#`/`^`/`/` sigil, the name (word characters, or a bare `.` for the current
- * item), an optional `?` marking it optional, zero or more `|filter` clauses,
- * and a matching third `}` when the tag opened with one.
+ * Tag grammar, as two fully separate alternatives rather than one pattern
+ * with independently-optional third braces: a strict `{{{...}}}` raw form
+ * and a strict `{{...}}` form. Each requires an exact, matching brace count
+ * on both ends. In order within each: an optional `#`/`^`/`/` sigil, the
+ * name (word characters, or a bare `.` for the current item), an optional
+ * `?` marking it optional, and zero or more `|filter` clauses.
+ *
+ * Keeping the two forms from sharing a group is deliberate: an earlier
+ * single-pattern version let a lone extra `{` or `}` sitting next to a
+ * *different* tag get folded into that tag's brace count (e.g. matching
+ * `{{{` + `name` + `}}` as a bogus "almost raw" tag), which is exactly the
+ * situation that arises when a literal `{{`/`}}` happens to sit next to a
+ * real tag. With this form, `{{{{x}}` fails the raw alternative outright
+ * (only 2 of the 3 required opening braces belong to it) and falls through
+ * to the plain alternative, which finds `{{x}}` starting two characters in.
  *
  * Names are `[\w.]+`, so `{{not-a-var}}` does not match and survives as literal
  * text — the pre-rewrite behavior, which an existing test pins.
  */
 const TAG =
-  /\{\{(\{)?\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)(\})?\}\}/g;
+  /\{\{\{\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)\}\}\}|\{\{\s*([#^/]?)\s*([\w.]+)\s*(\?)?\s*((?:\|\s*\w+\s*)*)\}\}/g;
 
 export function tokenize(template: string): Token[] {
   const tokens: Token[] = [];
@@ -78,12 +89,53 @@ export function tokenize(template: string): Token[] {
 
   let match: RegExpExecArray | null;
   while ((match = TAG.exec(template)) !== null) {
-    const [source, rawOpen, sigil, name, optional, filterClause, rawClose] =
-      match;
+    const [
+      source,
+      rawSigil,
+      rawName,
+      rawOptional,
+      rawFilterClause,
+      plainSigil,
+      plainName,
+      plainOptional,
+      plainFilterClause,
+    ] = match;
 
-    // A tag that opened with `{{{` must close with `}}}`. When the brace counts
-    // disagree it is not a tag at all — emit it as text.
-    if (Boolean(rawOpen) !== Boolean(rawClose)) continue;
+    const raw = rawName !== undefined;
+    const sigil = raw ? rawSigil : plainSigil;
+    const name = raw ? rawName : plainName;
+    const optional = raw ? rawOptional : plainOptional;
+    const filterClause = raw ? rawFilterClause : plainFilterClause;
+
+    // Even with the two brace forms kept separate, a tag can still sit
+    // directly against *extra* braces that belong to neither alternative —
+    // e.g. the `{{` in `{{{{x}}` that isn't part of `{{x}}`, or the trailing
+    // `}}` in `{{date}}}}`. An even run of those pairs off into its own
+    // literal `{{`/`}}` text, exactly as the legacy regex would leave it.
+    // An odd leftover (as in `{{{name}}`, one brace short of a raw close)
+    // means the tag boundary itself is ambiguous, so the whole run —
+    // leftover braces and the tag content alike — is left as literal text
+    // rather than guessing which tag was meant.
+    let leadStart = match.index;
+    while (leadStart > 0 && template[leadStart - 1] === "{") leadStart--;
+    const leadingExtra = match.index - leadStart;
+
+    const matchEnd = match.index + source.length;
+    let trailEnd = matchEnd;
+    while (trailEnd < template.length && template[trailEnd] === "}") {
+      trailEnd++;
+    }
+    const trailingExtra = trailEnd - matchEnd;
+
+    if (leadingExtra % 2 !== 0 || trailingExtra % 2 !== 0) {
+      // Retry from just past this match's own start — not `trailEnd` —
+      // so a smaller, valid match nested inside the same brace run still
+      // gets a chance. E.g. `{{{{url}}}}` rejects the 3-brace raw reading
+      // (one stray `{` and one stray `}` outside it, both odd) but must
+      // still find the plain `{{url}}` starting two characters later.
+      TAG.lastIndex = match.index + 1;
+      continue;
+    }
 
     if (match.index > lastIndex) {
       tokens.push({
@@ -123,7 +175,7 @@ export function tokenize(template: string): Token[] {
     tokens.push({
       kind: "var",
       name,
-      raw: Boolean(rawOpen),
+      raw,
       optional: Boolean(optional),
       filters,
       source,
@@ -155,17 +207,89 @@ export function extractVariables(template: string): string[] {
   return Array.from(vars);
 }
 
+/** A scope frame in the context stack. */
+type Frame = TemplateValue;
+
+interface Lookup {
+  found: boolean;
+  value: TemplateValue;
+}
+
 /**
- * Replace {{variableName}} tokens with values from the variables object.
- * Unmatched tokens are left as-is.
+ * Resolve a name against the context stack, innermost frame first, so a
+ * section body can reference both its own item's fields and top-level values.
+ */
+function lookup(stack: Frame[], name: string): Lookup {
+  if (name === ".") {
+    return { found: stack.length > 0, value: stack[stack.length - 1] };
+  }
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const frame = stack[i];
+    if (
+      frame &&
+      typeof frame === "object" &&
+      !Array.isArray(frame) &&
+      name in frame
+    ) {
+      return {
+        found: true,
+        value: (frame as Record<string, TemplateValue>)[name],
+      };
+    }
+  }
+  return { found: false, value: undefined };
+}
+
+function stringify(value: TemplateValue): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return "";
+  return String(value);
+}
+
+function renderNodes(nodes: Node[], stack: Frame[]): string {
+  let out = "";
+  for (const node of nodes) {
+    if (node.kind === "text") {
+      out += node.value;
+      continue;
+    }
+    if (node.kind === "var") {
+      const { found, value } = lookup(stack, node.name);
+      if (!found) {
+        // Optional tags collapse to nothing; required ones survive verbatim so
+        // `renderTemplate`'s check is what fails the send, not a silent blank.
+        out += node.optional ? "" : node.source;
+        continue;
+      }
+      const text = node.raw ? stringify(value) : escapeHtml(stringify(value));
+      out += applyFilters(text, node.filters);
+      continue;
+    }
+    out += renderSection(node, stack);
+  }
+  return out;
+}
+
+/** Placeholder until Task 5 — sections render as nothing. */
+function renderSection(
+  _node: Extract<Node, { kind: "section" }>,
+  _stack: Frame[],
+): string {
+  return "";
+}
+
+/**
+ * Render a template against a set of variables.
+ *
+ * Values are HTML-escaped by default; `{{{name}}}` opts a value out for
+ * pre-rendered HTML chunks. Escaping applies to substituted values only — the
+ * template's own markup and prose pass through untouched.
  */
 export function interpolate(
   template: string,
-  variables: Record<string, string>,
+  variables: TemplateVariables,
 ): string {
-  return template.replace(VARIABLE_REGEX, (match, key) => {
-    return key in variables ? variables[key] : match;
-  });
+  return renderNodes(parse(template), [variables]);
 }
 
 export type RenderTemplateResult =

--- a/worker/src/lib/send-email.ts
+++ b/worker/src/lib/send-email.ts
@@ -95,7 +95,8 @@ export type ReplyEmailFailure =
         | "EMAIL_NOT_FOUND"
         | "EMAIL_HAS_NO_PERSON"
         | "TEMPLATE_NOT_FOUND"
-        | "MISSING_BODY";
+        | "MISSING_BODY"
+        | "TEMPLATE_PARSE_ERROR";
       message: string;
     }
   | {
@@ -442,6 +443,13 @@ export async function replyToEmail(
 
     const rendered = renderTemplate(templateRows[0], variables ?? {});
     if (!rendered.ok) {
+      if (rendered.parseError) {
+        return {
+          ok: false,
+          code: "TEMPLATE_PARSE_ERROR",
+          message: rendered.parseError,
+        };
+      }
       return {
         ok: false,
         code: "MISSING_VARIABLES",

--- a/worker/src/lib/send-template.ts
+++ b/worker/src/lib/send-template.ts
@@ -32,6 +32,7 @@ export type SendTemplateSuccess = {
 
 export type SendTemplateFailure =
   | { ok: false; code: "TEMPLATE_NOT_FOUND"; message: string }
+  | { ok: false; code: "TEMPLATE_PARSE_ERROR"; message: string }
   | {
       ok: false;
       code: "MISSING_VARIABLES";
@@ -80,6 +81,13 @@ export async function sendTemplate(
 
   const rendered = renderTemplate(rows[0], variables);
   if (!rendered.ok) {
+    if (rendered.parseError) {
+      return {
+        ok: false,
+        code: "TEMPLATE_PARSE_ERROR",
+        message: rendered.parseError,
+      };
+    }
     return {
       ok: false,
       code: "MISSING_VARIABLES",

--- a/worker/src/lib/sequence-processor.ts
+++ b/worker/src/lib/sequence-processor.ts
@@ -90,6 +90,29 @@ export async function handleQueueBatch(
   }
 }
 
+/**
+ * Mark a step terminally failed and settle the enrollment.
+ *
+ * Every terminal branch must go through here rather than updating the row and
+ * returning. `completeEnrollmentIfDone` lives at the very end of
+ * `processSequenceEmail`, so an early return skips it and leaves the
+ * enrollment `active` with no outstanding steps — and since
+ * `enrollPersonInSequence` refuses to enroll anyone who already has an active
+ * enrollment, that contact can never be enrolled in any sequence again. A
+ * failed final step should end the drip, not wedge the person.
+ */
+async function failStep(
+  db: ReturnType<typeof drizzle>,
+  sequenceEmailId: string,
+  enrollmentId: string,
+): Promise<void> {
+  await db
+    .update(sequenceEmails)
+    .set({ status: "failed" })
+    .where(eq(sequenceEmails.id, sequenceEmailId));
+  await completeEnrollmentIfDone(db, enrollmentId);
+}
+
 export async function processSequenceEmail(
   db: ReturnType<typeof drizzle>,
   sender: EmailSender,
@@ -179,10 +202,7 @@ export async function processSequenceEmail(
     .limit(1);
 
   if (templateRows.length === 0) {
-    await db
-      .update(sequenceEmails)
-      .set({ status: "failed" })
-      .where(eq(sequenceEmails.id, sequenceEmailId));
+    await failStep(db, sequenceEmailId, enrollment.id);
     return;
   }
 
@@ -196,10 +216,7 @@ export async function processSequenceEmail(
     .limit(1);
 
   if (personRows.length === 0) {
-    await db
-      .update(sequenceEmails)
-      .set({ status: "failed" })
-      .where(eq(sequenceEmails.id, sequenceEmailId));
+    await failStep(db, sequenceEmailId, enrollment.id);
     return;
   }
 
@@ -238,10 +255,7 @@ export async function processSequenceEmail(
           error: err.message,
         }),
       );
-      await db
-        .update(sequenceEmails)
-        .set({ status: "failed" })
-        .where(eq(sequenceEmails.id, sequenceEmailId));
+      await failStep(db, sequenceEmailId, enrollment.id);
       return;
     }
     throw err;

--- a/worker/src/lib/sequence-processor.ts
+++ b/worker/src/lib/sequence-processor.ts
@@ -10,7 +10,7 @@ import { emailTemplates } from "../db/email-templates.schema";
 import { people } from "../db/people.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { outboxEmails } from "../db/outbox-emails.schema";
-import { interpolate } from "./interpolate";
+import { interpolate, TemplateParseError } from "./interpolate";
 import { formatFromAddress } from "./format-from-address";
 import { generateMessageId } from "./message-id";
 import { sendViaOutbox } from "./outbox";
@@ -213,9 +213,39 @@ export async function processSequenceEmail(
     ...customVars,
   };
 
-  // Interpolate template
-  const renderedSubject = interpolate(template.subject, mergedVars);
-  const renderedHtml = interpolate(template.bodyHtml, mergedVars);
+  // Interpolate template. The subject is a plain-text header, so it renders
+  // without HTML escaping; the body is HTML and stays escaped.
+  //
+  // A malformed template (unbalanced sections, unknown filter) throws
+  // TemplateParseError. Without this catch the throw would reach the queue
+  // handler, which retries — leaving the row stuck on "queued" forever and
+  // the enrollment never completing. Treat it as final, exactly like a
+  // missing template or missing person above.
+  let renderedSubject: string;
+  let renderedHtml: string;
+  try {
+    renderedSubject = interpolate(template.subject, mergedVars, {
+      escape: false,
+    });
+    renderedHtml = interpolate(template.bodyHtml, mergedVars);
+  } catch (err) {
+    if (err instanceof TemplateParseError) {
+      console.error(
+        "[sequence] template parse error",
+        JSON.stringify({
+          sequenceEmailId,
+          templateSlug: seqEmail.templateSlug,
+          error: err.message,
+        }),
+      );
+      await db
+        .update(sequenceEmails)
+        .set({ status: "failed" })
+        .where(eq(sequenceEmails.id, sequenceEmailId));
+      return;
+    }
+    throw err;
+  }
 
   const messageId = generateMessageId(fromAddress);
   const formattedFrom = await formatFromAddress(db, fromAddress);

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -4,13 +4,14 @@ import { nanoid } from "nanoid";
 import { assertInboxAllowed, isInboxAllowed } from "../lib/inbox-permissions";
 import { emailTemplates } from "../db/email-templates.schema";
 import { json200Response, json201Response } from "../lib/helpers";
-import { extractVariables } from "../lib/interpolate";
+import { analyzeTemplate, TemplateParseError } from "../lib/interpolate";
 import { sendTemplate } from "../lib/send-template";
 import type { Variables } from "../variables";
 import { bearerSecurity } from "../lib/openapi-auth";
 import {
   ErrorSchema,
   inboxForbiddenResponse,
+  SendPathErrorSchema,
 } from "../lib/openapi-send-errors";
 
 export const emailTemplatesRouter = new OpenAPIHono<{
@@ -257,6 +258,10 @@ const getTemplateVariablesRoute = createRoute({
       z.object({ variables: z.array(z.string()) }),
       "Template variables",
     ),
+    400: {
+      description: "Template has an unbalanced section",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 
@@ -275,11 +280,17 @@ emailTemplatesRouter.openapi(getTemplateVariablesRoute, async (c) => {
   }
 
   const template = rows[0];
-  const subjectVars = extractVariables(template.subject);
-  const bodyVars = extractVariables(template.bodyHtml);
-  const allVars = Array.from(new Set([...subjectVars, ...bodyVars]));
+  let analysis;
+  try {
+    analysis = analyzeTemplate(template.subject, template.bodyHtml);
+  } catch (err) {
+    if (err instanceof TemplateParseError) {
+      return c.json({ error: err.message }, 400);
+    }
+    throw err;
+  }
 
-  return c.json({ variables: allVars }, 200);
+  return c.json({ variables: analysis.required }, 200);
 });
 
 // --- SEND ---
@@ -318,15 +329,10 @@ const sendTemplateRoute = createRoute({
       "Email sent",
     ),
     400: {
-      description: "Missing required template variables",
+      description:
+        "Missing required template variables, or the template has an unbalanced section.",
       content: {
-        "application/json": {
-          schema: z.object({
-            error: z.string(),
-            missingVariables: z.array(z.string()),
-            requiredVariables: z.array(z.string()),
-          }),
-        },
+        "application/json": { schema: SendPathErrorSchema },
       },
     },
     ...inboxForbiddenResponse,
@@ -355,6 +361,9 @@ emailTemplatesRouter.openapi(sendTemplateRoute, async (c) => {
   if (!result.ok) {
     if (result.code === "TEMPLATE_NOT_FOUND") {
       return c.json({ error: result.message }, 404);
+    }
+    if (result.code === "TEMPLATE_PARSE_ERROR") {
+      return c.json({ error: result.message }, 400);
     }
     return c.json(
       {

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -294,7 +294,10 @@ sendRouter.openapi(replyEmailRoute, async (c) => {
         400,
       );
     }
-    if (result.code === "MISSING_BODY") {
+    if (
+      result.code === "MISSING_BODY" ||
+      result.code === "TEMPLATE_PARSE_ERROR"
+    ) {
       return c.json({ error: result.message }, 400);
     }
     return c.json({ error: result.message }, 404);


### PR DESCRIPTION
## Summary

Rewrites the template interpolator from flat `{{key}}` regex substitution into a tokenize → parse → render pipeline supporting a Mustache-style subset, and makes HTML escaping the default. First of a three-PR stack addressing #112 and #227.

Note that #227 corrects a premise in #112: that issue describes `{{name}}` as "HTML-escaped substitution (current behavior)". Substitution was **raw**. An implementation preserving "current behavior" would have preserved the vulnerability.

## Changes

| Tag | Behavior |
| --- | --- |
| `{{key}}` | Value, HTML-escaped in the body; plain text in the subject |
| `{{{key}}}` | Value, raw — for pre-rendered HTML |
| `{{key?}}` | Optional; renders empty instead of failing the send |
| `{{key\|nl2br}}` | Escaped, then newlines become `<br>` |
| `{{#key}}…{{/key}}` | Renders if truthy; iterates arrays with a context stack |
| `{{^key}}…{{/key}}` | Renders if falsy or empty |
| `{{.}}` | Current item inside an array-of-strings section |

- `analyzeTemplate` separates **required** variables from names that resolve per-item inside a section. Getting this backwards would make every send using a section return 400, so it is covered by mutation-tested assertions.
- New `TEMPLATE_PARSE_ERROR` (400) on `/:slug/send`, `/:slug/variables`, and `/api/send/reply/:id`. `analyzeTemplate` can throw where the old regex could not, and three call sites previously mistranslated that — one into a 500, two into a "missing variables" error naming no variables.
- Section nesting is capped at 64 levels, throwing `TemplateParseError` rather than a `RangeError`.

### Two fixes found in review of this PR

- **Filter names are validated with `hasOwn`, not `in`.** `in` walks the prototype chain, so `{{x|toString}}` and `{{x|__defineGetter__}}` passed validation and were then *called* as filters — rendering `[object Object]` into an email, or throwing a `TypeError` from outside every caller's `TemplateParseError` handling and escaping as an unhandled 500.
- **Section polarity merges across sources.** A name written `{{^promo}}` in the subject and `{{#promo}}` in the body kept whichever flag was seen first, so a required section could be reported as an optional empty-state branch purely because the author wrote the empty-state half first. A section is now inverted only if *every* occurrence is inverted, mirroring how `required` already won over `optional`.

## Breaking changes

Both are documented in `CHANGELOG.md` and `README.md`.

1. **Variables are HTML-escaped by default.** Templates deliberately passing HTML must switch those tags to `{{{key}}}`. This affects sequence sends too, which share the renderer. Subject lines are *not* escaped — they are plain-text headers.
2. **Templates with 3+ consecutive braces change meaning**, because `{{{key}}}` now means raw output. Previously `{{{name}}}` rendered as `{` + value + `}`. This is unavoidable: supporting raw output and preserving the old reading are mutually exclusive. Templates using only `{{key}}` in ordinary text are unaffected.

Tag names deliberately stay `\w+` (plus a bare `.`), matching the old regex exactly, so `{{ spaced }}` and `{{dotted.name}}` remain literal text rather than silently becoming required variables.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — 6 pre-existing errors, none in files this PR touches. Note: the bare `yarn tsc --noEmit` this repo mandates compiles **zero** files (root `tsconfig.json` has `"files": []`), so it validates nothing; see the review notes.
- [x] Interpolate suites + template/send/sequence routers: 193 tests across 12 files
- [x] Full suite — **green on CI** (`vitest`, `test`, `playwright`, `prettier`, CodeQL all passing)

Approach: a compatibility harness was written and made to pass **before** the rewrite began — a frozen copy of the pre-rewrite implementation, a 5000-case differential fuzz asserting the new renderer agrees with it, and a golden corpus of the seven seeded demo templates with pinned output. The eight pre-existing cases in `interpolate.test.ts` are unmodified; they were the tripwire.

That harness caught a real tokenizer bug that a reviewer had hand-traced and cleared.

## Notes for reviewers

- **The local-vs-CI test discrepancy is resolved.** Earlier local runs showed 1–4 failures, always 5000ms timeouts on unrelated suites (health-and-auth, blocklist-router, notifications-router, push-subscriptions-router) and a different subset each run. It was environmental — stale `workerd` processes from other projects saturating the machine. CI is green on a clean runner.
- **The template editor does not yet understand sections.** Its variable list comes from an older extractor, so section templates should be exercised via the API until PR 3 lands. Called out in the README. (#230 fixes this and removes the caveat.)
- Subject header injection via `\r\n` was investigated and is a non-issue: mimetext RFC 2047-encodes the subject, and other providers pass it as a JSON field.
- The sequence parse-error path used to leave the enrollment `active`, as did the pre-existing missing-template and missing-person paths. All three now go through one `failStep` helper that marks the row `failed` **and** settles the enrollment. This mattered more than the original note suggested: `enrollPersonInSequence` refuses anyone with an active enrollment, so a drip whose last step had a broken template locked that contact out of every future sequence, permanently, with one `console.error` as the only trace.
- The other follow-up this PR originally listed — templates not being validated for balanced sections at create/update time — **is now fixed in #229**, which rejects an unparseable template at write time.

Closes #112 and part of #227. PRs 2 and 3 add the API surface for nested variables and the editor UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
