### PR TITLE
feat(api): nested template variables and richer /variables response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `POST /api/send/reply/{id}` — those routes could not return 400 for this
   reason before. A sequence step whose template does not parse is marked
   `failed` rather than retried forever. (#112)
+- Template `variables` payloads may nest objects and arrays up to 32 levels
+  deep; deeper is rejected with `400` naming the limit. Zod's recursive descent
+  through the self-referencing value schema has no bound of its own, so a
+  payload of a few KB but thousands of levels deep overflowed the stack — a
+  `RangeError`, which is not a `ZodError` and so surfaced as an unhandled 500.
+  The guard applies on every send path, including the MCP tools. (#227)
+- Templates are validated when they are written. `POST` and `PUT
+/api/email-templates` reject a template whose tags do not parse, with the
+  diagnostic naming the offending tag. Previously a broken template stored
+  cleanly and failed much later — on every send, on `/variables`, and by
+  marking sequence steps `failed` terminally, with a worker log as the only
+  trace. `PUT` validates the template as it will exist after the merge, since
+  editing only the subject can still unbalance a section across the pair.
+  (#227)
 - Section nesting is capped at 64 levels; deeper templates are rejected as a
   parse error rather than overflowing the renderer's stack. (#112)
 - Total section expansion is capped at 20,000 body renders per template, as
@@ -83,14 +97,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{{{name}}}` rendered as `{` + the value + `}`; it is now an unescaped
   substitution. Templates that only use `{{key}}` and ordinary text are
   unaffected. (#112)
-- `GET /api/email-templates/{slug}/variables` now returns only the **required**
-  variables — the names a caller must supply or the send is rejected. Names
-  marked optional with `{{key?}}` and names used inside a `{{#section}}` body
-  are deliberately omitted: a section-body name resolves against the current
-  item at render time, so it is not something the caller passes at the top
-  level, and listing it would suggest a contract that does not exist. The
-  response is unchanged for templates that use only `{{key}}` tags; it differs
-  only once a template adopts the new syntax. (#112)
+- `GET /api/email-templates/{slug}/variables` returns three lists. `variables`
+  keeps its name, its `string[]` type, and its meaning — the names a caller
+  must supply or the send is rejected — so existing integrations are
+  unaffected. Alongside it, `optional` carries names that render empty when
+  absent (`{{key?}}` tags and inverted sections), and `sections` carries each
+  section's name, whether it is inverted, and the names its body references.
+  Section-body names stay out of `variables`: they resolve against the current
+  item at render time, so listing them would suggest a contract that does not
+  exist. (#112, #227)
 
 ### Known limitations
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,17 @@ Create reusable HTML email templates with `{{variable}}` interpolation. Edit tem
 body are _not_ validated, because they resolve against the current item at
 render time rather than against what the caller passed. An unresolved name
 inside a section renders **empty**; only the section's own name is required.
-`GET /api/email-templates/{slug}/variables` reflects exactly this: it lists the
-required names, and omits both `{{key?}}` optionals and section-body names.
+
+`GET /api/email-templates/{slug}/variables` returns three lists:
+
+- `variables` — top-level names the caller must supply, or the send fails.
+  This is the send contract; its shape and meaning are unchanged.
+- `optional` — names that render empty when absent: `{{key?}}` tags and
+  inverted (`{{^key}}`) section names.
+- `sections` — each section's name, whether it's inverted, and the names its
+  body references. Those body names resolve per item at render time and are
+  never part of `variables`, even though the response now surfaces them for
+  the editor and API callers building a form around a template.
 
 #### Template syntax
 

--- a/worker/src/__tests__/email-templates-router.test.ts
+++ b/worker/src/__tests__/email-templates-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { env } from "cloudflare:workers";
 import {
   applyMigrations,
@@ -240,6 +240,65 @@ describe("email templates router", () => {
       expect(data.error).toMatch(/\{\{#a\}\}/);
       expect(data.missingVariables).toBeUndefined();
       expect(data.requiredVariables).toBeUndefined();
+    });
+  });
+
+  describe("templates: sections and nested variables", () => {
+    beforeEach(() => {
+      // DemoSender always succeeds, so the send path runs end-to-end and
+      // actually stores the rendered body instead of failing on the fake
+      // RESEND_API_KEY the global test env sets. See send-router.test.ts for
+      // the same pattern.
+      (env as any).DEMO_MODE = "1";
+    });
+
+    afterEach(() => {
+      (env as any).DEMO_MODE = "0";
+    });
+
+    it("accepts an array of objects in the send payload and renders each item", async () => {
+      await createTestTemplate({
+        slug: "digest",
+        subject: "Your digest",
+        bodyHtml: "{{#items}}<li>{{label}}</li>{{/items}}",
+      });
+
+      const res = await authFetch("/api/email-templates/digest/send", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          to: "a@example.com",
+          fromAddress: "support@example.com",
+          variables: { items: [{ label: "one" }, { label: "two" }] },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+
+      const rows = await getDb().select().from(sentEmails);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].bodyHtml).toContain("<li>one</li>");
+      expect(rows[0].bodyHtml).toContain("<li>two</li>");
+    });
+
+    it("reports optional and section variables from /variables", async () => {
+      await createTestTemplate({
+        slug: "digest2",
+        subject: "Hi {{name}}",
+        bodyHtml: "{{promo?}}{{#items}}{{label}}{{/items}}",
+      });
+
+      const res = await authFetch("/api/email-templates/digest2/variables", {
+        apiKey,
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.variables).toEqual(["name", "items"]);
+      expect(body.optional).toEqual(["promo"]);
+      expect(body.sections).toEqual([
+        { name: "items", inverted: false, variables: ["label"] },
+      ]);
     });
   });
 

--- a/worker/src/__tests__/email-templates-router.test.ts
+++ b/worker/src/__tests__/email-templates-router.test.ts
@@ -11,7 +11,7 @@ import {
 import { suppressions } from "../db/suppressions.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { outboxEmails } from "../db/outbox-emails.schema";
-import { MAX_VARIABLE_DEPTH } from "../routers/email-templates-router";
+import { MAX_VARIABLE_DEPTH } from "../lib/template-variables-schema";
 
 /** Builds a value nested `n` array-levels deep, terminating in a string leaf. */
 function buildNestedArray(n: number): unknown {
@@ -60,6 +60,41 @@ describe("email templates router", () => {
         }),
       });
       expect(res.status).toBe(400);
+    });
+
+    it("rejects a template whose sections do not parse", async () => {
+      // Storing this would defer the failure to send time, where every send
+      // 400s and every sequence step is marked `failed` — a terminal state
+      // the poller never revisits, with no signal to the author.
+      const res = await authFetch("/api/email-templates", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          slug: "broken",
+          name: "Broken",
+          subject: "Hi",
+          bodyHtml: "{{#items}}<li>{{label}}</li>",
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Unclosed section");
+    });
+
+    it("rejects a template with an unknown filter", async () => {
+      const res = await authFetch("/api/email-templates", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          slug: "bad-filter",
+          name: "Bad filter",
+          subject: "Hi",
+          bodyHtml: "<p>{{name|upper}}</p>",
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Unknown filter");
     });
   });
 
@@ -152,6 +187,48 @@ describe("email templates router", () => {
         body: JSON.stringify({ name: "Test" }),
       });
       expect(res.status).toBe(404);
+    });
+
+    it("rejects an update that leaves the template unparseable", async () => {
+      await createTestTemplate({ slug: "welcome" });
+
+      const res = await authFetch("/api/email-templates/welcome", {
+        apiKey,
+        method: "PUT",
+        body: JSON.stringify({ bodyHtml: "{{#items}}<li>{{label}}</li>" }),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toContain("Unclosed section");
+    });
+
+    it("validates the merged template, not just the fields being changed", async () => {
+      // Both fields are optional on this route. A body that opens a section
+      // closed by the subject only parses as a pair, so validating the
+      // incoming field alone would reject a template that is in fact fine —
+      // and, in the reverse direction, accept one that is not.
+      await createTestTemplate({
+        slug: "paired",
+        subject: "Hi",
+        bodyHtml: "<p>plain</p>",
+      });
+
+      // Changing only the subject must still be checked against the stored body.
+      const bad = await authFetch("/api/email-templates/paired", {
+        apiKey,
+        method: "PUT",
+        body: JSON.stringify({ subject: "{{/nope}}" }),
+      });
+      expect(bad.status).toBe(400);
+
+      // And a well-formed pair still goes through.
+      const good = await authFetch("/api/email-templates/paired", {
+        apiKey,
+        method: "PUT",
+        body: JSON.stringify({
+          bodyHtml: "{{#items}}<li>{{label}}</li>{{/items}}",
+        }),
+      });
+      expect(good.status).toBe(200);
     });
   });
 

--- a/worker/src/__tests__/email-templates-router.test.ts
+++ b/worker/src/__tests__/email-templates-router.test.ts
@@ -11,6 +11,12 @@ import {
 import { suppressions } from "../db/suppressions.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { outboxEmails } from "../db/outbox-emails.schema";
+import { MAX_VARIABLE_DEPTH } from "../routers/email-templates-router";
+
+/** Builds a value nested `n` array-levels deep, terminating in a string leaf. */
+function buildNestedArray(n: number): unknown {
+  return n <= 0 ? "leaf" : [buildNestedArray(n - 1)];
+}
 
 describe("email templates router", () => {
   let apiKey: string;
@@ -299,6 +305,54 @@ describe("email templates router", () => {
       expect(body.sections).toEqual([
         { name: "items", inverted: false, variables: ["label"] },
       ]);
+    });
+
+    it("rejects a variables payload nested past MAX_VARIABLE_DEPTH with 400, not 500", async () => {
+      await createTestTemplate({
+        slug: "deep",
+        subject: "S",
+        bodyHtml: "<p>B</p>",
+      });
+
+      const res = await authFetch("/api/email-templates/deep/send", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          to: "a@example.com",
+          fromAddress: "support@example.com",
+          // One level past the cap — buildNestedArray(MAX_VARIABLE_DEPTH)
+          // puts its deepest leaf at depth MAX_VARIABLE_DEPTH + 1.
+          variables: { items: buildNestedArray(MAX_VARIABLE_DEPTH) },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      // The Zod validation error surfaces as { error: { message: "<json array>" } };
+      // assert the underlying custom-issue message, not its exact envelope shape.
+      expect(data.error.message).toContain(String(MAX_VARIABLE_DEPTH));
+      expect(data.error.message).toMatch(/nested too deeply/i);
+    });
+
+    it("accepts a variables payload nested right at MAX_VARIABLE_DEPTH", async () => {
+      await createTestTemplate({
+        slug: "deep-ok",
+        subject: "S",
+        bodyHtml: "<p>B</p>",
+      });
+
+      const res = await authFetch("/api/email-templates/deep-ok/send", {
+        apiKey,
+        method: "POST",
+        body: JSON.stringify({
+          to: "a@example.com",
+          fromAddress: "support@example.com",
+          // Deepest leaf lands exactly at MAX_VARIABLE_DEPTH — within bounds.
+          variables: { items: buildNestedArray(MAX_VARIABLE_DEPTH - 1) },
+        }),
+      });
+
+      expect(res.status).toBe(201);
     });
   });
 

--- a/worker/src/__tests__/mcp-variables-depth.test.ts
+++ b/worker/src/__tests__/mcp-variables-depth.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { z } from "@hono/zod-openapi";
+import {
+  templateValueSchema,
+  templateVariablesSchema,
+  MAX_VARIABLE_DEPTH,
+} from "../lib/template-variables-schema";
+
+/**
+ * The depth guard exists because Zod's recursive descent through a
+ * self-referencing `z.lazy` has no bound of its own: a payload of a few KB but
+ * thousands of levels deep overflows the stack before any handler runs, and a
+ * `RangeError` is not a `ZodError`, so nothing upstream turns it into a 400.
+ *
+ * The HTTP routes compose `templateVariablesSchema`, which runs an iterative
+ * pre-walk first. The MCP tools were widened to accept nested values at the
+ * same time but composed the bare recursive value schema, leaving that one
+ * surface with the crash the guard was written to close.
+ */
+
+/** Build `{k: [[[...]]]}` nested `depth` levels deep. */
+function nested(depth: number): Record<string, unknown> {
+  let v: unknown = "x";
+  for (let i = 0; i < depth; i++) v = [v];
+  return { k: v };
+}
+
+describe("template variables depth guard", () => {
+  it("rejects an over-deep payload with a clean error, not a stack overflow", () => {
+    const result = templateVariablesSchema.safeParse(
+      nested(MAX_VARIABLE_DEPTH + 10),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a payload within the limit", () => {
+    expect(templateVariablesSchema.safeParse(nested(5)).success).toBe(true);
+  });
+
+  it("demonstrates why the bare value schema must not be used alone", () => {
+    // Pinning the hazard rather than the fix: this is the composition the MCP
+    // tools used to have, and it is why they now share the guarded schema.
+    const unguarded = z.record(z.string(), templateValueSchema);
+    expect(() => unguarded.safeParse(nested(5000))).toThrow(RangeError);
+  });
+});
+
+describe("MCP tool inputs share the guarded schema", () => {
+  /**
+   * Asserted against the module source rather than by invoking the MCP server,
+   * which needs a full transport and an authenticated session to stand up. The
+   * property that matters is a composition choice, and it is exactly the kind
+   * of thing that silently regresses when a fourth tool is added by copying an
+   * existing one.
+   */
+  it("no tool composes the unguarded recursive value schema", async () => {
+    const source = await import("../mcp/server?raw").then(
+      (m) => (m as unknown as { default: string }).default,
+    );
+    expect(source).not.toMatch(
+      /z\s*\.record\(\s*z\.string\(\)\s*,\s*mcpTemplateValueSchema/,
+    );
+  });
+});

--- a/worker/src/__tests__/openapi-doc.test.ts
+++ b/worker/src/__tests__/openapi-doc.test.ts
@@ -30,4 +30,50 @@ describe("OpenAPI /doc", () => {
       { [BEARER_AUTH_SCHEME]: [] },
     ]);
   });
+
+  it("registers the recursive TemplateValue schema as a bounded $ref, not inline recursion", async () => {
+    const res = await exports.default.fetch("http://localhost/doc");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      components: { schemas?: Record<string, unknown> };
+      paths: Record<
+        string,
+        {
+          post?: {
+            requestBody?: {
+              content?: Record<string, { schema?: unknown }>;
+            };
+          };
+        }
+      >;
+    };
+
+    // The lazy schema is registered under its own component name — proof
+    // the .openapi("TemplateValue") ref id took effect instead of the
+    // generator inlining (or infinitely recursing through) the union.
+    const templateValue = doc.components.schemas?.TemplateValue as
+      | { anyOf?: Array<Record<string, unknown>> }
+      | undefined;
+    expect(templateValue).toBeDefined();
+    expect(Array.isArray(templateValue?.anyOf)).toBe(true);
+    // Serializing it must terminate — an unbounded/circular structure here
+    // would throw on JSON.stringify (or never return) instead of failing
+    // a plain assertion.
+    const serialized = JSON.stringify(templateValue);
+    expect(serialized).toContain("#/components/schemas/TemplateValue");
+
+    // The send route's `variables` field must compose with that same ref
+    // rather than falling back to an untyped object.
+    const sendSchema = doc.paths["/api/email-templates/{slug}/send"]?.post
+      ?.requestBody?.content?.["application/json"]?.schema as
+      | {
+          properties?: {
+            variables?: { additionalProperties?: { $ref?: string } };
+          };
+        }
+      | undefined;
+    expect(sendSchema?.properties?.variables?.additionalProperties?.$ref).toBe(
+      "#/components/schemas/TemplateValue",
+    );
+  });
 });

--- a/worker/src/__tests__/openapi-send-schemas.test.ts
+++ b/worker/src/__tests__/openapi-send-schemas.test.ts
@@ -7,7 +7,7 @@ describe("OpenAPI send schemas", () => {
     await applyMigrations();
   });
 
-  it("GET /doc registers SendEmailSchema, CcEntry, and ReplyEmailSchema", async () => {
+  it("GET /doc registers SendEmailSchema, CcEntry, ReplyEmailSchema, and TemplateValue", async () => {
     const res = await exports.default.fetch("http://localhost/doc");
     expect(res.status).toBe(200);
     const doc = (await res.json()) as {
@@ -20,8 +20,17 @@ describe("OpenAPI send schemas", () => {
     };
 
     const schemas = doc.components.schemas ?? {};
+    // `TemplateValue` is the recursive schema for template variable values.
+    // It has to be a named component rather than an inline one — a self
+    // referencing `z.lazy` union can only be expressed via `$ref`, so
+    // inlining it would recurse forever when the document is generated.
     expect(Object.keys(schemas).sort()).toEqual(
-      ["CcEntry", "ReplyEmailSchema", "SendEmailSchema"].sort(),
+      [
+        "CcEntry",
+        "ReplyEmailSchema",
+        "SendEmailSchema",
+        "TemplateValue",
+      ].sort(),
     );
 
     const send = schemas.SendEmailSchema;

--- a/worker/src/__tests__/send-router.test.ts
+++ b/worker/src/__tests__/send-router.test.ts
@@ -326,6 +326,43 @@ describe("send router", () => {
       expect(data).not.toHaveProperty("missingVariables");
       expect(data).not.toHaveProperty("requiredVariables");
     });
+
+    it("accepts nested section variables on a reply", async () => {
+      // The reply route's schema was `Record<string, string>` while
+      // ReplyEmailPayload already accepted TemplateVariables, so any template
+      // using {{#items}} was 400'd here while working on the templates route.
+      const person = await createTestPerson({
+        id: "p-nested",
+        email: "d@example.com",
+      });
+      await createTestEmail({
+        id: "rcv-nested",
+        personId: person.id,
+        recipient: "me@saasmail.test",
+        subject: "hi",
+        messageId: "nested@example.com",
+      });
+      await createTestTemplate({
+        slug: "digest",
+        subject: "Your digest",
+        bodyHtml: "<ul>{{#items}}<li>{{label}}</li>{{/items}}</ul>",
+      });
+
+      const res = await authFetch("/api/send/reply/rcv-nested", {
+        apiKey,
+        method: "POST",
+        body: buildSendForm({
+          fromAddress: "me@saasmail.test",
+          templateSlug: "digest",
+          variables: { items: [{ label: "one" }, { label: "two" }] },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const db = getDb();
+      const rows = await db.select().from(sentEmails);
+      expect(rows[0].bodyHtml).toBe("<ul><li>one</li><li>two</li></ul>");
+    });
   });
 
   describe("GET /api/people/grouped after sending", () => {

--- a/worker/src/__tests__/sequence-processor.test.ts
+++ b/worker/src/__tests__/sequence-processor.test.ts
@@ -568,7 +568,11 @@ describe("sequence processor - template rendering", () => {
   });
 
   /** Seed a sequence, enrollment, and one queued step for `slug`. */
-  async function seedStep(slug: string, personEmail = "a@test.com") {
+  async function seedStep(
+    slug: string,
+    personEmail = "a@test.com",
+    variables: Record<string, unknown> = {},
+  ) {
     const db = getDb();
     const now = Math.floor(Date.now() / 1000);
     await createTestPerson({ id: "p1", email: personEmail, name: "O'Brien" });
@@ -584,7 +588,7 @@ describe("sequence processor - template rendering", () => {
       sequenceId: "seq-1",
       personId: "p1",
       status: "active",
-      variables: "{}",
+      variables: JSON.stringify(variables),
       fromAddress: "test@test.com",
       enrolledAt: now,
     });
@@ -598,6 +602,41 @@ describe("sequence processor - template rendering", () => {
     });
     return db;
   }
+
+  it("renders a section from nested enrollment variables", async () => {
+    // Enrollment variables were typed and validated as Record<string,string>,
+    // so a drip template using {{#items}} could never be given its data —
+    // the section rendered as nothing and the row was still marked sent.
+    const db = await seedStep("digest", "a@test.com", {
+      items: [{ label: "one" }, { label: "two" }],
+    });
+    await createTestTemplate({
+      slug: "digest",
+      subject: "Your digest",
+      bodyHtml: "<ul>{{#items}}<li>{{label}}</li>{{/items}}</ul>",
+    });
+
+    const fakeSender: EmailSender = {
+      provider: "none",
+      maxAttachmentBytes: () => 25_000_000,
+      send: vi.fn(async (_params: SendEmailParams) => ({
+        id: "fake-id",
+        error: null,
+      })),
+    };
+
+    await processSequenceEmail(
+      db,
+      fakeSender,
+      env as unknown as CloudflareBindings,
+      "se-1",
+    );
+
+    const sent = await db.select().from(sentEmails);
+    expect(sent).toHaveLength(1);
+    // `toContain`, not `toBe`: the processor appends an unsubscribe footer.
+    expect(sent[0].bodyHtml).toContain("<ul><li>one</li><li>two</li></ul>");
+  });
 
   it("marks the row failed on a malformed template instead of leaving it queued", async () => {
     // interpolate throws TemplateParseError on an unbalanced template. Without

--- a/worker/src/lib/enroll-sequence.ts
+++ b/worker/src/lib/enroll-sequence.ts
@@ -7,13 +7,14 @@ import { sequenceEnrollments } from "../db/sequence-enrollments.schema";
 import { sequences } from "../db/sequences.schema";
 import { assertInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
 import { isDemoMode } from "./is-dev";
+import type { TemplateVariables } from "./interpolate";
 import type { SequenceEmailMessage } from "./sequence-processor";
 
 export type EnrollSequenceInput = {
   personId?: string;
   personEmail?: string;
   fromAddress: string;
-  variables: Record<string, string>;
+  variables: TemplateVariables;
   skipSteps: number[];
   delayOverrides: Record<string, number>;
 };
@@ -32,7 +33,7 @@ export type EnrollmentRecord = {
   personId: string;
   fromAddress: string;
   status: string;
-  variables: Record<string, string>;
+  variables: TemplateVariables;
   enrolledAt: number;
   cancelledAt: number | null;
 };

--- a/worker/src/lib/send-email.ts
+++ b/worker/src/lib/send-email.ts
@@ -12,7 +12,7 @@ import { computeConversationId, externalsOnly } from "./conversation-id";
 import { createEmailSender } from "./email-sender";
 import { formatFromAddress } from "./format-from-address";
 import { assertInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
-import { renderTemplate } from "./interpolate";
+import { renderTemplate, type TemplateVariables } from "./interpolate";
 import { generateMessageId } from "./message-id";
 import type { ParsedFile } from "./multipart-send";
 import { sendViaOutbox, type OutboxOutcome } from "./outbox";
@@ -66,7 +66,7 @@ export type ReplyEmailPayload = {
   bodyText?: string;
   cc?: SendCcEntry[];
   templateSlug?: string;
-  variables?: Record<string, string>;
+  variables?: TemplateVariables;
   replyTo?: string;
 };
 

--- a/worker/src/lib/send-template.ts
+++ b/worker/src/lib/send-template.ts
@@ -7,7 +7,7 @@ import { sentEmails } from "../db/sent-emails.schema";
 import { createEmailSender } from "./email-sender";
 import { formatFromAddress } from "./format-from-address";
 import { assertInboxAllowed, type AllowedInboxes } from "./inbox-permissions";
-import { renderTemplate } from "./interpolate";
+import { renderTemplate, type TemplateVariables } from "./interpolate";
 import { generateMessageId } from "./message-id";
 import { sendViaOutbox, type OutboxOutcome } from "./outbox";
 
@@ -17,7 +17,7 @@ export type SendTemplateParams = {
   slug: string;
   to: string;
   fromAddress: string;
-  variables: Record<string, string>;
+  variables: TemplateVariables;
   allowed: AllowedInboxes;
 };
 

--- a/worker/src/lib/sequence-processor.ts
+++ b/worker/src/lib/sequence-processor.ts
@@ -10,7 +10,11 @@ import { emailTemplates } from "../db/email-templates.schema";
 import { people } from "../db/people.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { outboxEmails } from "../db/outbox-emails.schema";
-import { interpolate, TemplateParseError } from "./interpolate";
+import {
+  interpolate,
+  TemplateParseError,
+  type TemplateVariables,
+} from "./interpolate";
 import { formatFromAddress } from "./format-from-address";
 import { generateMessageId } from "./message-id";
 import { sendViaOutbox } from "./outbox";
@@ -223,8 +227,8 @@ export async function processSequenceEmail(
   const person = personRows[0];
 
   // Merge variables: person auto-vars + enrollment custom vars (custom wins)
-  const customVars: Record<string, string> = JSON.parse(enrollment.variables);
-  const mergedVars: Record<string, string> = {
+  const customVars: TemplateVariables = JSON.parse(enrollment.variables);
+  const mergedVars: TemplateVariables = {
     name: person.name ?? "",
     email: person.email,
     ...customVars,

--- a/worker/src/lib/template-variables-schema.ts
+++ b/worker/src/lib/template-variables-schema.ts
@@ -1,0 +1,113 @@
+import { z } from "@hono/zod-openapi";
+
+/**
+ * A template variable value. Recursive so arrays of objects can reach
+ * `{{#section}}` bodies; `z.lazy` is what lets the schema refer to itself.
+ *
+ * The `.openapi("TemplateValue")` name is required, not decorative: without a
+ * registered ref id, `@asteasolutions/zod-to-openapi` has no way to stop
+ * expanding a self-referencing lazy schema and either recurses forever while
+ * building `/doc` or (depending on version) silently degrades to an opaque
+ * `{}` schema. Naming it turns the self-reference into a proper
+ * `$ref: '#/components/schemas/TemplateValue'` — verified against
+ * `openapi-doc.test.ts` and `openapi-bootstrap.test.ts`.
+ *
+ * This lives in `lib/` rather than in a router because every route that
+ * forwards `variables` to `renderTemplate` needs the identical shape AND the
+ * identical depth guard. A second copy would also re-register the same
+ * `TemplateValue` component name from a different schema object.
+ */
+export const templateValueSchema: z.ZodType<unknown> = z
+  .lazy(() =>
+    z.union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.null(),
+      z.array(templateValueSchema),
+      z.record(z.string(), templateValueSchema),
+    ]),
+  )
+  .openapi("TemplateValue");
+
+/**
+ * Maximum nesting depth allowed in a send request's `variables` payload.
+ *
+ * `templateValueSchema` is unbounded on its own: Zod's recursive descent
+ * through a self-referencing `z.lazy` has no depth limit, so a payload of
+ * only a few KB but thousands of levels deep blows Zod's own call stack —
+ * a `RangeError` with no app-level `onError` handler to catch it, surfacing
+ * as an unhandled 500 for any authenticated caller. A `.superRefine`
+ * attached directly to the recursive schema does not help: Zod crashes
+ * descending into the lazy schema before any refinement on it ever runs.
+ *
+ * The fix (`templateVariablesSchema` below) walks the raw, not-yet-parsed
+ * value ITERATIVELY — an explicit stack, not a recursive function, so the
+ * guard itself cannot be the thing that overflows — before Zod ever
+ * descends into the recursive schema. 32 is generous: real templates nest a
+ * handful of section/object levels at most.
+ */
+export const MAX_VARIABLE_DEPTH = 32;
+
+/**
+ * Iteratively finds the first depth (if any) that exceeds `maxDepth` in
+ * `root`. Depth 0 is `root` itself; each array item or object property adds
+ * one level. Returns `null` when every value is within bounds.
+ */
+function findExcessiveDepth(root: unknown, maxDepth: number): number | null {
+  const stack: Array<{ value: unknown; depth: number }> = [
+    { value: root, depth: 0 },
+  ];
+  while (stack.length > 0) {
+    const { value, depth } = stack.pop()!;
+    if (depth > maxDepth) return depth;
+    if (Array.isArray(value)) {
+      for (const item of value) stack.push({ value: item, depth: depth + 1 });
+    } else if (value !== null && typeof value === "object") {
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        stack.push({
+          value: (value as Record<string, unknown>)[key],
+          depth: depth + 1,
+        });
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The `variables` schema for every route that renders a template.
+ *
+ * Composed with `z.preprocess`, not `.superRefine().pipe(...)`. Both run the
+ * depth guard before the recursive schema, but they differ in how
+ * `@asteasolutions/zod-to-openapi` documents them: for a plain `.pipe(x)`,
+ * the generator documents the PRE-pipe ("in") schema, which here is just
+ * `z.record(z.string(), z.unknown())` — an unhelpful `{}` shape that drops
+ * the `TemplateValue` ref entirely (verified against the real `/doc` output
+ * while building this). `z.preprocess(fn, schema)` is internally the same
+ * pipe machinery but with the check function on the "in" side wrapped as a
+ * `ZodTransform`, and for exactly that shape the generator documents the
+ * POST-pipe ("out") schema instead — `schema` here, i.e. the recursive,
+ * named `templateValueSchema`. That's the one difference that makes this
+ * composition preserve the OpenAPI component; confirmed against `/doc` in
+ * `openapi-doc.test.ts`.
+ *
+ * The preprocess function returns `z.NEVER` on failure specifically so the
+ * inner schema's own (recursive) parse never runs against the
+ * still-too-deep raw value — returning the original value instead would
+ * just move the crash one step later.
+ */
+export const templateVariablesSchema = z.preprocess(
+  (raw, ctx) => {
+    const excess = findExcessiveDepth(raw, MAX_VARIABLE_DEPTH);
+    if (excess !== null) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Template variables are nested too deeply — the limit is ${MAX_VARIABLE_DEPTH} levels.`,
+      });
+      return z.NEVER;
+    }
+    return raw;
+  },
+  z.record(z.string(), templateValueSchema),
+);

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -17,7 +17,7 @@ import {
 // `{{#section}}` is sendable from MCP too. Aliased on import because the
 // name it carries in the OpenAPI document is meaningless here — the MCP SDK
 // converts this to JSON Schema on its own.
-import { templateValueSchema as mcpTemplateValueSchema } from "../lib/template-variables-schema";
+import { templateVariablesSchema } from "../lib/template-variables-schema";
 import { deleteEmailWithAttachments } from "../lib/delete-email";
 import { searchEmails } from "../lib/queries/search";
 
@@ -337,8 +337,7 @@ export function buildMcpServer(ctx: McpContext): McpServer {
         fromAddress: z
           .string()
           .describe("Sender identity; must be one of your allowed inboxes."),
-        variables: z
-          .record(z.string(), mcpTemplateValueSchema)
+        variables: templateVariablesSchema
           .optional()
           .describe(
             "Values for the template's {{placeholders}}. Missing ones are reported back with the full required list. Values may be nested arrays/objects for {{#section}} bodies.",
@@ -444,8 +443,7 @@ export function buildMcpServer(ctx: McpContext): McpServer {
           .string()
           .optional()
           .describe("Render this saved template instead of bodyHtml."),
-        variables: z
-          .record(z.string(), mcpTemplateValueSchema)
+        variables: templateVariablesSchema
           .optional()
           .describe(
             "Values for the template's placeholders. May be nested arrays/objects for {{#section}} bodies.",
@@ -522,8 +520,7 @@ export function buildMcpServer(ctx: McpContext): McpServer {
         fromAddress: z
           .string()
           .describe("Sender identity; must be one of your allowed inboxes."),
-        variables: z
-          .record(z.string(), mcpTemplateValueSchema)
+        variables: templateVariablesSchema
           .optional()
           .describe(
             "Values for placeholders used by the sequence templates. May be nested arrays/objects for {{#section}} bodies.",

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -13,6 +13,11 @@ import {
   getEmailById,
   setEmailRead,
 } from "../lib/queries/emails";
+// The same recursive value shape the HTTP routes accept, so a template using
+// `{{#section}}` is sendable from MCP too. Aliased on import because the
+// name it carries in the OpenAPI document is meaningless here — the MCP SDK
+// converts this to JSON Schema on its own.
+import { templateValueSchema as mcpTemplateValueSchema } from "../lib/template-variables-schema";
 import { deleteEmailWithAttachments } from "../lib/delete-email";
 import { searchEmails } from "../lib/queries/search";
 
@@ -333,10 +338,10 @@ export function buildMcpServer(ctx: McpContext): McpServer {
           .string()
           .describe("Sender identity; must be one of your allowed inboxes."),
         variables: z
-          .record(z.string(), z.string())
+          .record(z.string(), mcpTemplateValueSchema)
           .optional()
           .describe(
-            "Values for the template's {{placeholders}}. Missing ones are reported back with the full required list.",
+            "Values for the template's {{placeholders}}. Missing ones are reported back with the full required list. Values may be nested arrays/objects for {{#section}} bodies.",
           ),
       },
     },
@@ -440,9 +445,11 @@ export function buildMcpServer(ctx: McpContext): McpServer {
           .optional()
           .describe("Render this saved template instead of bodyHtml."),
         variables: z
-          .record(z.string(), z.string())
+          .record(z.string(), mcpTemplateValueSchema)
           .optional()
-          .describe("Values for the template's placeholders."),
+          .describe(
+            "Values for the template's placeholders. May be nested arrays/objects for {{#section}} bodies.",
+          ),
         cc: ccSchema,
         replyTo: z
           .email()
@@ -516,9 +523,11 @@ export function buildMcpServer(ctx: McpContext): McpServer {
           .string()
           .describe("Sender identity; must be one of your allowed inboxes."),
         variables: z
-          .record(z.string(), z.string())
+          .record(z.string(), mcpTemplateValueSchema)
           .optional()
-          .describe("Values for placeholders used by the sequence templates."),
+          .describe(
+            "Values for placeholders used by the sequence templates. May be nested arrays/objects for {{#section}} bodies.",
+          ),
         skipSteps: z
           .array(z.number().int())
           .optional()

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -44,6 +44,88 @@ const templateValueSchema: z.ZodType<unknown> = z
   )
   .openapi("TemplateValue");
 
+/**
+ * Maximum nesting depth allowed in a send request's `variables` payload.
+ *
+ * `templateValueSchema` is unbounded on its own: Zod's recursive descent
+ * through a self-referencing `z.lazy` has no depth limit, so a payload of
+ * only a few KB but thousands of levels deep blows Zod's own call stack —
+ * a `RangeError` with no app-level `onError` handler to catch it, surfacing
+ * as an unhandled 500 for any authenticated caller. A `.superRefine`
+ * attached directly to the recursive schema does not help: Zod crashes
+ * descending into the lazy schema before any refinement on it ever runs.
+ *
+ * The fix (`templateVariablesSchema` below) walks the raw, not-yet-parsed
+ * value ITERATIVELY — an explicit stack, not a recursive function, so the
+ * guard itself cannot be the thing that overflows — before Zod ever
+ * descends into the recursive schema. 32 is generous: real templates nest a
+ * handful of section/object levels at most.
+ */
+export const MAX_VARIABLE_DEPTH = 32;
+
+/**
+ * Iteratively finds the first depth (if any) that exceeds `maxDepth` in
+ * `root`. Depth 0 is `root` itself; each array item or object property adds
+ * one level. Returns `null` when every value is within bounds.
+ */
+function findExcessiveDepth(root: unknown, maxDepth: number): number | null {
+  const stack: Array<{ value: unknown; depth: number }> = [
+    { value: root, depth: 0 },
+  ];
+  while (stack.length > 0) {
+    const { value, depth } = stack.pop()!;
+    if (depth > maxDepth) return depth;
+    if (Array.isArray(value)) {
+      for (const item of value) stack.push({ value: item, depth: depth + 1 });
+    } else if (value !== null && typeof value === "object") {
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        stack.push({
+          value: (value as Record<string, unknown>)[key],
+          depth: depth + 1,
+        });
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The send route's `variables` schema.
+ *
+ * Composed with `z.preprocess`, not `.superRefine().pipe(...)`. Both run the
+ * depth guard before the recursive schema, but they differ in how
+ * `@asteasolutions/zod-to-openapi` documents them: for a plain `.pipe(x)`,
+ * the generator documents the PRE-pipe ("in") schema, which here is just
+ * `z.record(z.string(), z.unknown())` — an unhelpful `{}` shape that drops
+ * the `TemplateValue` ref entirely (verified against the real `/doc` output
+ * while building this). `z.preprocess(fn, schema)` is internally the same
+ * pipe machinery but with the check function on the "in" side wrapped as a
+ * `ZodTransform`, and for exactly that shape the generator documents the
+ * POST-pipe ("out") schema instead — `schema` here, i.e. the recursive,
+ * named `templateValueSchema`. That's the one difference that makes this
+ * composition preserve the OpenAPI component; confirmed against `/doc` in
+ * `openapi-doc.test.ts`.
+ *
+ * The preprocess function returns `z.NEVER` on failure specifically so the
+ * inner schema's own (recursive) parse never runs against the
+ * still-too-deep raw value — returning the original value instead would
+ * just move the crash one step later.
+ */
+const templateVariablesSchema = z.preprocess(
+  (raw, ctx) => {
+    const excess = findExcessiveDepth(raw, MAX_VARIABLE_DEPTH);
+    if (excess !== null) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Template variables are nested too deeply — the limit is ${MAX_VARIABLE_DEPTH} levels.`,
+      });
+      return z.NEVER;
+    }
+    return raw;
+  },
+  z.record(z.string(), templateValueSchema),
+);
+
 const EmailTemplateSchema = z.object({
   id: z.string(),
   slug: z.string(),
@@ -360,10 +442,7 @@ const sendTemplateRoute = createRoute({
           schema: z.object({
             to: z.string().email(),
             fromAddress: z.string().email(),
-            variables: z
-              .record(z.string(), templateValueSchema)
-              .optional()
-              .default({}),
+            variables: templateVariablesSchema.optional().default({}),
           }),
         },
       },

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -19,6 +19,31 @@ export const emailTemplatesRouter = new OpenAPIHono<{
   Variables: Variables;
 }>();
 
+/**
+ * A template variable value. Recursive so arrays of objects can reach
+ * `{{#section}}` bodies; `z.lazy` is what lets the schema refer to itself.
+ *
+ * The `.openapi("TemplateValue")` name is required, not decorative: without a
+ * registered ref id, `@asteasolutions/zod-to-openapi` has no way to stop
+ * expanding a self-referencing lazy schema and either recurses forever while
+ * building `/doc` or (depending on version) silently degrades to an opaque
+ * `{}` schema. Naming it turns the self-reference into a proper
+ * `$ref: '#/components/schemas/TemplateValue'` — verified against
+ * `openapi-doc.test.ts` and `openapi-bootstrap.test.ts`.
+ */
+const templateValueSchema: z.ZodType<unknown> = z
+  .lazy(() =>
+    z.union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.null(),
+      z.array(templateValueSchema),
+      z.record(z.string(), templateValueSchema),
+    ]),
+  )
+  .openapi("TemplateValue");
+
 const EmailTemplateSchema = z.object({
   id: z.string(),
   slug: z.string(),
@@ -255,7 +280,27 @@ const getTemplateVariablesRoute = createRoute({
   },
   responses: {
     ...json200Response(
-      z.object({ variables: z.array(z.string()) }),
+      z.object({
+        variables: z.array(z.string()).openapi({
+          description: "Variables the caller must supply, or the send fails.",
+        }),
+        optional: z.array(z.string()).openapi({
+          description:
+            "Variables that render empty when absent — `{{key?}}` tags and inverted sections.",
+        }),
+        sections: z
+          .array(
+            z.object({
+              name: z.string(),
+              inverted: z.boolean(),
+              variables: z.array(z.string()),
+            }),
+          )
+          .openapi({
+            description:
+              "Sections and the names their bodies reference. Those names resolve per-item and are not required at the top level.",
+          }),
+      }),
       "Template variables",
     ),
     400: {
@@ -290,7 +335,14 @@ emailTemplatesRouter.openapi(getTemplateVariablesRoute, async (c) => {
     throw err;
   }
 
-  return c.json({ variables: analysis.required }, 200);
+  return c.json(
+    {
+      variables: analysis.required,
+      optional: analysis.optional,
+      sections: analysis.sections,
+    },
+    200,
+  );
 });
 
 // --- SEND ---
@@ -308,7 +360,10 @@ const sendTemplateRoute = createRoute({
           schema: z.object({
             to: z.string().email(),
             fromAddress: z.string().email(),
-            variables: z.record(z.string(), z.string()).optional().default({}),
+            variables: z
+              .record(z.string(), templateValueSchema)
+              .optional()
+              .default({}),
           }),
         },
       },

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -13,118 +13,37 @@ import {
   inboxForbiddenResponse,
   SendPathErrorSchema,
 } from "../lib/openapi-send-errors";
+import { templateVariablesSchema } from "../lib/template-variables-schema";
 
 export const emailTemplatesRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
   Variables: Variables;
 }>();
 
-/**
- * A template variable value. Recursive so arrays of objects can reach
- * `{{#section}}` bodies; `z.lazy` is what lets the schema refer to itself.
- *
- * The `.openapi("TemplateValue")` name is required, not decorative: without a
- * registered ref id, `@asteasolutions/zod-to-openapi` has no way to stop
- * expanding a self-referencing lazy schema and either recurses forever while
- * building `/doc` or (depending on version) silently degrades to an opaque
- * `{}` schema. Naming it turns the self-reference into a proper
- * `$ref: '#/components/schemas/TemplateValue'` — verified against
- * `openapi-doc.test.ts` and `openapi-bootstrap.test.ts`.
- */
-const templateValueSchema: z.ZodType<unknown> = z
-  .lazy(() =>
-    z.union([
-      z.string(),
-      z.number(),
-      z.boolean(),
-      z.null(),
-      z.array(templateValueSchema),
-      z.record(z.string(), templateValueSchema),
-    ]),
-  )
-  .openapi("TemplateValue");
+// The variables schema and its depth guard are shared with the reply,
+// sequence-enrollment, and MCP paths — see lib/template-variables-schema.ts.
 
 /**
- * Maximum nesting depth allowed in a send request's `variables` payload.
+ * Reject a template whose tags do not parse, at write time.
  *
- * `templateValueSchema` is unbounded on its own: Zod's recursive descent
- * through a self-referencing `z.lazy` has no depth limit, so a payload of
- * only a few KB but thousands of levels deep blows Zod's own call stack —
- * a `RangeError` with no app-level `onError` handler to catch it, surfacing
- * as an unhandled 500 for any authenticated caller. A `.superRefine`
- * attached directly to the recursive schema does not help: Zod crashes
- * descending into the lazy schema before any refinement on it ever runs.
+ * Without this, an unbalanced section or unknown filter stores happily and
+ * only fails much later: every send and every `/variables` call returns 400,
+ * and `sequence-processor` marks each affected step `failed` — terminal,
+ * since the poller only ever re-selects `pending` rows. Enrolled recipients
+ * silently never receive the email and the only trace is a worker log.
+ * Failing the write puts the diagnostic in front of the person who typed it.
  *
- * The fix (`templateVariablesSchema` below) walks the raw, not-yet-parsed
- * value ITERATIVELY — an explicit stack, not a recursive function, so the
- * guard itself cannot be the thing that overflows — before Zod ever
- * descends into the recursive schema. 32 is generous: real templates nest a
- * handful of section/object levels at most.
+ * Returns the parse error message, or null when the template is fine.
  */
-export const MAX_VARIABLE_DEPTH = 32;
-
-/**
- * Iteratively finds the first depth (if any) that exceeds `maxDepth` in
- * `root`. Depth 0 is `root` itself; each array item or object property adds
- * one level. Returns `null` when every value is within bounds.
- */
-function findExcessiveDepth(root: unknown, maxDepth: number): number | null {
-  const stack: Array<{ value: unknown; depth: number }> = [
-    { value: root, depth: 0 },
-  ];
-  while (stack.length > 0) {
-    const { value, depth } = stack.pop()!;
-    if (depth > maxDepth) return depth;
-    if (Array.isArray(value)) {
-      for (const item of value) stack.push({ value: item, depth: depth + 1 });
-    } else if (value !== null && typeof value === "object") {
-      for (const key of Object.keys(value as Record<string, unknown>)) {
-        stack.push({
-          value: (value as Record<string, unknown>)[key],
-          depth: depth + 1,
-        });
-      }
-    }
+function templateParseError(subject: string, bodyHtml: string): string | null {
+  try {
+    analyzeTemplate(subject, bodyHtml);
+    return null;
+  } catch (err) {
+    if (err instanceof TemplateParseError) return err.message;
+    throw err;
   }
-  return null;
 }
-
-/**
- * The send route's `variables` schema.
- *
- * Composed with `z.preprocess`, not `.superRefine().pipe(...)`. Both run the
- * depth guard before the recursive schema, but they differ in how
- * `@asteasolutions/zod-to-openapi` documents them: for a plain `.pipe(x)`,
- * the generator documents the PRE-pipe ("in") schema, which here is just
- * `z.record(z.string(), z.unknown())` — an unhelpful `{}` shape that drops
- * the `TemplateValue` ref entirely (verified against the real `/doc` output
- * while building this). `z.preprocess(fn, schema)` is internally the same
- * pipe machinery but with the check function on the "in" side wrapped as a
- * `ZodTransform`, and for exactly that shape the generator documents the
- * POST-pipe ("out") schema instead — `schema` here, i.e. the recursive,
- * named `templateValueSchema`. That's the one difference that makes this
- * composition preserve the OpenAPI component; confirmed against `/doc` in
- * `openapi-doc.test.ts`.
- *
- * The preprocess function returns `z.NEVER` on failure specifically so the
- * inner schema's own (recursive) parse never runs against the
- * still-too-deep raw value — returning the original value instead would
- * just move the crash one step later.
- */
-const templateVariablesSchema = z.preprocess(
-  (raw, ctx) => {
-    const excess = findExcessiveDepth(raw, MAX_VARIABLE_DEPTH);
-    if (excess !== null) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Template variables are nested too deeply — the limit is ${MAX_VARIABLE_DEPTH} levels.`,
-      });
-      return z.NEVER;
-    }
-    return raw;
-  },
-  z.record(z.string(), templateValueSchema),
-);
 
 const EmailTemplateSchema = z.object({
   id: z.string(),
@@ -159,12 +78,22 @@ const createTemplateRoute = createRoute({
   },
   responses: {
     ...json201Response(EmailTemplateSchema, "Created email template"),
+    400: {
+      description:
+        "Template has an unbalanced section or an unknown filter — see the parse diagnostic.",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 
 emailTemplatesRouter.openapi(createTemplateRoute, async (c) => {
   const db = c.get("db");
   const { slug, name, subject, bodyHtml, fromAddress } = c.req.valid("json");
+
+  const parseError = templateParseError(subject, bodyHtml);
+  if (parseError) {
+    return c.json({ error: parseError }, 400);
+  }
 
   const allowed = c.get("allowedInboxes")!;
   if (fromAddress != null) {
@@ -283,6 +212,11 @@ const updateTemplateRoute = createRoute({
   },
   responses: {
     ...json200Response(EmailTemplateSchema, "Updated email template"),
+    400: {
+      description:
+        "Template has an unbalanced section or an unknown filter — see the parse diagnostic.",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 
@@ -304,6 +238,17 @@ emailTemplatesRouter.openapi(updateTemplateRoute, async (c) => {
   const allowed = c.get("allowedInboxes")!;
   if (updates.fromAddress !== undefined && updates.fromAddress !== null) {
     assertInboxAllowed(allowed, updates.fromAddress);
+  }
+
+  // Both fields are optional on this route, so validate the template as it
+  // will exist AFTER the merge — editing only the subject can still leave a
+  // section unbalanced across the pair.
+  const parseError = templateParseError(
+    updates.subject ?? existing[0].subject,
+    updates.bodyHtml ?? existing[0].bodyHtml,
+  );
+  if (parseError) {
+    return c.json({ error: parseError }, 400);
   }
 
   await db

--- a/worker/src/routers/send-router.ts
+++ b/worker/src/routers/send-router.ts
@@ -11,6 +11,7 @@ import {
   replyNotFoundResponse,
   replyValidationErrorResponse,
 } from "../lib/openapi-send-errors";
+import { templateVariablesSchema } from "../lib/template-variables-schema";
 
 export const sendRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -207,8 +208,9 @@ export const ReplyEmailSchema = z
       description:
         "Optional template slug to render as the reply body instead of bodyHtml/bodyText.",
     }),
-    variables: z.record(z.string(), z.string()).optional().openapi({
-      description: "Template variables when templateSlug is set.",
+    variables: templateVariablesSchema.optional().openapi({
+      description:
+        "Template variables when templateSlug is set. Values may be nested arrays/objects for `{{#section}}` bodies.",
     }),
     replyTo: z.string().email().optional().openapi({
       description: "Override Reply-To header for this reply.",

--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -11,6 +11,10 @@ import { json200Response, json201Response } from "../lib/helpers";
 import { enrollPersonInSequence } from "../lib/enroll-sequence";
 import type { Variables } from "../variables";
 import { bearerSecurity } from "../lib/openapi-auth";
+import {
+  templateValueSchema,
+  templateVariablesSchema,
+} from "../lib/template-variables-schema";
 
 export const sequencesRouter = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -45,7 +49,7 @@ const EnrollSchema = z
     personId: z.string().optional(),
     personEmail: z.string().email().optional(),
     fromAddress: z.string().email(),
-    variables: z.record(z.string(), z.string()).optional().default({}),
+    variables: templateVariablesSchema.optional().default({}),
     skipSteps: z.array(z.number().int()).optional().default([]),
     delayOverrides: z
       .record(z.string(), z.number().int().min(0))
@@ -64,9 +68,9 @@ const EnrollmentSchema = z.object({
     description: "Sender identity used for all steps in this enrollment.",
   }),
   status: z.string(),
-  variables: z.record(z.string(), z.string()).openapi({
+  variables: z.record(z.string(), templateValueSchema).openapi({
     description:
-      "Template variables for this enrollment. API responses return a parsed object (stored as JSON in the database).",
+      "Template variables for this enrollment. API responses return a parsed object (stored as JSON in the database). Values may be nested arrays/objects for `{{#section}}` bodies.",
   }),
   enrolledAt: z.number(),
   cancelledAt: z.number().nullable(),


### PR DESCRIPTION
## Summary

Second PR in the stack. PR 1 taught the renderer to iterate arrays with `{{#items}}`, but callers could not reach that — the send endpoint's schema was `z.record(z.string(), z.string())`, so an array was rejected before it ever got to the renderer. This widens the schema on **every** send path and extends the `/variables` response.

Stacked on #228 — review that first; this PR's diff is only the API surface.

## Changes

- `POST /api/email-templates/:slug/send` accepts nested `variables`: strings, numbers, booleans, null, arrays, and objects, via a recursive `TemplateValue` schema registered as a named OpenAPI component.
- `GET /api/email-templates/:slug/variables` gains `optional` and `sections` alongside the existing `variables`. **`variables` keeps its name, its `string[]` type, and its meaning** — the set the caller must supply. Purely additive for existing callers.
- `sendTemplate` and `replyToEmail` parameter types widened from `Record<string, string>` to `TemplateVariables`.
- Variable nesting is capped at 32 levels, returning 400 with the limit named.
- **The widening now covers the reply endpoint, sequence enrollment, and the MCP tools**, not just template sends — see below.
- **Templates are validated at write time.** `POST` / `PUT /api/email-templates` reject a template whose tags do not parse, with the parse diagnostic naming the offending tag.

## Why the depth cap

Review found that the recursive schema had no bound: a payload of a few KB with a deeply-nested array threw `RangeError: Maximum call stack size exceeded` from inside Zod's own `z.lazy` validator. With no `onError` handler, that surfaced as an unhandled **500**. Reproduced at depth 3000; depth 2000 returned 201.

Worth noting the guard that *looked* like it covered this and didn't: PR 1 caps template section nesting at 64 levels, but that bounds the template, not the variables. `lookup` and `stringify` are also safe — `stringify` returns `""` for objects without recursing. The recursive schema was the only unbounded path, and it crashed before any renderer safety ran.

The check is iterative (explicit stack) and runs via `z.preprocess` so it executes *before* Zod's recursive descent — a `superRefine` on the recursive schema would never run, because Zod crashes first.

One implementation note for reviewers: the obvious `.superRefine().pipe(...)` composition silently drops the `TemplateValue` `$ref` from the generated OpenAPI document, because `zod-to-openapi` documents the pre-pipe schema for a plain `.pipe`. `z.preprocess` documents the post-pipe schema, so `/doc` is unchanged. There is a test asserting the component and the `$ref` survive.

## Closing the capability gap

An earlier revision of this PR deferred the remaining send paths as a follow-up. That deferral is gone — the gap is closed here, because leaving it meant a `{{#items}}` template was reachable through one endpoint and a 400 through the others, which is a worse contract than either extreme.

`worker/src/lib/template-variables-schema.ts` now holds the recursive schema *and* its depth guard as one shared module. `send-router` and `sequences-router` both use `templateVariablesSchema` — schema plus guard. `enroll-sequence` only needed the widened `TemplateVariables` *type*, since validation happens at its router. That sharing matters beyond tidiness: a second copy would re-register the same `TemplateValue` OpenAPI component from a different schema object, and a copy that drifted on the depth cap would reopen the 500.

**The MCP tools are covered too, after review found they were not.** `worker/src/mcp/server.ts` composed `z.record(z.string(), templateValueSchema)` for its `send_template`, reply, and `enroll_sequence` tools — the recursive value schema *without* the depth preprocessing — so it was the one surface still carrying the crash this PR exists to close. Measured before the fix: that shape accepts a 40-level payload the HTTP routes reject and throws `RangeError: Maximum call stack size exceeded` at depth 5000. A `RangeError` is not a `ZodError`, so no tool-level handling runs and there is no app-level `onError`. All three tools now use `templateVariablesSchema`. The accompanying test asserts the composition against the module source rather than standing up a transport and an authenticated session — blunt, but this is a copy-paste regression, and a fourth tool added by copying an existing one is exactly how the third got here.

## Why write-time validation

Without it an unbalanced section stores happily and only fails much later: every send and every `/variables` call returns 400, and `sequence-processor` marks each affected step `failed` — terminal, since the poller only re-selects `pending` rows. Enrolled recipients silently never receive the email and the only trace is a worker log. Failing the write puts the diagnostic in front of the person who typed it.

`PUT` validates the template *as it will exist after the merge*, since editing only the subject can still leave a section unbalanced across the subject/body pair.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — 6 pre-existing errors, none in files this PR touches. Note: the bare `yarn tsc --noEmit` this repo mandates compiles **zero** files (root `tsconfig.json` has `"files": []`), so it validates nothing; see the review notes.
- [x] 17 files / 206 tests — interpolate suites, `email-templates-router`, `send-router`, `send-helper`, sequence tests, `openapi-doc`, `openapi-bootstrap`
- [x] Full suite — **green on CI** (`vitest`, `test`, `playwright`, `prettier`, CodeQL all passing)

Coverage worth calling out: the end-to-end test sends a template with an array of objects and reads back the stored `bodyHtml` asserting both iterated items rendered — proving sections are actually reachable, not merely that Zod accepts the payload.

## Notes for reviewers

- The 32-level cap is not yet in the README; callers learn it from the 400 message, which names the limit.
- Write-time validation does not retroactively fix templates already stored in a broken state — those still fail at send. There is no migration; the set is expected to be empty or tiny.

Part of #112 and #227. PR 3 adds the editor UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
