### PR TITLE
feat(ui): template syntax and styling reference in the editor

### DIFF
--- a/.claude/skills/create-saasmail-template/SKILL.md
+++ b/.claude/skills/create-saasmail-template/SKILL.md
@@ -89,18 +89,32 @@ empty list — it fails the send. That is deliberate: a digest whose `items` the
 caller forgot to pass would otherwise go out silently empty, which is worse than a
 `400`. If absence is legitimate, write `{{#items?}}`.
 
-**Names inside a section body are never required, and never validated.** They
+**Names inside a section body never appear in `variables`.** They are expected to
 resolve against the current item at render time, so the caller does not supply them
-at the top level. An unresolvable one renders **empty** — no error, no literal
-`{{token}}` mailed to a customer.
+at the top level, and an unresolvable one renders **empty** rather than mailing a
+literal `{{token}}` to a customer.
 
-That has a consequence worth internalizing, because it is the sharpest edge in the
-grammar: **wrapping a tag in a section silently removes it from validation.** Move
-`{{upgradeUrl}}` inside a `{{^isPaidPlan}}` block and it drops out of `variables`; a
-caller that forgets it now gets no error and ships `<a href="">` — a dead link — to
-a real customer. Same for a typo (`{{prcie}}`), which just renders nothing. Keep
-values that must be present at the top level, or verify them in the caller, and
-proofread section bodies with a real test send.
+But "inside a section" is narrower than it looks, and the difference is the
+sharpest thing in the grammar. A section only creates a per-item scope when its
+value is an **array or an object**. An inverted `{{^key}}` section, and a regular
+`{{#key}}` section given a boolean or other scalar, render their bodies against the
+unchanged top level — so names in _those_ bodies are ordinary top-level lookups.
+
+The send path treats the two cases differently, and correctly:
+
+- **Under an iterating section**, an unresolved name renders empty and is not an
+  error. Items legitimately differ in which optional fields they carry.
+- **Under a scope-less section** (inverted, or scalar-valued), an unresolved name
+  is a caller error and **fails the send** with that name in `missingVariables`.
+  `{{^isPaidPlan}}<a href="{{upgradeUrl}}">` with no `upgradeUrl` supplied returns
+  400 rather than mailing `<a href="">`.
+
+One asymmetry to know: that second check is dynamic, so those names do **not**
+appear in `/variables` — the analyzer cannot tell statically whether a section
+will receive an array or a boolean. `/variables` is the static contract; the send
+catches the rest. A test send with a realistic payload is still the only way to
+prove a section body is right, and a typo inside an iterating body (`{{prcie}}`)
+remains silent by design.
 
 **Required wins over optional, and `#` wins over `^`.** If a name appears as both
 `{{a}}` and `{{a?}}`, it is required. If it appears as both `{{^promo}}` and
@@ -170,7 +184,20 @@ resolve against the item they are nested in, falling back outward as above.
 Values substituted into the **body** are HTML-escaped: `&`, `<`, `>`, `"`, and `'`
 become entities. This is the default because template values routinely carry
 user-typed content, and an email signed by your own domain is the last place you
-want that content injecting markup.
+want that content introducing tags.
+
+**Escaping those five characters is the whole guarantee — it is not a
+sanitizer.** Two gaps matter when you place a tag:
+
+- **Quote every attribute.** `<a href="{{url}}">` is safe; `<a href={{url}}>` is
+  not, because a space is not escaped. `url = "# onmouseover=alert(1)"` renders
+  `<a href=# onmouseover=alert(1)>` — a handler injected through the _escaped_
+  form.
+- **Escaping is not a URL check.** `<a href="{{url}}">` with
+  `url = "javascript:alert(1)"` passes through untouched; there is no scheme
+  allowlist. If a URL can come from an end user, validate the scheme before you
+  pass it in. (Inbox signatures go through `sanitize-signature.ts`, which strips
+  `javascript:` and `vbscript:`; the template renderer applies no such filter.)
 
 `{{{key}}}` opts a single value out, for HTML you produced yourself and trust — a
 pre-rendered block, a sanitized rich-text field. Never wrap a value that originated
@@ -284,8 +311,9 @@ bounds the data you send, the other the template you write.)
 | `400 "Missing required template variables"` | Caller omitted a name in `variables`. The body lists `missingVariables` and `requiredVariables` — reconcile against `/variables`.                                                                                         |
 | Literal `{{key}}` in a delivered email      | A sequence step whose enrollment omitted that variable. Direct template sends can't do this; they `400` first.                                                                                                            |
 | A blank where a list should be              | A scalar `{{items}}` used on an array. Use a section.                                                                                                                                                                     |
-| A blank inside a repeated block             | A name the item does not have (often a typo). Section-body names render empty by design.                                                                                                                                  |
+| A blank inside a repeated block             | A name the item does not have (often a typo). Only _iterating_ sections blank silently; under an inverted or boolean section the same miss fails the send.                                                                |
 | Escaped markup visible to the recipient     | Value carries HTML but the tag is `{{key}}`. Use `{{{key}}}` — only if the value is trusted.                                                                                                                              |
+| `400` naming a render limit                 | A section nested inside itself: the inner tag re-resolves to the same top-level value and re-iterates it, so work grows as N^depth. Restructure so the inner section uses a different name.                               |
 | Sequence step silently never arrives        | Its template does not parse; the step is marked `failed` and never retried. Write-time validation prevents this for templates created through the API.                                                                    |
 
 ## Changing a live template

--- a/.claude/skills/create-saasmail-template/SKILL.md
+++ b/.claude/skills/create-saasmail-template/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: create-saasmail-template
+description: Write, validate, and create email templates for a saasmail instance — the full `{{variable}}` interpolation grammar, conditional/repeating `{{#section}}` rendering, HTML escaping, and the required-vs-optional send contract. Use this skill whenever the user is authoring or editing a saasmail email template, or asks anything about template markup: "add a welcome email template", "loop over line items in the email", "show this block only if they have a trial", "why does my send say missing required variables", "how do I stop the HTML in this variable from being escaped", "make this template handle an empty list". Also use it when the user is designing a sequence's step templates, since sequence sends interpolate under different (laxer, more dangerous) rules than direct template sends.
+---
+
+# Creating saasmail email templates
+
+A template is a stored `subject` + `bodyHtml` pair rendered against caller-supplied
+variables at send time. The renderer is Mustache-_flavored_ but deliberately not
+Mustache — it is a small, strict grammar in `worker/src/lib/interpolate.ts`, and
+the differences are where mistakes happen.
+
+Writing a template is really writing a **contract**: the tags you use decide which
+variable names every future caller must supply, and a caller that misses one gets
+a `400` instead of an email. Design that contract on purpose.
+
+To _send_ mail, enroll people in sequences, or manage API keys, use `/use-saasmail`
+instead — this skill is about authoring the template itself.
+
+## Workflow
+
+1. **Decide the contract first.** For each piece of dynamic content, decide whether
+   the caller must always supply it (`{{key}}`), might omit it (`{{key?}}`), or
+   whether it is a list/conditional block (`{{#key}}`). Getting this wrong is the
+   single most common failure — see "The send contract" below.
+2. **Write the markup.** Email HTML, with tags from the grammar table.
+3. **Create it** via `POST /api/email-templates`, or in the UI at `/templates/new`
+   (which shows the detected variables and a live preview as you type). A template
+   whose tags do not parse is rejected at write time with a diagnostic naming the
+   offending tag — you cannot store a broken one.
+4. **Verify the contract** with `GET /api/email-templates/{slug}/variables`. Confirm
+   the `variables` list matches what the caller actually passes — this is the check
+   that catches a mistyped or accidentally-required name before it reaches
+   production.
+5. **Test-send** to a real address and look at the result in a mail client.
+
+Never skip step 4. The analyzer's answer, not your reading of the template, is what
+the send path enforces.
+
+## The grammar
+
+A tag is `{{` or `{{{`, an optional sigil, a name, an optional `?`, zero or more
+`|filter` clauses, and a matching close of the same brace count.
+
+| Tag                  | Behavior                                                        |
+| -------------------- | --------------------------------------------------------------- |
+| `{{key}}`            | Value. HTML-escaped in the body; plain text in the subject      |
+| `{{{key}}}`          | Value, unescaped — for pre-rendered HTML you trust              |
+| `{{key?}}`           | Optional. Renders empty when absent instead of failing the send |
+| `{{key\|nl2br}}`     | Escaped, then newlines become `<br>`                            |
+| `{{#key}}…{{/key}}`  | Renders if truthy; iterates if the value is an array            |
+| `{{#key?}}…{{/key}}` | Same, but absence does not fail the send                        |
+| `{{^key}}…{{/key}}`  | Renders only if falsy, absent, or an empty array                |
+| `{{.}}`              | The current item, inside an array-of-strings section            |
+
+**A name is `\w+` (letters, digits, underscore) or a bare `.`, with no whitespace
+anywhere inside the braces.** Anything that does not match is left alone as literal
+text — `{{ spaced }}`, `{{user.name}}`, `{{not-a-var}}`, and `{{}}` all render
+verbatim and are not variables. This strictness is a feature: prose and CSS that
+happen to contain braces can never be silently promoted into a required variable
+that starts rejecting every send.
+
+There are no dotted paths. `{{user.name}}` is _text_, not a lookup — reach nested
+data with a section (`{{#user}}{{name}}{{/user}}`) instead.
+
+The only filter that exists is `nl2br`. Any other name — `{{x|upper}}`,
+`{{x|toString}}` — is a parse error that rejects the template at write time.
+
+Only the name is matched when closing, so `{{#key?}}` closes with `{{/key}}` — the
+`?` and any filters belong to the opening tag.
+
+## The send contract: required vs optional vs section
+
+`analyzeTemplate` walks the subject and body and produces the three lists that
+`GET /{slug}/variables` returns and the send path enforces:
+
+- **`variables` (required)** — every top-level `{{key}}` and every regular
+  `{{#key}}` section name. A send missing any of these fails with `400`,
+  `missingVariables`, and `requiredVariables`. Nothing is mailed.
+- **`optional`** — `{{key?}}`, `{{#key?}}`, and inverted `{{^key}}` names. Absent,
+  they render empty.
+- **`sections`** — each section's name, whether it is inverted, and the names its
+  body references.
+
+Four rules follow from this, each of which is commonly guessed backwards:
+
+**A regular section name is required.** `{{#items}}` absent does not render an
+empty list — it fails the send. That is deliberate: a digest whose `items` the
+caller forgot to pass would otherwise go out silently empty, which is worse than a
+`400`. If absence is legitimate, write `{{#items?}}`.
+
+**Names inside a section body are never required, and never validated.** They
+resolve against the current item at render time, so the caller does not supply them
+at the top level. An unresolvable one renders **empty** — no error, no literal
+`{{token}}` mailed to a customer.
+
+That has a consequence worth internalizing, because it is the sharpest edge in the
+grammar: **wrapping a tag in a section silently removes it from validation.** Move
+`{{upgradeUrl}}` inside a `{{^isPaidPlan}}` block and it drops out of `variables`; a
+caller that forgets it now gets no error and ships `<a href="">` — a dead link — to
+a real customer. Same for a typo (`{{prcie}}`), which just renders nothing. Keep
+values that must be present at the top level, or verify them in the caller, and
+proofread section bodies with a real test send.
+
+**Required wins over optional, and `#` wins over `^`.** If a name appears as both
+`{{a}}` and `{{a?}}`, it is required. If it appears as both `{{^promo}}` and
+`{{#promo}}`, the section is required and reported as non-inverted — a section is
+only treated as an absence-branch when _every_ occurrence of it is inverted.
+
+**Supplying a name satisfies it, whatever the value.** The check is "did the caller
+pass this key", not "is it non-empty". `{"name": null}` passes validation and
+renders an empty string. Callers cannot be forced to send meaningful content — only
+to acknowledge the field.
+
+## Conditional and repeating rendering
+
+A section's value decides whether the body renders and how many times.
+
+| Value                                    | `{{#key}}`                | `{{^key}}` |
+| ---------------------------------------- | ------------------------- | ---------- |
+| Non-empty array                          | renders once per item     | skipped    |
+| Empty array `[]`                         | skipped                   | renders    |
+| Object                                   | renders once, item scoped | skipped    |
+| `true`, non-empty string, nonzero number | renders once              | skipped    |
+| `false`, `""`, `0`, `null`, absent       | skipped                   | renders    |
+
+Note `0` and `""` are falsy. `{{#count}}You have {{count}}{{/count}}` renders
+nothing when the count is zero — usually what you want, but check it is.
+
+**The empty-state pattern** is a `#`/`^` pair on the same name:
+
+```html
+{{#items}}
+<tr>
+  <td>{{name}}</td>
+  <td>{{currency}}{{price}}</td>
+</tr>
+{{/items}} {{^items}}
+<tr>
+  <td colspan="2">Nothing to show yet.</td>
+</tr>
+{{/items}}
+```
+
+Because `{{#items}}` is required and `{{^items}}` is optional, that pair reports
+`items` as **required** overall — the caller must pass the list (possibly `[]`), and
+the empty case renders the fallback row.
+
+**Scope falls through.** Inside a section, a name is looked up on the current item
+first, then on each enclosing scope, out to the top level. So `{{currency}}` above
+can live at the top level while `{{name}}` and `{{price}}` come from each item.
+Only own properties resolve — `{{constructor}}`, `{{toString}}` and friends never
+pick up JavaScript built-ins.
+
+**Arrays of strings use `{{.}}`:**
+
+```html
+{{#tags}}<span class="tag">{{.}}</span>{{/tags}}
+```
+
+**A truthy scalar renders the body once without pushing scope**, which makes
+`{{#isTrial}}…{{/isTrial}}` a plain boolean conditional whose body still sees every
+top-level variable.
+
+Sections nest (up to 64 levels; exceeding that is a parse error). Inner sections
+resolve against the item they are nested in, falling back outward as above.
+
+## Escaping, raw output, and the subject line
+
+Values substituted into the **body** are HTML-escaped: `&`, `<`, `>`, `"`, and `'`
+become entities. This is the default because template values routinely carry
+user-typed content, and an email signed by your own domain is the last place you
+want that content injecting markup.
+
+`{{{key}}}` opts a single value out, for HTML you produced yourself and trust — a
+pre-rendered block, a sanitized rich-text field. Never wrap a value that originated
+from an end user in triple braces.
+
+The **subject** is a plain-text header, not HTML, so it is never escaped: `{{key}}`
+and `{{{key}}}` are equivalent there, and a name like `O'Brien` arrives intact
+rather than as `O&#39;Brien`. HTML-emitting filters are skipped in the subject, so
+`{{note|nl2br}}` in a subject leaves the newlines alone instead of printing a
+literal `<br>` at the recipient.
+
+**Non-scalar values render empty.** If `{{items}}` holds an array or object, the
+tag produces an empty string — not `[object Object]`, and not the list. Rendering a
+collection requires a section. A blank spot where a list should be almost always
+means a scalar tag was used on an array.
+
+**Multi-line values collapse in HTML.** Use `{{key|nl2br}}`, or wrap the block:
+
+```html
+<div style="white-space: pre-line">{{message}}</div>
+```
+
+Filters run _after_ escaping, so `{{key|nl2br}}` is safe on user content: the value
+is escaped first, then its newlines become `<br>`.
+
+## Two behaviors specific to a send path
+
+**`{{unsubscribe_url}}` behaves differently per path.** The send pipeline
+substitutes a per-recipient unsubscribe URL into the rendered HTML, and appends a
+minimal footer if the URL is not already present.
+
+- On `POST /api/email-templates/{slug}/send`, the template renderer runs _first_
+  and treats `{{unsubscribe_url}}` as an ordinary required variable — so a template
+  containing it fails every send with `missingVariables: ["unsubscribe_url"]`.
+  **Leave it out of templates sent this way** and let the footer auto-append.
+- On sequence steps, the renderer does not enforce required names, so an unsupplied
+  `{{unsubscribe_url}}` survives verbatim and the pipeline replaces it in place —
+  which is how you control where the link sits in a drip email.
+
+**Sequence sends do not validate required variables at all.** They interpolate
+directly: any top-level name the enrollment did not supply renders as the literal
+text `{{foo}}` _in the delivered email_. There is no `400` to catch it. So in a
+template destined for a sequence step, mark everything not guaranteed as
+`{{foo?}}`. Sequences do always provide `name` and `email` from the person record
+(enrollment variables of the same name win), so `{{name}}` and `{{email}}` are safe
+there.
+
+## Creating the template
+
+`POST /api/email-templates`, `application/json`, `Authorization: Bearer sk_…`:
+
+```bash
+curl -X POST "$SAASMAIL_URL/api/email-templates" \
+  -H "Authorization: Bearer $SAASMAIL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug": "order-receipt",
+    "name": "Order receipt",
+    "subject": "Your receipt from {{storeName}}",
+    "bodyHtml": "<p>Thanks, {{firstName}}!</p>{{#items}}<p>{{name}} — {{price}}</p>{{/items}}{{^items}}<p>No items.</p>{{/items}}",
+    "fromAddress": "noreply@yourdomain.com"
+  }'
+```
+
+- `slug` must match `^[a-z0-9-]+$` and is the send-time identifier. It is unique
+  and not rewritable by `PUT`; choose it deliberately.
+- `fromAddress` scopes the template to an inbox and must be one the caller is
+  allowed to send from. `null` makes the template global, which only admins may do
+  — members get `403 "from_address is required for members"`.
+- There is no `bodyText` field. Templates are HTML-only; the plain-text part is
+  handled by the send pipeline.
+
+Update with `PUT /api/email-templates/{slug}` (all fields optional). The template is
+re-validated _as it will exist after the merge_, so editing only the subject can
+still be rejected for a section left unbalanced across the pair.
+
+### Verify, then test-send
+
+```bash
+curl -H "Authorization: Bearer $SAASMAIL_KEY" \
+  "$SAASMAIL_URL/api/email-templates/order-receipt/variables"
+# → { "variables": ["storeName","firstName","items"],
+#     "optional": [],
+#     "sections": [{"name":"items","inverted":false,"variables":["name","price"]}] }
+```
+
+Read that back against the caller you are writing. `sections[].variables` tells you
+the shape of each item — here, `items` must be an array of objects with `name` and
+`price`. Then send one to yourself:
+
+```bash
+curl -X POST "$SAASMAIL_URL/api/email-templates/order-receipt/send" \
+  -H "Authorization: Bearer $SAASMAIL_KEY" -H "Content-Type: application/json" \
+  -d '{"to":"you@example.com","fromAddress":"noreply@yourdomain.com",
+       "variables":{"storeName":"Acme","firstName":"Ada",
+                    "items":[{"name":"Widget","price":"$9"}]}}'
+```
+
+Exercise the empty case too (`"items": []`) — the inverted branch is the half
+nobody tests.
+
+The `variables` payload may nest objects and arrays up to **32** levels deep; deeper
+is rejected with `400`. (Independent of the 64-level cap on section nesting: one
+bounds the data you send, the other the template you write.)
+
+## Failure modes
+
+| Symptom                                     | Cause                                                                                                                                                                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400` on create/update naming a tag         | Unbalanced/mismatched section or unknown filter. Messages are exact: `Unclosed section {{#a}} — add a matching {{/a}}.`, `{{/b}} does not match the open section {{#a}}.`, `Unexpected {{/a}} — no section is open here.` |
+| `400 "Missing required template variables"` | Caller omitted a name in `variables`. The body lists `missingVariables` and `requiredVariables` — reconcile against `/variables`.                                                                                         |
+| Literal `{{key}}` in a delivered email      | A sequence step whose enrollment omitted that variable. Direct template sends can't do this; they `400` first.                                                                                                            |
+| A blank where a list should be              | A scalar `{{items}}` used on an array. Use a section.                                                                                                                                                                     |
+| A blank inside a repeated block             | A name the item does not have (often a typo). Section-body names render empty by design.                                                                                                                                  |
+| Escaped markup visible to the recipient     | Value carries HTML but the tag is `{{key}}`. Use `{{{key}}}` — only if the value is trusted.                                                                                                                              |
+| Sequence step silently never arrives        | Its template does not parse; the step is marked `failed` and never retried. Write-time validation prevents this for templates created through the API.                                                                    |
+
+## Changing a live template
+
+Adding a required tag to a template that is already in production breaks every
+caller that has not been updated — their next send `400`s. Either deploy the caller
+first, or introduce the name as `{{key?}}`, backfill the callers, and tighten it to
+`{{key}}` afterward. Removing a tag is always safe; extra variables in a payload are
+ignored.
+
+## Worked examples
+
+`references/examples.md` has four complete, copy-ready templates — a receipt with a
+line-item table and empty state, a digest with nested sections, a trial-expiry notice
+driven by boolean conditionals, and a sequence step written for the lax path — each
+with the `/variables` contract it actually produces and a payload that satisfies it.
+Read it when you want a working shape to adapt rather than assembling one from the
+rules above.
+
+## Source of truth
+
+If any behavior here seems wrong, the code decides:
+
+- `worker/src/lib/interpolate.ts` — grammar, rendering, `analyzeTemplate`
+- `worker/src/routers/email-templates-router.ts` — CRUD, write-time validation, `/variables`
+- `worker/src/lib/send-template.ts` — the strict send path
+- `worker/src/lib/sequence-processor.ts` — the lax sequence path
+- `worker/src/lib/send.ts` — unsubscribe URL substitution and footer

--- a/.claude/skills/create-saasmail-template/references/examples.md
+++ b/.claude/skills/create-saasmail-template/references/examples.md
@@ -1,0 +1,323 @@
+# Worked template examples
+
+Four complete templates, each with the `/variables` contract it produces and a
+payload that satisfies it. Every contract below was produced by running the
+template through `analyzeTemplate`, so it is what the API will actually report.
+
+Adapt these rather than assembling markup from the rules — the shapes here cover
+most of what templates need to do.
+
+## Contents
+
+- [1. Order receipt — line items with an empty state](#1-order-receipt)
+- [2. Weekly digest — nested sections](#2-weekly-digest)
+- [3. Trial expiry — boolean conditionals and optional values](#3-trial-expiry)
+- [4. Sequence step — the lax-path rules](#4-sequence-step)
+
+---
+
+## 1. Order receipt
+
+The core pattern: a repeating table plus the inverted branch for an empty list.
+`currency` lives at the top level and is visible inside the loop through scope
+fallthrough.
+
+**Subject**
+
+```
+Your receipt from {{storeName}}
+```
+
+**Body**
+
+```html
+<p>Thanks for your order, {{firstName}}.</p>
+
+<table width="100%" cellpadding="8" cellspacing="0">
+  {{#items}}
+  <tr>
+    <td>{{name}}</td>
+    <td align="right">{{currency}}{{price}}</td>
+  </tr>
+  {{/items}} {{^items}}
+  <tr>
+    <td colspan="2">This order had no billable items.</td>
+  </tr>
+  {{/items}}
+  <tr>
+    <td><strong>Total</strong></td>
+    <td align="right"><strong>{{currency}}{{total}}</strong></td>
+  </tr>
+</table>
+
+{{#note?}}
+<div style="white-space: pre-line; color: #666">{{note}}</div>
+{{/note}}
+```
+
+**Contract**
+
+```json
+{
+  "variables": ["storeName", "firstName", "items", "currency", "total"],
+  "optional": ["note"],
+  "sections": [
+    {
+      "name": "items",
+      "inverted": false,
+      "variables": ["name", "currency", "price"]
+    },
+    { "name": "note", "inverted": false, "variables": ["note"] }
+  ]
+}
+```
+
+`currency` appears in both lists: required at the top level (the totals row uses it
+outside any section) and listed under `items` because the loop body references it
+too. A name in `sections[].variables` is not automatically item-scoped — it is
+simply a name that body mentions, wherever it ends up resolving.
+
+**Payload**
+
+```json
+{
+  "storeName": "Acme",
+  "firstName": "Ada",
+  "currency": "$",
+  "total": "18.00",
+  "items": [
+    { "name": "Widget", "price": "9.00" },
+    { "name": "Sprocket", "price": "9.00" }
+  ],
+  "note": "Ships Tuesday.\nTracking follows."
+}
+```
+
+Send it once with `"items": []` too — that is the branch nobody exercises.
+
+The `?` is a property of the opening tag, not part of the name, so `{{#note?}}`
+closes with `{{/note}}`. (A stray `{{/note?}}` also parses, since only the name is
+matched, but it reads as though optionality were something you close — write
+`{{/note}}`.)
+
+## 2. Weekly digest
+
+Nested sections. Each inner name resolves against its own item first, then falls
+back outward — `{{siteName}}` is top-level yet readable from two levels deep.
+
+**Subject**
+
+```
+{{siteName}} — what happened this week
+```
+
+**Body**
+
+```html
+<h1>This week on {{siteName}}</h1>
+
+{{#categories}}
+<h2>{{title}}</h2>
+{{#posts}}
+<p><a href="{{url}}">{{headline}}</a> — {{author}}</p>
+{{/posts}} {{^posts}}
+<p>Nothing new in {{title}} this week.</p>
+{{/posts}} {{/categories}} {{^categories}}
+<p>A quiet week — nothing to report.</p>
+{{/categories}}
+```
+
+**Contract**
+
+```json
+{
+  "variables": ["siteName", "categories"],
+  "optional": [],
+  "sections": [
+    {
+      "name": "categories",
+      "inverted": false,
+      "variables": ["title", "posts", "url", "headline", "author"]
+    }
+  ]
+}
+```
+
+`sections[].variables` is flattened across every depth beneath the section, so
+`url`/`headline`/`author` appear there even though they belong to `posts` items,
+not to a category. Use it as a checklist of names the payload should provide
+_somewhere_ under that section, not as a per-item schema.
+
+`posts` produces no top-level section entry of its own and is never required — it
+lives inside `categories`. A category object without a `posts` key simply takes the
+`{{^posts}}` branch.
+
+**Payload**
+
+```json
+{
+  "siteName": "Acme Blog",
+  "categories": [
+    {
+      "title": "Engineering",
+      "posts": [
+        {
+          "url": "https://acme.dev/a",
+          "headline": "Shipping faster",
+          "author": "Ada"
+        }
+      ]
+    },
+    { "title": "Design", "posts": [] }
+  ]
+}
+```
+
+## 3. Trial expiry
+
+Booleans as sections, and values the caller may legitimately not have.
+
+**Subject**
+
+```
+{{firstName}}, your trial ends in {{daysLeft}} days
+```
+
+**Body**
+
+```html
+<p>Hi {{firstName}},</p>
+
+{{#isPaidPlan}}
+<p>You are already on {{planName}} — nothing to do.</p>
+{{/isPaidPlan}} {{^isPaidPlan}}
+<p>Your trial ends in {{daysLeft}} days.</p>
+<p><a href="{{upgradeUrl}}">Choose a plan</a></p>
+{{/isPaidPlan}} {{#discountCode?}}
+<p>Use code <strong>{{discountCode}}</strong> for 20% off.</p>
+{{/discountCode}}
+```
+
+**Contract**
+
+```json
+{
+  "variables": ["firstName", "daysLeft", "isPaidPlan"],
+  "optional": ["discountCode"],
+  "sections": [
+    {
+      "name": "isPaidPlan",
+      "inverted": false,
+      "variables": ["planName", "daysLeft", "upgradeUrl"]
+    },
+    { "name": "discountCode", "inverted": false, "variables": ["discountCode"] }
+  ]
+}
+```
+
+Two things worth noticing, both of which contradict a reasonable guess.
+
+**`isPaidPlan` is required**, even though the `{{^isPaidPlan}}` half exists to handle
+its absence. A name inverted in one place and regular in another is required —
+required always wins. If you want the "no such key" case to be legal, every
+occurrence must be inverted, or the regular one must be written `{{#isPaidPlan?}}`.
+
+**`upgradeUrl` is _not_ required**, even though the email is useless without it,
+because it sits inside the `{{^isPaidPlan}}` section. Section-body names are never
+part of the send contract. A caller that forgets it gets no error — it renders
+empty and ships `<a href="">Choose a plan</a>`, a dead link, to a real customer.
+This is the sharpest edge in the whole grammar: **moving a tag inside a section
+silently removes it from validation.** If a value must be present, either keep its
+tag at the top level or verify it in the caller.
+
+`planName` has the same exposure. If the caller sets `isPaidPlan: true` and forgets
+`planName`, the sentence renders "You are already on — nothing to do." Guard
+content like that with an inner section when a blank is unacceptable:
+
+```html
+{{#isPaidPlan}}
+<p>
+  You are already on{{#planName}} {{planName}}{{/planName}} — nothing to do.
+</p>
+{{/isPaidPlan}}
+```
+
+**Payload**
+
+```json
+{
+  "firstName": "Ada",
+  "daysLeft": 3,
+  "upgradeUrl": "https://acme.dev/upgrade",
+  "isPaidPlan": false
+}
+```
+
+`daysLeft: 0` would render "ends in 0 days" from a `{{daysLeft}}` tag — but a
+`{{#daysLeft}}` section would treat `0` as falsy and skip. Numbers that can be zero
+are a classic section bug.
+
+## 4. Sequence step
+
+Templates used as sequence steps render under different rules: no required-variable
+validation, so an unsupplied top-level name is mailed to the recipient as the
+literal text `{{name}}`. Write defensively.
+
+**Subject**
+
+```
+Welcome to {{productName?}}
+```
+
+**Body**
+
+```html
+<p>Hi {{name}},</p>
+<p>Thanks for signing up with {{email}}.</p>
+
+{{#firstProjectUrl?}}
+<p><a href="{{firstProjectUrl}}">Pick up where you left off</a></p>
+{{/firstProjectUrl}}
+
+<p style="font-size: 12px; color: #666">
+  <a href="{{unsubscribe_url}}">Unsubscribe</a>
+</p>
+```
+
+**Contract**
+
+```json
+{
+  "variables": ["name", "email", "unsubscribe_url"],
+  "optional": ["productName", "firstProjectUrl"],
+  "sections": [
+    {
+      "name": "firstProjectUrl",
+      "inverted": false,
+      "variables": ["firstProjectUrl"]
+    }
+  ]
+}
+```
+
+Read that as a warning label, not a contract: on the sequence path nothing enforces
+`variables`, which is precisely why this template can get away with a bare
+`{{unsubscribe_url}}` that would fail every direct send.
+
+Rules this template is obeying:
+
+- **`{{name}}` and `{{email}}` need no `?`.** Sequence sends always merge them in
+  from the person record before rendering (enrollment variables of the same name
+  override them).
+- **Everything else carries `?`.** `productName` and `firstProjectUrl` come from the
+  enrollment's `variables`, which nothing validates — without `?` an enrollment that
+  omitted them would mail `{{productName}}` verbatim.
+- **`{{unsubscribe_url}}` is used bare, and only here.** On the sequence path the
+  renderer leaves the unresolved tag in place and the send pipeline swaps in the
+  per-recipient URL, which is how you control where the link sits. Put that same tag
+  in a template sent through `POST /api/email-templates/{slug}/send` and every send
+  fails with `missingVariables: ["unsubscribe_url"]` — there, omit it entirely and
+  let the footer auto-append.
+
+A template used on _both_ paths cannot mention `{{unsubscribe_url}}`. Keep the
+sequence version separate, or drop the tag and accept the appended footer.

--- a/.claude/skills/create-saasmail-template/references/examples.md
+++ b/.claude/skills/create-saasmail-template/references/examples.md
@@ -222,17 +222,23 @@ its absence. A name inverted in one place and regular in another is required —
 required always wins. If you want the "no such key" case to be legal, every
 occurrence must be inverted, or the regular one must be written `{{#isPaidPlan?}}`.
 
-**`upgradeUrl` is _not_ required**, even though the email is useless without it,
-because it sits inside the `{{^isPaidPlan}}` section. Section-body names are never
-part of the send contract. A caller that forgets it gets no error — it renders
-empty and ships `<a href="">Choose a plan</a>`, a dead link, to a real customer.
-This is the sharpest edge in the whole grammar: **moving a tag inside a section
-silently removes it from validation.** If a value must be present, either keep its
-tag at the top level or verify it in the caller.
+**`upgradeUrl` is absent from every list, yet the send still fails without it.**
+It sits inside `{{^isPaidPlan}}`, and an inverted section pushes no per-item
+scope — so the name is really a top-level lookup. The analyzer cannot see that
+statically (it does not know what value `isPaidPlan` will receive), so
+`/variables` omits it; the renderer _can_ see it, so a send that omits it returns
+`{"missingVariables": ["upgradeUrl"]}` instead of mailing `<a href="">`.
 
-`planName` has the same exposure. If the caller sets `isPaidPlan: true` and forgets
-`planName`, the sentence renders "You are already on — nothing to do." Guard
-content like that with an inner section when a blank is unacceptable:
+Take the lesson, not the list: **`/variables` is the static contract, and it is a
+lower bound.** A section body can require more than it advertises. That is why the
+workflow ends with a test send rather than with reading `/variables`.
+
+`planName` behaves the same way — `{{#isPaidPlan}}` given `true` is scalar, so it
+pushes no scope either, and omitting `planName` fails the send. Had `isPaidPlan`
+been an array of objects, the identical template would treat `planName` as a
+per-item field and render it empty without complaint. If you want the blank to be
+deliberate rather than an error, mark it optional (`{{planName?}}`) or guard it
+with an inner section:
 
 ```html
 {{#isPaidPlan}}

--- a/.claude/skills/use-saasmail/SKILL.md
+++ b/.claude/skills/use-saasmail/SKILL.md
@@ -105,7 +105,9 @@ Sending to a recipient **cancels any active sequence enrollment** for that perso
 
 ## 2. Send using a template
 
-Templates let you store the subject + HTML body once and render with variables at send time. Variables in templates use `{{name}}` syntax (Mustache-style).
+Templates let you store the subject + HTML body once and render with variables at send time. Variables in templates use `{{name}}` syntax (Mustache-flavored, but a stricter grammar of its own).
+
+This section covers _sending_ through an existing template. To write or edit one — conditionals, loops, optional variables, escaping — use `/create-saasmail-template`, which documents the grammar and the required-vs-optional contract in full.
 
 ### Discover templates and their variables
 
@@ -116,8 +118,15 @@ curl -H "Authorization: Bearer $SAASMAIL_KEY" "$SAASMAIL_URL/api/email-templates
 # Get the required variables for a given template
 curl -H "Authorization: Bearer $SAASMAIL_KEY" \
   "$SAASMAIL_URL/api/email-templates/welcome-email/variables"
-# → { "variables": ["firstName", "verifyUrl"] }
+# → { "variables": ["firstName", "verifyUrl"],   ← must supply, or the send 400s
+#     "optional":  ["couponCode"],               ← render empty when absent
+#     "sections":  [{ "name": "items", "inverted": false,
+#                     "variables": ["name", "price"] }] }
 ```
+
+`variables` is the send contract. `sections` tells you which names take an array or
+object — `items` above wants a list of `{ name, price }` objects — and those inner
+names are never listed in `variables`, because they resolve per item at render time.
 
 Always call the `/variables` endpoint before sending if you don't know the template intimately — `POST .../send` will reject the request with `400` and list the missing variables, but checking up front avoids a round trip.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trace. `PUT` validates the template as it will exist after the merge, since
   editing only the subject can still unbalance a section across the pair.
   (#227)
+- The template editor understands the full grammar. Detected variables are
+  grouped into Required / Optional / Sections with each chip showing the tag as
+  written (`{{^promo}}`, `{{#promo?}}`, `{{name?}}`), the live preview
+  substitutes sample values so a section renders as repeated content, and a
+  "Syntax & styling" card documents the tag table, escaping, and multi-line
+  values. The editor now renders through the worker's own renderer rather than
+  a copy, so the preview and the chips cannot disagree with what a send does.
+  (#112)
+- The sequence editor's enroll snippet and the template list's variable badge
+  use the same analyzer. Both previously scanned for `{{name}}` with a regex
+  that, for a section template, collected the per-item names the endpoint
+  ignores and omitted the section name it rejects the request for — so the
+  snippet was copy-pasteable into a `400`. The snippet now shows a section as
+  an array of its own fields. (#112)
 - Section nesting is capped at 64 levels; deeper templates are rejected as a
   parse error rather than overflowing the renderer's stack. (#112)
 - Total section expansion is capped at 20,000 body renders per template, as
@@ -106,15 +120,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Section-body names stay out of `variables`: they resolve against the current
   item at render time, so listing them would suggest a contract that does not
   exist. (#112, #227)
-
-### Known limitations
-
-- The template editor UI does not recognise sections yet: its variable list
-  comes from an older extractor, so a template using `{{#items}}…{{/items}}`
-  will show a misleading set of variables in the editor and its preview may
-  not match what is sent. Exercise section templates through the API until the
-  follow-up lands. Sending is unaffected — the API and sequence sends use the
-  new renderer.
 
 ## [0.10.0] - 2026-06-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,4 @@ Self-hosted email server on Cloudflare Workers. See README.md for full documenta
 
 - `/saasmail-onboarding` — Interactive setup wizard for deploying a new saasmail instance
 - `/use-saasmail` — How to call a deployed saasmail instance's HTTP API to send emails (raw or via templates) and enroll recipients in sequences
+- `/create-saasmail-template` — Authoring email templates: the `{{variable}}` grammar, conditional and repeating `{{#section}}` rules, escaping, and the required-vs-optional send contract

--- a/README.md
+++ b/README.md
@@ -161,15 +161,16 @@ inside a section renders **empty**; only the section's own name is required.
 
 #### Template syntax
 
-| Tag                 | Behavior                                            |
-| ------------------- | --------------------------------------------------- |
-| `{{key}}`           | Value, HTML-escaped                                 |
-| `{{{key}}}`         | Value, raw — for pre-rendered HTML                  |
-| `{{key?}}`          | Optional; renders empty instead of failing the send |
-| `{{key\|nl2br}}`    | Escaped, then newlines become `<br>`                |
-| `{{#key}}…{{/key}}` | Renders if truthy; iterates arrays                  |
-| `{{^key}}…{{/key}}` | Renders if falsy or empty                           |
-| `{{.}}`             | Current item inside an array-of-strings section     |
+| Tag                  | Behavior                                                   |
+| -------------------- | ---------------------------------------------------------- |
+| `{{key}}`            | Value, HTML-escaped in the body; plain text in the subject |
+| `{{{key}}}`          | Value, raw — for pre-rendered HTML                         |
+| `{{key?}}`           | Optional; renders empty instead of failing the send        |
+| `{{key\|nl2br}}`     | Escaped, then newlines become `<br>`                       |
+| `{{#key}}…{{/key}}`  | Renders if truthy; iterates arrays                         |
+| `{{#key?}}…{{/key}}` | Same as `{{#key}}`, but doesn't fail the send if missing   |
+| `{{^key}}…{{/key}}`  | Renders if falsy or empty                                  |
+| `{{.}}`              | Current item inside an array-of-strings section            |
 
 ```html
 {{#items}}

--- a/README.md
+++ b/README.md
@@ -200,12 +200,17 @@ sending something half-formed. This affects
 `GET /api/email-templates/{slug}/variables`, and `POST /api/send/reply/{id}`.
 A sequence step whose template does not parse is marked `failed`.
 
-> **Caveat: the editor UI does not understand sections yet.** Its variable
-> list is computed by an older extractor, so a template using
-> `{{#items}}…{{/items}}` shows a misleading variable list in the editor and
-> its preview may not match what actually goes out. Sending is unaffected —
-> the API and sequence sends use the new renderer. Exercise section templates
-> via the API until the follow-up UI change lands.
+The `variables` payload itself — the JSON you POST, not the template markup —
+may nest objects and arrays up to 32 levels deep. A payload nested deeper than
+that is rejected with `400` naming the limit, rather than risking a stack
+overflow while validating it. This is independent of the 64-level cap on
+section nesting above: one bounds the data you send, the other bounds the
+template you write.
+
+The template editor's UI understands this grammar too — grouping detected
+variables into Required, Optional, and Sections, and rendering a live preview
+with sample values in place of the raw tokens — so what you see while editing
+matches what a real send does.
 
 ##### Upgrading: escaping is now the default
 

--- a/e2e/specs/templates.spec.ts
+++ b/e2e/specs/templates.spec.ts
@@ -3,10 +3,14 @@
 //
 // Preview mechanics: TemplateEditorPage uses a Code/Split/Preview view
 // toggle that defaults to split-pane. Left pane = HTML Source
-// (CodeMirror). Right pane = an <iframe srcDoc={bodyHtml}>. There are
-// no variable-value input fields in the UI — the preview renders the
-// raw HTML including any {{variable}} tokens. Variable names are shown
-// as read-only chips in a Variables row above the editor.
+// (CodeMirror). Right pane = an <iframe srcDoc={...}> rendered through the
+// same client-side analyzer/renderer as the variable chips (see
+// src/lib/template-syntax.ts). There are no variable-value input fields in
+// the UI — instead each detected variable is substituted with a sample
+// placeholder shaped like `<name>`, HTML-escaped like a real send, so a
+// `{{name}}` tag in the source renders as the literal text "<name>" in the
+// preview rather than the raw token. Variable names are shown as read-only
+// chips, grouped by Required/Optional/Sections, above the editor.
 //
 // The update API uses PUT /api/email-templates/:slug (not PATCH).
 
@@ -65,10 +69,12 @@ test.describe.serial("templates CRUD", () => {
       page.locator("code").filter({ hasText: "{{product}}" }),
     ).toBeVisible();
 
-    // Preview iframe should contain the typed HTML
+    // Preview iframe renders the template with sample values substituted —
+    // "{{name}}" becomes the literal text "<name>" (HTML-escaped, so it
+    // shows as text rather than being parsed as a tag), not the raw token.
     const previewFrame = page.frameLocator('iframe[title="Email preview"]');
-    await expect(previewFrame.locator("body")).toContainText("{{name}}");
-    await expect(previewFrame.locator("body")).toContainText("{{product}}");
+    await expect(previewFrame.locator("body")).toContainText("<name>");
+    await expect(previewFrame.locator("body")).toContainText("<product>");
 
     // Save and expect redirect back to /templates. The header action
     // button reads "Create template" in new mode, "Save changes" in edit.

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -31,6 +31,7 @@ import {
 import { dispatchEmailSent } from "@/lib/email-events";
 import { getFromLabel } from "@/lib/format";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
+import { analyzeTemplateClient } from "@/lib/template-syntax";
 import { cn } from "@/lib/utils";
 
 const ATTACHMENT_CAP_BYTES = 25 * 1024 * 1024;
@@ -52,18 +53,6 @@ interface ReplyComposerProps {
 }
 
 type Tab = "freeform" | "template";
-
-function extractVariables(subject: string, bodyHtml: string): string[] {
-  const vars = new Set<string>();
-  const regex = /\{\{(\w+)\}\}/g;
-  for (const src of [subject, bodyHtml]) {
-    let m: RegExpExecArray | null;
-    while ((m = regex.exec(src)) !== null) {
-      vars.add(m[1]);
-    }
-  }
-  return Array.from(vars);
-}
 
 export default function ReplyComposer({
   emailId,
@@ -175,12 +164,21 @@ export default function ReplyComposer({
   const selectedTemplate =
     templates.find((t) => t.slug === selectedSlug) ?? null;
 
+  // Only top-level names, same contract the send API validates — names
+  // scoped inside a {{#section}} resolve per item, not from this form, so
+  // they're deliberately excluded (see src/lib/template-syntax.ts).
   const requiredVars = useMemo(() => {
     if (!selectedTemplate) return [];
-    return extractVariables(
-      selectedTemplate.subject,
-      selectedTemplate.bodyHtml,
-    );
+    try {
+      return analyzeTemplateClient(
+        selectedTemplate.subject,
+        selectedTemplate.bodyHtml,
+      ).required;
+    } catch {
+      // A stored template shouldn't fail to parse, but if one somehow does,
+      // fall back to no prompts rather than crashing the composer.
+      return [];
+    }
   }, [selectedTemplate]);
 
   useEffect(() => {

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -167,19 +167,28 @@ export default function ReplyComposer({
   // Only top-level names, same contract the send API validates — names
   // scoped inside a {{#section}} resolve per item, not from this form, so
   // they're deliberately excluded (see src/lib/template-syntax.ts).
-  const requiredVars = useMemo(() => {
-    if (!selectedTemplate) return [];
+  const templateAnalysis = useMemo(() => {
+    if (!selectedTemplate) return null;
     try {
       return analyzeTemplateClient(
         selectedTemplate.subject,
         selectedTemplate.bodyHtml,
-      ).required;
+      );
     } catch {
       // A stored template shouldn't fail to parse, but if one somehow does,
       // fall back to no prompts rather than crashing the composer.
-      return [];
+      return null;
     }
   }, [selectedTemplate]);
+  const requiredVars = templateAnalysis?.required ?? [];
+  // A required name that's actually a section (e.g. {{#items}}) needs an
+  // array of objects, not the plain string this form's inputs collect —
+  // label it with its real syntax rather than the bare {{name}} used for
+  // scalar variables, so the prompt isn't misleading about what's needed.
+  const sectionVarNames = useMemo(
+    () => new Set((templateAnalysis?.sections ?? []).map((s) => s.name)),
+    [templateAnalysis],
+  );
 
   useEffect(() => {
     if (!selectedTemplate) return;
@@ -465,7 +474,9 @@ export default function ReplyComposer({
                                   className="grid grid-cols-[120px_1fr] items-center gap-3"
                                 >
                                   <label className="truncate font-mono text-xs text-text-tertiary">
-                                    {`{{${v}}}`}
+                                    {sectionVarNames.has(v)
+                                      ? `{{#${v}}}`
+                                      : `{{${v}}}`}
                                   </label>
                                   <input
                                     value={templateVars[v] ?? ""}
@@ -480,6 +491,15 @@ export default function ReplyComposer({
                                 </div>
                               ))}
                             </div>
+                            {[...sectionVarNames].some((n) =>
+                              requiredVars.includes(n),
+                            ) && (
+                              <p className="mt-2 text-[11px] font-light text-text-tertiary">
+                                Section variables (#) need an array of objects —
+                                this form can only send plain text, so send
+                                those via the API instead.
+                              </p>
+                            )}
                           </div>
                         )}
                       </>

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -31,7 +31,7 @@ import {
 import { dispatchEmailSent } from "@/lib/email-events";
 import { getFromLabel } from "@/lib/format";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
-import { analyzeTemplateClient } from "@/lib/template-syntax";
+import { analyzeTemplateClient, chipLabel } from "@/lib/template-syntax";
 import { cn } from "@/lib/utils";
 
 const ATTACHMENT_CAP_BYTES = 25 * 1024 * 1024;
@@ -182,9 +182,9 @@ export default function ReplyComposer({
   }, [selectedTemplate]);
   const requiredVars = templateAnalysis?.required ?? [];
   // A required name that's actually a section (e.g. {{#items}}) needs an
-  // array of objects, not the plain string this form's inputs collect —
-  // label it with its real syntax rather than the bare {{name}} used for
-  // scalar variables, so the prompt isn't misleading about what's needed.
+  // array of objects, not the plain string this form's inputs collect — used
+  // below to warn that such a template can't be filled in from here. The
+  // chip text itself comes from the shared `chipLabel`.
   const sectionVarNames = useMemo(
     () => new Set((templateAnalysis?.sections ?? []).map((s) => s.name)),
     [templateAnalysis],
@@ -474,8 +474,8 @@ export default function ReplyComposer({
                                   className="grid grid-cols-[120px_1fr] items-center gap-3"
                                 >
                                   <label className="truncate font-mono text-xs text-text-tertiary">
-                                    {sectionVarNames.has(v)
-                                      ? `{{#${v}}}`
+                                    {templateAnalysis
+                                      ? chipLabel(v, templateAnalysis)
                                       : `{{${v}}}`}
                                   </label>
                                   <input

--- a/src/lib/template-syntax.ts
+++ b/src/lib/template-syntax.ts
@@ -1,313 +1,38 @@
 /**
  * Browser-side template analysis and preview rendering.
  *
- * This is a deliberate, hand-kept-in-sync duplicate of the tokenize → parse →
- * render pipeline in `worker/src/lib/interpolate.ts`. Worker code is not
- * importable from the browser bundle (it pulls in Cloudflare-only globals
- * elsewhere in the worker tree), so the editor gets its own copy of just the
- * grammar and semantics it needs: what a template requires, and what it
- * looks like once filled in.
+ * The grammar and semantics come straight from the worker's renderer —
+ * `worker/src/lib/interpolate.ts` imports nothing and touches no Cloudflare
+ * globals, so it bundles for the browser as-is via the `@worker` alias. This
+ * file adds only what the editor needs on top: sample values to preview
+ * against.
  *
- * KEEP THESE TWO FILES IN SYNC. If you change tag grammar, escaping rules,
- * filters, or section semantics in `interpolate.ts`, mirror the change here
- * — `worker/src/__tests__/interpolate*.test.ts` is the source of truth this
- * file must agree with. There is no shared package (yet); this comment is
- * the contract.
+ * It used to be a hand-copied duplicate of the whole tokenize → parse →
+ * render pipeline, kept correct by a comment. That drifted (the copy lost
+ * the `escape` argument to `applyFilters`, and validated filter names with
+ * `in`, which let `{{x|toString}}` through), and drift here is invisible:
+ * the editor silently shows a preview and a chip strip that disagree with
+ * what the send API actually accepts.
  */
 
-/** Any value a template variable can carry. Mirrors `TemplateValue`. */
-type TemplateValue =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | TemplateValue[]
-  | { [key: string]: TemplateValue };
+import {
+  analyzeTemplate,
+  interpolate,
+  TemplateParseError,
+  type TemplateAnalysis,
+} from "@worker/lib/interpolate";
 
-/** Describes what a template needs and offers, for the editor UI. */
-export interface TemplateAnalysis {
-  /** Top-level names the caller must supply, or the send fails. */
-  required: string[];
-  /** Names that render empty when absent: `{{key?}}` and inverted sections. */
-  optional: string[];
-  /** Sections and the names their bodies reference (informational only —
-   *  those inner names resolve per item at render time, never validated). */
-  sections: Array<{ name: string; inverted: boolean; variables: string[] }>;
-}
-
-/** Thrown for unbalanced sections or an unknown filter — mirrors `TemplateParseError`. */
-class TemplateSyntaxError extends Error {}
+export { TemplateParseError, type TemplateAnalysis };
 
 /**
- * Escape the five characters significant in HTML text and both attribute
- * quoting styles. Mirrors `escapeHtml` in interpolate.ts exactly.
+ * Describe what a template needs and offers, for the editor UI.
+ *
+ * Thin alias over the worker's `analyzeTemplate` so the editor and the
+ * `/variables` endpoint can never disagree about what a template requires.
+ * Throws `TemplateParseError` on an unbalanced section or unknown filter —
+ * mid-edit is a normal state to be in, so callers should catch.
  */
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-/** Value filters. Mirrors the fixed one-entry registry in interpolate.ts. */
-const FILTERS: Record<string, (s: string) => string> = {
-  nl2br: (s) => s.replace(/\r\n|\r|\n/g, "<br>"),
-};
-
-type Token =
-  | { kind: "text"; value: string }
-  | {
-      kind: "var";
-      name: string;
-      raw: boolean;
-      optional: boolean;
-      filters: string[];
-      source: string;
-    }
-  | {
-      kind: "open";
-      name: string;
-      inverted: boolean;
-      optional: boolean;
-      source: string;
-    }
-  | { kind: "close"; name: string; source: string };
-
-/*
- * Same two-alternate grammar as interpolate.ts's `TAG`: a strict `{{{...}}}`
- * raw form and a strict `{{...}}` form, each requiring an exact matching
- * brace count. A name is `\w+` or a bare `.` — no whitespace anywhere inside
- * the tag, no dots in a real name. `{{ spaced }}` and `{{a.b}}` are left
- * alone as literal text, exactly like the renderer, so the editor never
- * flags a name the API wouldn't actually require.
- */
-const TAG =
-  /\{\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}\}|\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}/g;
-
-function tokenize(template: string): Token[] {
-  const tokens: Token[] = [];
-  let lastIndex = 0;
-  TAG.lastIndex = 0;
-
-  let match: RegExpExecArray | null;
-  while ((match = TAG.exec(template)) !== null) {
-    const [
-      source,
-      rawSigil,
-      rawName,
-      rawOptional,
-      rawFilterClause,
-      plainSigil,
-      plainName,
-      plainOptional,
-      plainFilterClause,
-    ] = match;
-
-    const raw = rawName !== undefined;
-    const sigil = raw ? rawSigil : plainSigil;
-    const name = raw ? rawName : plainName;
-    const optional = raw ? rawOptional : plainOptional;
-    const filterClause = raw ? rawFilterClause : plainFilterClause;
-
-    if (match.index > lastIndex) {
-      tokens.push({
-        kind: "text",
-        value: template.slice(lastIndex, match.index),
-      });
-    }
-    lastIndex = match.index + source.length;
-
-    if (sigil === "/") {
-      tokens.push({ kind: "close", name, source });
-      continue;
-    }
-    if (sigil === "#" || sigil === "^") {
-      tokens.push({
-        kind: "open",
-        name,
-        inverted: sigil === "^",
-        optional: Boolean(optional),
-        source,
-      });
-      continue;
-    }
-
-    const filters = (filterClause ?? "").split("|").filter(Boolean);
-    for (const f of filters) {
-      if (!(f in FILTERS)) {
-        throw new TemplateSyntaxError(
-          `Unknown filter "${f}" in ${source}. Available filters: ${Object.keys(FILTERS).join(", ")}.`,
-        );
-      }
-    }
-
-    tokens.push({
-      kind: "var",
-      name,
-      raw,
-      optional: Boolean(optional),
-      filters,
-      source,
-    });
-  }
-
-  if (lastIndex < template.length) {
-    tokens.push({ kind: "text", value: template.slice(lastIndex) });
-  }
-  return tokens;
-}
-
-type Node =
-  | { kind: "text"; value: string }
-  | {
-      kind: "var";
-      name: string;
-      raw: boolean;
-      optional: boolean;
-      filters: string[];
-      source: string;
-    }
-  | {
-      kind: "section";
-      name: string;
-      inverted: boolean;
-      optional: boolean;
-      children: Node[];
-    };
-
-/** Mirrors `MAX_SECTION_DEPTH` in interpolate.ts. */
-const MAX_SECTION_DEPTH = 64;
-
-/** Fold the token stream into a tree. Mirrors `parse` in interpolate.ts. */
-function parse(template: string): Node[] {
-  const root: Node[] = [];
-  const stack: Array<{
-    node: Extract<Node, { kind: "section" }>;
-    source: string;
-  }> = [];
-
-  const currentChildren = () =>
-    stack.length === 0 ? root : stack[stack.length - 1].node.children;
-
-  for (const token of tokenize(template)) {
-    switch (token.kind) {
-      case "text":
-      case "var":
-        currentChildren().push(token);
-        break;
-      case "open": {
-        if (stack.length >= MAX_SECTION_DEPTH) {
-          throw new TemplateSyntaxError(
-            `Sections nested too deeply at ${token.source} — the limit is ${MAX_SECTION_DEPTH} levels.`,
-          );
-        }
-        const node: Extract<Node, { kind: "section" }> = {
-          kind: "section",
-          name: token.name,
-          inverted: token.inverted,
-          optional: token.optional,
-          children: [],
-        };
-        currentChildren().push(node);
-        stack.push({ node, source: token.source });
-        break;
-      }
-      case "close": {
-        const open = stack.pop();
-        if (!open) {
-          throw new TemplateSyntaxError(
-            `Unexpected ${token.source} — no section is open here.`,
-          );
-        }
-        if (open.node.name !== token.name) {
-          throw new TemplateSyntaxError(
-            `${token.source} does not match the open section ${open.source}.`,
-          );
-        }
-        break;
-      }
-    }
-  }
-
-  if (stack.length > 0) {
-    throw new TemplateSyntaxError(
-      `Unclosed section ${stack[stack.length - 1].source} — add a matching {{/${stack[stack.length - 1].node.name}}}.`,
-    );
-  }
-
-  return root;
-}
-
-/**
- * Describe what a template needs and offers. Mirrors `analyzeTemplate` in
- * interpolate.ts, including the recursive descendant collection: a
- * section's `variables` list includes names from sub-sections nested inside
- * it too, because only the outermost section of a nest is a top-level
- * caller contract — the same reason nested sections don't get their own
- * top-level `sections` entry here either.
- */
-export function analyzeTemplateClient(...sources: string[]): TemplateAnalysis {
-  const required = new Set<string>();
-  const optional = new Set<string>();
-  const sectionsByName = new Map<
-    string,
-    TemplateAnalysis["sections"][number]
-  >();
-
-  function collectInner(nodes: Node[], into: Set<string>): void {
-    for (const node of nodes) {
-      if (node.kind === "var") {
-        if (node.name !== ".") into.add(node.name);
-      } else if (node.kind === "section") {
-        into.add(node.name);
-        collectInner(node.children, into);
-      }
-    }
-  }
-
-  function walkTopLevel(nodes: Node[]): void {
-    for (const node of nodes) {
-      if (node.kind === "text") continue;
-      if (node.kind === "var") {
-        if (node.name === ".") continue;
-        (node.optional ? optional : required).add(node.name);
-        continue;
-      }
-      if (node.name !== ".") {
-        (node.inverted || node.optional ? optional : required).add(node.name);
-      }
-      const inner = new Set<string>();
-      collectInner(node.children, inner);
-
-      const existing = sectionsByName.get(node.name);
-      if (existing) {
-        for (const v of inner) {
-          if (!existing.variables.includes(v)) existing.variables.push(v);
-        }
-      } else {
-        sectionsByName.set(node.name, {
-          name: node.name,
-          inverted: node.inverted,
-          variables: Array.from(inner),
-        });
-      }
-    }
-  }
-
-  for (const source of sources) walkTopLevel(parse(source));
-
-  // A name that is required somewhere is required overall.
-  for (const name of required) optional.delete(name);
-
-  return {
-    required: Array.from(required),
-    optional: Array.from(optional),
-    sections: Array.from(sectionsByName.values()),
-  };
-}
+export const analyzeTemplateClient = analyzeTemplate;
 
 /**
  * Placeholder values so the live preview renders sections as content
@@ -322,6 +47,15 @@ export function sampleValues(
     vars[name] = `<${name}>`;
   }
   for (const section of analysis.sections) {
+    // An inverted section renders its body only when the value is FALSY, so
+    // giving `{{^items}}` a sample array would hide the very branch the
+    // author is trying to look at — the empty-state copy would never appear
+    // in the preview. Leave it absent (and drop any scalar placeholder set
+    // above, which would be truthy) so the empty state is what renders.
+    if (section.inverted) {
+      delete vars[section.name];
+      continue;
+    }
     vars[section.name] = [0, 1].map(() =>
       Object.fromEntries(section.variables.map((v) => [v, `<${v}>`])),
     );
@@ -329,118 +63,57 @@ export function sampleValues(
   return vars;
 }
 
-/* ------------------------------- rendering ------------------------------- */
-/* Mirrors renderNodes/renderSection/lookup/isTruthy/stringify in
- * interpolate.ts. Preview only ever renders the HTML body, so — unlike the
- * worker, which also renders a plain-text subject — this always escapes. */
-
-type Frame = TemplateValue;
-
-interface Lookup {
-  found: boolean;
-  value: TemplateValue;
-}
-
-function hasOwn(obj: object, name: string): boolean {
-  return Object.prototype.hasOwnProperty.call(obj, name);
-}
-
-function lookup(stack: Frame[], name: string): Lookup {
-  if (name === ".") {
-    return { found: stack.length > 0, value: stack[stack.length - 1] };
-  }
-  for (let i = stack.length - 1; i >= 0; i--) {
-    const frame = stack[i];
-    if (
-      frame &&
-      typeof frame === "object" &&
-      !Array.isArray(frame) &&
-      hasOwn(frame, name)
-    ) {
-      return {
-        found: true,
-        value: (frame as Record<string, TemplateValue>)[name],
-      };
-    }
-  }
-  return { found: false, value: undefined };
-}
-
-function stringify(value: TemplateValue): string {
-  if (value === null || value === undefined) return "";
-  if (typeof value === "object") return "";
-  return String(value);
-}
-
-function isTruthy(value: TemplateValue): boolean {
-  if (Array.isArray(value)) return value.length > 0;
-  if (value === null || value === undefined) return false;
-  if (typeof value === "object") return true;
-  return Boolean(value);
-}
-
-function applyFilters(value: string, filters: string[]): string {
-  return filters.reduce((acc, f) => FILTERS[f](acc), value);
-}
-
-function renderNodes(
-  nodes: Node[],
-  stack: Frame[],
-  inSection: boolean,
+/**
+ * The exact tag text for a section's chip. Must always be a string that
+ * really appears in the template — never a syntax that contradicts it:
+ *   - inverted (`{{^key}}`) always renders that way, `?` or not, since
+ *     inversion alone already makes it optional.
+ *   - a non-inverted section that's optional (`analysis.optional` includes
+ *     it) got there via a trailing `?`, so it renders as `{{#key?}}`.
+ *   - otherwise it's a plain required section, `{{#key}}`.
+ */
+export function sectionChipLabel(
+  section: TemplateAnalysis["sections"][number],
+  analysis: TemplateAnalysis,
 ): string {
-  let out = "";
-  for (const node of nodes) {
-    if (node.kind === "text") {
-      out += node.value;
-      continue;
-    }
-    if (node.kind === "var") {
-      const { found, value } = lookup(stack, node.name);
-      if (!found) {
-        out += node.optional || inSection ? "" : node.source;
-        continue;
-      }
-      const text = node.raw ? stringify(value) : escapeHtml(stringify(value));
-      out += applyFilters(text, node.filters);
-      continue;
-    }
-    out += renderSection(node, stack);
-  }
-  return out;
+  if (section.inverted) return `{{^${section.name}}}`;
+  if (analysis.optional.includes(section.name)) return `{{#${section.name}?}}`;
+  return `{{#${section.name}}}`;
 }
 
-function renderSection(
-  node: Extract<Node, { kind: "section" }>,
-  stack: Frame[],
-): string {
-  const { value } = lookup(stack, node.name);
-  const truthy = isTruthy(value);
-  // A section body is always "in section" once entered, at any depth.
-  const inner = true;
+/**
+ * The tag text to display for any analyzed top-level name.
+ *
+ * Lives here rather than in a page component because the editor's chip strip
+ * and the reply composer's variable prompts both need it and had drifted:
+ * the composer labelled every section `{{#name}}`, including inverted ones,
+ * which is the inverse of what the template actually says.
+ */
+export function chipLabel(name: string, analysis: TemplateAnalysis): string {
+  const section = analysis.sections.find((s) => s.name === name);
+  if (section) return sectionChipLabel(section, analysis);
+  return analysis.optional.includes(name) ? `{{${name}?}}` : `{{${name}}}`;
+}
 
-  if (node.inverted)
-    return truthy ? "" : renderNodes(node.children, stack, inner);
-  if (!truthy) return "";
-
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => renderNodes(node.children, [...stack, item], inner))
-      .join("");
-  }
-  if (value && typeof value === "object") {
-    return renderNodes(node.children, [...stack, value], inner);
-  }
-  return renderNodes(node.children, stack, inner);
+/** Whether an analyzed name is a section rather than a scalar variable. */
+export function isSectionName(
+  analysis: TemplateAnalysis,
+  name: string,
+): boolean {
+  return analysis.sections.some((s) => s.name === name);
 }
 
 /**
  * Render a template against sample values for the live preview. Throws on
  * an unbalanced section or unknown filter (mid-edit is a normal state to be
  * in) — callers should catch and fall back to showing the raw source.
+ *
+ * Always escapes: the preview only ever renders the HTML body, never the
+ * plain-text subject the worker renders with `{ escape: false }`.
  */
 export function renderPreview(
   template: string,
   variables: Record<string, unknown>,
 ): string {
-  return renderNodes(parse(template), [variables as TemplateValue], false);
+  return interpolate(template, variables as Parameters<typeof interpolate>[1]);
 }

--- a/src/lib/template-syntax.ts
+++ b/src/lib/template-syntax.ts
@@ -1,0 +1,446 @@
+/**
+ * Browser-side template analysis and preview rendering.
+ *
+ * This is a deliberate, hand-kept-in-sync duplicate of the tokenize → parse →
+ * render pipeline in `worker/src/lib/interpolate.ts`. Worker code is not
+ * importable from the browser bundle (it pulls in Cloudflare-only globals
+ * elsewhere in the worker tree), so the editor gets its own copy of just the
+ * grammar and semantics it needs: what a template requires, and what it
+ * looks like once filled in.
+ *
+ * KEEP THESE TWO FILES IN SYNC. If you change tag grammar, escaping rules,
+ * filters, or section semantics in `interpolate.ts`, mirror the change here
+ * — `worker/src/__tests__/interpolate*.test.ts` is the source of truth this
+ * file must agree with. There is no shared package (yet); this comment is
+ * the contract.
+ */
+
+/** Any value a template variable can carry. Mirrors `TemplateValue`. */
+type TemplateValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | TemplateValue[]
+  | { [key: string]: TemplateValue };
+
+/** Describes what a template needs and offers, for the editor UI. */
+export interface TemplateAnalysis {
+  /** Top-level names the caller must supply, or the send fails. */
+  required: string[];
+  /** Names that render empty when absent: `{{key?}}` and inverted sections. */
+  optional: string[];
+  /** Sections and the names their bodies reference (informational only —
+   *  those inner names resolve per item at render time, never validated). */
+  sections: Array<{ name: string; inverted: boolean; variables: string[] }>;
+}
+
+/** Thrown for unbalanced sections or an unknown filter — mirrors `TemplateParseError`. */
+class TemplateSyntaxError extends Error {}
+
+/**
+ * Escape the five characters significant in HTML text and both attribute
+ * quoting styles. Mirrors `escapeHtml` in interpolate.ts exactly.
+ */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Value filters. Mirrors the fixed one-entry registry in interpolate.ts. */
+const FILTERS: Record<string, (s: string) => string> = {
+  nl2br: (s) => s.replace(/\r\n|\r|\n/g, "<br>"),
+};
+
+type Token =
+  | { kind: "text"; value: string }
+  | {
+      kind: "var";
+      name: string;
+      raw: boolean;
+      optional: boolean;
+      filters: string[];
+      source: string;
+    }
+  | {
+      kind: "open";
+      name: string;
+      inverted: boolean;
+      optional: boolean;
+      source: string;
+    }
+  | { kind: "close"; name: string; source: string };
+
+/*
+ * Same two-alternate grammar as interpolate.ts's `TAG`: a strict `{{{...}}}`
+ * raw form and a strict `{{...}}` form, each requiring an exact matching
+ * brace count. A name is `\w+` or a bare `.` — no whitespace anywhere inside
+ * the tag, no dots in a real name. `{{ spaced }}` and `{{a.b}}` are left
+ * alone as literal text, exactly like the renderer, so the editor never
+ * flags a name the API wouldn't actually require.
+ */
+const TAG =
+  /\{\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}\}|\{\{([#^/]?)(\w+|\.)(\?)?((?:\|\w+)*)\}\}/g;
+
+function tokenize(template: string): Token[] {
+  const tokens: Token[] = [];
+  let lastIndex = 0;
+  TAG.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = TAG.exec(template)) !== null) {
+    const [
+      source,
+      rawSigil,
+      rawName,
+      rawOptional,
+      rawFilterClause,
+      plainSigil,
+      plainName,
+      plainOptional,
+      plainFilterClause,
+    ] = match;
+
+    const raw = rawName !== undefined;
+    const sigil = raw ? rawSigil : plainSigil;
+    const name = raw ? rawName : plainName;
+    const optional = raw ? rawOptional : plainOptional;
+    const filterClause = raw ? rawFilterClause : plainFilterClause;
+
+    if (match.index > lastIndex) {
+      tokens.push({
+        kind: "text",
+        value: template.slice(lastIndex, match.index),
+      });
+    }
+    lastIndex = match.index + source.length;
+
+    if (sigil === "/") {
+      tokens.push({ kind: "close", name, source });
+      continue;
+    }
+    if (sigil === "#" || sigil === "^") {
+      tokens.push({
+        kind: "open",
+        name,
+        inverted: sigil === "^",
+        optional: Boolean(optional),
+        source,
+      });
+      continue;
+    }
+
+    const filters = (filterClause ?? "").split("|").filter(Boolean);
+    for (const f of filters) {
+      if (!(f in FILTERS)) {
+        throw new TemplateSyntaxError(
+          `Unknown filter "${f}" in ${source}. Available filters: ${Object.keys(FILTERS).join(", ")}.`,
+        );
+      }
+    }
+
+    tokens.push({
+      kind: "var",
+      name,
+      raw,
+      optional: Boolean(optional),
+      filters,
+      source,
+    });
+  }
+
+  if (lastIndex < template.length) {
+    tokens.push({ kind: "text", value: template.slice(lastIndex) });
+  }
+  return tokens;
+}
+
+type Node =
+  | { kind: "text"; value: string }
+  | {
+      kind: "var";
+      name: string;
+      raw: boolean;
+      optional: boolean;
+      filters: string[];
+      source: string;
+    }
+  | {
+      kind: "section";
+      name: string;
+      inverted: boolean;
+      optional: boolean;
+      children: Node[];
+    };
+
+/** Mirrors `MAX_SECTION_DEPTH` in interpolate.ts. */
+const MAX_SECTION_DEPTH = 64;
+
+/** Fold the token stream into a tree. Mirrors `parse` in interpolate.ts. */
+function parse(template: string): Node[] {
+  const root: Node[] = [];
+  const stack: Array<{
+    node: Extract<Node, { kind: "section" }>;
+    source: string;
+  }> = [];
+
+  const currentChildren = () =>
+    stack.length === 0 ? root : stack[stack.length - 1].node.children;
+
+  for (const token of tokenize(template)) {
+    switch (token.kind) {
+      case "text":
+      case "var":
+        currentChildren().push(token);
+        break;
+      case "open": {
+        if (stack.length >= MAX_SECTION_DEPTH) {
+          throw new TemplateSyntaxError(
+            `Sections nested too deeply at ${token.source} — the limit is ${MAX_SECTION_DEPTH} levels.`,
+          );
+        }
+        const node: Extract<Node, { kind: "section" }> = {
+          kind: "section",
+          name: token.name,
+          inverted: token.inverted,
+          optional: token.optional,
+          children: [],
+        };
+        currentChildren().push(node);
+        stack.push({ node, source: token.source });
+        break;
+      }
+      case "close": {
+        const open = stack.pop();
+        if (!open) {
+          throw new TemplateSyntaxError(
+            `Unexpected ${token.source} — no section is open here.`,
+          );
+        }
+        if (open.node.name !== token.name) {
+          throw new TemplateSyntaxError(
+            `${token.source} does not match the open section ${open.source}.`,
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  if (stack.length > 0) {
+    throw new TemplateSyntaxError(
+      `Unclosed section ${stack[stack.length - 1].source} — add a matching {{/${stack[stack.length - 1].node.name}}}.`,
+    );
+  }
+
+  return root;
+}
+
+/**
+ * Describe what a template needs and offers. Mirrors `analyzeTemplate` in
+ * interpolate.ts, including the recursive descendant collection: a
+ * section's `variables` list includes names from sub-sections nested inside
+ * it too, because only the outermost section of a nest is a top-level
+ * caller contract — the same reason nested sections don't get their own
+ * top-level `sections` entry here either.
+ */
+export function analyzeTemplateClient(...sources: string[]): TemplateAnalysis {
+  const required = new Set<string>();
+  const optional = new Set<string>();
+  const sectionsByName = new Map<
+    string,
+    TemplateAnalysis["sections"][number]
+  >();
+
+  function collectInner(nodes: Node[], into: Set<string>): void {
+    for (const node of nodes) {
+      if (node.kind === "var") {
+        if (node.name !== ".") into.add(node.name);
+      } else if (node.kind === "section") {
+        into.add(node.name);
+        collectInner(node.children, into);
+      }
+    }
+  }
+
+  function walkTopLevel(nodes: Node[]): void {
+    for (const node of nodes) {
+      if (node.kind === "text") continue;
+      if (node.kind === "var") {
+        if (node.name === ".") continue;
+        (node.optional ? optional : required).add(node.name);
+        continue;
+      }
+      if (node.name !== ".") {
+        (node.inverted || node.optional ? optional : required).add(node.name);
+      }
+      const inner = new Set<string>();
+      collectInner(node.children, inner);
+
+      const existing = sectionsByName.get(node.name);
+      if (existing) {
+        for (const v of inner) {
+          if (!existing.variables.includes(v)) existing.variables.push(v);
+        }
+      } else {
+        sectionsByName.set(node.name, {
+          name: node.name,
+          inverted: node.inverted,
+          variables: Array.from(inner),
+        });
+      }
+    }
+  }
+
+  for (const source of sources) walkTopLevel(parse(source));
+
+  // A name that is required somewhere is required overall.
+  for (const name of required) optional.delete(name);
+
+  return {
+    required: Array.from(required),
+    optional: Array.from(optional),
+    sections: Array.from(sectionsByName.values()),
+  };
+}
+
+/**
+ * Placeholder values so the live preview renders sections as content
+ * instead of showing literal `{{#items}}` tags. Two items per section so a
+ * loop visibly repeats rather than looking like a single conditional block.
+ */
+export function sampleValues(
+  analysis: TemplateAnalysis,
+): Record<string, unknown> {
+  const vars: Record<string, unknown> = {};
+  for (const name of [...analysis.required, ...analysis.optional]) {
+    vars[name] = `<${name}>`;
+  }
+  for (const section of analysis.sections) {
+    vars[section.name] = [0, 1].map(() =>
+      Object.fromEntries(section.variables.map((v) => [v, `<${v}>`])),
+    );
+  }
+  return vars;
+}
+
+/* ------------------------------- rendering ------------------------------- */
+/* Mirrors renderNodes/renderSection/lookup/isTruthy/stringify in
+ * interpolate.ts. Preview only ever renders the HTML body, so — unlike the
+ * worker, which also renders a plain-text subject — this always escapes. */
+
+type Frame = TemplateValue;
+
+interface Lookup {
+  found: boolean;
+  value: TemplateValue;
+}
+
+function hasOwn(obj: object, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, name);
+}
+
+function lookup(stack: Frame[], name: string): Lookup {
+  if (name === ".") {
+    return { found: stack.length > 0, value: stack[stack.length - 1] };
+  }
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const frame = stack[i];
+    if (
+      frame &&
+      typeof frame === "object" &&
+      !Array.isArray(frame) &&
+      hasOwn(frame, name)
+    ) {
+      return {
+        found: true,
+        value: (frame as Record<string, TemplateValue>)[name],
+      };
+    }
+  }
+  return { found: false, value: undefined };
+}
+
+function stringify(value: TemplateValue): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return "";
+  return String(value);
+}
+
+function isTruthy(value: TemplateValue): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  if (value === null || value === undefined) return false;
+  if (typeof value === "object") return true;
+  return Boolean(value);
+}
+
+function applyFilters(value: string, filters: string[]): string {
+  return filters.reduce((acc, f) => FILTERS[f](acc), value);
+}
+
+function renderNodes(
+  nodes: Node[],
+  stack: Frame[],
+  inSection: boolean,
+): string {
+  let out = "";
+  for (const node of nodes) {
+    if (node.kind === "text") {
+      out += node.value;
+      continue;
+    }
+    if (node.kind === "var") {
+      const { found, value } = lookup(stack, node.name);
+      if (!found) {
+        out += node.optional || inSection ? "" : node.source;
+        continue;
+      }
+      const text = node.raw ? stringify(value) : escapeHtml(stringify(value));
+      out += applyFilters(text, node.filters);
+      continue;
+    }
+    out += renderSection(node, stack);
+  }
+  return out;
+}
+
+function renderSection(
+  node: Extract<Node, { kind: "section" }>,
+  stack: Frame[],
+): string {
+  const { value } = lookup(stack, node.name);
+  const truthy = isTruthy(value);
+  // A section body is always "in section" once entered, at any depth.
+  const inner = true;
+
+  if (node.inverted)
+    return truthy ? "" : renderNodes(node.children, stack, inner);
+  if (!truthy) return "";
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => renderNodes(node.children, [...stack, item], inner))
+      .join("");
+  }
+  if (value && typeof value === "object") {
+    return renderNodes(node.children, [...stack, value], inner);
+  }
+  return renderNodes(node.children, stack, inner);
+}
+
+/**
+ * Render a template against sample values for the live preview. Throws on
+ * an unbalanced section or unknown filter (mid-edit is a normal state to be
+ * in) — callers should catch and fall back to showing the raw source.
+ */
+export function renderPreview(
+  template: string,
+  variables: Record<string, unknown>,
+): string {
+  return renderNodes(parse(template), [variables as TemplateValue], false);
+}

--- a/src/pages/SequenceEditorPage.tsx
+++ b/src/pages/SequenceEditorPage.tsx
@@ -25,6 +25,7 @@ import {
   type SequenceStep,
   type EmailTemplate,
 } from "@/lib/api";
+import { analyzeTemplateClient } from "@/lib/template-syntax";
 import { cn } from "@/lib/utils";
 
 /** Round delay-hours into a friendlier string for the summary line. */
@@ -371,38 +372,69 @@ function ApiReferenceCard({
 }) {
   const [open, setOpen] = useState(false);
 
-  // Walk the templates referenced by the sequence's steps and gather
-  // every {{var}} they need. The enrollment endpoint validates that
-  // these are present in `variables` on the request body.
-  const { allVars, perTemplate } = useMemo(() => {
+  // Walk the templates referenced by the sequence's steps and gather the names
+  // a caller must supply. The enrollment endpoint validates these against
+  // `variables` on the request body.
+  //
+  // Analyzed with the shared analyzer, not a `{{(\w+)}}` scan. Once sections
+  // existed the regex was inverted from the real contract: it collected
+  // `{{price}}` from inside a `{{#items}}` body — which resolves per item and
+  // is never required — while missing `{{#items}}` itself, which is. The
+  // snippet below is meant to be copied and run, so it advertised names the
+  // endpoint ignores and omitted the one it rejects the request for.
+  const { allVars, perTemplate, sectionFields } = useMemo(() => {
     const usedSlugs = new Set(steps.map((s) => s.templateSlug).filter(Boolean));
     const usedTemplates = templates.filter((t) => usedSlugs.has(t.slug));
     const all = new Set<string>();
     const per: { slug: string; name: string; vars: string[] }[] = [];
-    const re = /\{\{(\w+)\}\}/g;
+    // Section name -> the names its body references, so the sample payload can
+    // show an array of objects instead of a string a section cannot use.
+    const sections = new Map<string, string[]>();
     for (const t of usedTemplates) {
-      const local = new Set<string>();
-      for (const src of [t.subject, t.bodyHtml]) {
-        let m: RegExpExecArray | null;
-        while ((m = re.exec(src)) !== null) {
-          local.add(m[1]);
-          all.add(m[1]);
-        }
+      let analysis;
+      try {
+        analysis = analyzeTemplateClient(t.subject, t.bodyHtml);
+      } catch {
+        // A template stored before write-time validation may not parse. Skip
+        // it rather than dropping the whole snippet.
+        continue;
       }
-      if (local.size > 0) {
-        per.push({
-          slug: t.slug,
-          name: t.name,
-          vars: Array.from(local),
-        });
+      for (const s of analysis.sections) {
+        if (!sections.has(s.name)) sections.set(s.name, s.variables);
+      }
+      for (const v of analysis.required) all.add(v);
+      if (analysis.required.length > 0) {
+        per.push({ slug: t.slug, name: t.name, vars: analysis.required });
       }
     }
-    return { allVars: Array.from(all), perTemplate: per };
+    return {
+      allVars: Array.from(all),
+      perTemplate: per,
+      sectionFields: sections,
+    };
   }, [steps, templates]);
 
   const varsObj =
     allVars.length > 0
-      ? Object.fromEntries(allVars.map((v) => [v, `<${v.toUpperCase()}>`]))
+      ? Object.fromEntries(
+          allVars.map((v) => {
+            const fields = sectionFields.get(v);
+            // A required section takes an ARRAY of items. Emitting a string
+            // here passes validation and then renders one row with every field
+            // blank — the enroll succeeds and the mail is silently wrong.
+            if (fields) {
+              return [
+                v,
+                [
+                  Object.fromEntries(
+                    fields.map((f) => [f, `<${f.toUpperCase()}>`]),
+                  ),
+                ],
+              ];
+            }
+            return [v, `<${v.toUpperCase()}>`];
+          }),
+        )
       : undefined;
 
   const endpoint = `${typeof window !== "undefined" ? window.location.origin : ""}/api/sequences/${sequenceId}/enroll`;

--- a/src/pages/TemplateEditorPage.tsx
+++ b/src/pages/TemplateEditorPage.tsx
@@ -21,8 +21,11 @@ import {
 import { fetchTemplate, createTemplate, updateTemplate } from "@/lib/api";
 import {
   analyzeTemplateClient,
-  sampleValues,
+  chipLabel,
+  isSectionName,
   renderPreview,
+  sampleValues,
+  sectionChipLabel,
   type TemplateAnalysis,
 } from "@/lib/template-syntax";
 import { cn } from "@/lib/utils";
@@ -85,7 +88,6 @@ export default function TemplateEditorPage() {
       return EMPTY_ANALYSIS;
     }
   }, [subject, bodyHtml]);
-  const variables = analysis.required;
 
   const previewHtml = useMemo(() => {
     try {
@@ -366,10 +368,7 @@ export default function TemplateEditorPage() {
         <SyntaxCard />
 
         {/* --- API reference (collapsible, no longer a slide-over) --- */}
-        <ApiReferenceCard
-          slug={slugValue || slug || ""}
-          variables={variables}
-        />
+        <ApiReferenceCard slug={slugValue || slug || ""} analysis={analysis} />
       </form>
     </PageContainer>
   );
@@ -439,28 +438,6 @@ function ToggleButton({
 
 /** Whether `name` belongs to a section, so plain-variable groups can skip it
  *  — a section already gets its own chip with the correct sigil below. */
-function isSectionName(analysis: TemplateAnalysis, name: string): boolean {
-  return analysis.sections.some((s) => s.name === name);
-}
-
-/**
- * The exact tag text for a section's chip. Must always be a string that
- * really appears in the template — never a syntax that contradicts it:
- *   - inverted (`{{^key}}`) always renders that way, `?` or not, since
- *     inversion alone already makes it optional.
- *   - a non-inverted section that's optional (`analysis.optional` includes
- *     it) got there via a trailing `?`, so it renders as `{{#key?}}`.
- *   - otherwise it's a plain required section, `{{#key}}`.
- */
-function sectionChipLabel(
-  section: TemplateAnalysis["sections"][number],
-  analysis: TemplateAnalysis,
-): string {
-  if (section.inverted) return `{{^${section.name}}}`;
-  if (analysis.optional.includes(section.name)) return `{{#${section.name}?}}`;
-  return `{{#${section.name}}}`;
-}
-
 function VarGroup({
   label,
   items,
@@ -640,19 +617,33 @@ function SyntaxCard() {
 
 function ApiReferenceCard({
   slug,
-  variables,
+  analysis,
 }: {
   slug: string;
-  variables: string[];
+  analysis: TemplateAnalysis;
 }) {
   const [open, setOpen] = useState(false);
+  const variables = analysis.required;
 
+  // A required section name takes an ARRAY of items, not a string. Emitting
+  // `"items": "<items>"` here would have the reader send a scalar, which
+  // passes validation and then renders one row with every field blank — the
+  // send succeeds and the email is silently wrong. (A required section is
+  // always non-inverted; an inverted one is optional by definition.)
+  const sectionsByName = new Map(analysis.sections.map((s) => [s.name, s]));
   const varsObject = variables.reduce(
     (acc, v) => {
-      acc[v] = `<${v}>`;
+      const section = sectionsByName.get(v);
+      acc[v] = section
+        ? [
+            Object.fromEntries(
+              section.variables.map((inner) => [inner, `<${inner}>`]),
+            ),
+          ]
+        : `<${v}>`;
       return acc;
     },
-    {} as Record<string, string>,
+    {} as Record<string, unknown>,
   );
 
   const curlBody = JSON.stringify(
@@ -725,7 +716,7 @@ function ApiReferenceCard({
                     className="rounded-full bg-violet/10 px-2 py-0.5 text-[11px] font-mono"
                     style={{ color: "#7c5cfc" }}
                   >
-                    {`{{${v}}}`}
+                    {chipLabel(v, analysis)}
                   </code>
                 ))}
               </div>

--- a/src/pages/TemplateEditorPage.tsx
+++ b/src/pages/TemplateEditorPage.tsx
@@ -2,10 +2,10 @@ import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   ArrowLeft,
+  BookOpen,
   ChevronDown,
   Code2,
   Eye,
-  Hash,
   Sparkles,
   Wand2,
 } from "lucide-react";
@@ -19,20 +19,19 @@ import {
   SectionHeader,
 } from "@/components/PageForm";
 import { fetchTemplate, createTemplate, updateTemplate } from "@/lib/api";
+import {
+  analyzeTemplateClient,
+  sampleValues,
+  renderPreview,
+  type TemplateAnalysis,
+} from "@/lib/template-syntax";
 import { cn } from "@/lib/utils";
 
-/** Extract {{variableName}} tokens from any number of source strings. */
-function extractVariables(...sources: string[]): string[] {
-  const vars = new Set<string>();
-  for (const src of sources) {
-    const regex = /\{\{(\w+)\}\}/g;
-    let m: RegExpExecArray | null;
-    while ((m = regex.exec(src)) !== null) {
-      vars.add(m[1]);
-    }
-  }
-  return Array.from(vars);
-}
+const EMPTY_ANALYSIS: TemplateAnalysis = {
+  required: [],
+  optional: [],
+  sections: [],
+};
 
 /** Lightweight HTML pretty-printer for the "Format" button — adds line
  *  breaks between adjacent tags and indents nested blocks. */
@@ -76,10 +75,26 @@ export default function TemplateEditorPage() {
   const [loading, setLoading] = useState(isEdit);
   const [viewMode, setViewMode] = useState<ViewMode>("split");
 
-  const variables = useMemo(
-    () => extractVariables(subject, bodyHtml),
-    [subject, bodyHtml],
-  );
+  // A section left open mid-keystroke (e.g. typing "{{#items}}" before its
+  // closing tag) is a normal, transient state, not a bug — fall back to an
+  // empty analysis rather than crashing the page on every keystroke.
+  const analysis = useMemo(() => {
+    try {
+      return analyzeTemplateClient(subject, bodyHtml);
+    } catch {
+      return EMPTY_ANALYSIS;
+    }
+  }, [subject, bodyHtml]);
+  const variables = analysis.required;
+
+  const previewHtml = useMemo(() => {
+    try {
+      return renderPreview(bodyHtml, sampleValues(analysis));
+    } catch {
+      // Unbalanced sections mid-edit are normal — show the source instead.
+      return bodyHtml;
+    }
+  }, [bodyHtml, analysis]);
 
   useEffect(() => {
     if (!slug) return;
@@ -265,23 +280,33 @@ export default function TemplateEditorPage() {
             </div>
           </div>
 
-          {/* Inline auto-detected variables. Blank when none, so the strip
-              doesn't take space until something useful shows up. */}
-          {variables.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 border-b border-border bg-bg-subtle/40 px-5 py-2.5">
-              <Hash size={11} className="text-text-tertiary" />
-              <span className="text-[10px] font-medium uppercase tracking-wider text-text-tertiary">
-                Variables
-              </span>
-              {variables.map((v) => (
-                <code
-                  key={v}
-                  className="rounded-full bg-violet/10 px-2 py-0.5 text-[11px] font-mono"
-                  style={{ color: "#7c5cfc" }}
-                >
-                  {`{{${v}}}`}
-                </code>
-              ))}
+          {/* Inline auto-detected variables, grouped by contract: required
+              names fail the send if missing, optional ones render empty,
+              and sections need an array/object rather than a plain value.
+              Blank when none, so the strip doesn't take space until
+              something useful shows up. */}
+          {(analysis.required.length > 0 ||
+            analysis.optional.length > 0 ||
+            analysis.sections.length > 0) && (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-bg-subtle/40 px-5 py-2.5">
+              <VarGroup
+                label="Required"
+                names={analysis.required}
+                render={(v) => `{{${v}}}`}
+                className="bg-violet/10 text-[#7c5cfc]"
+              />
+              <VarGroup
+                label="Optional"
+                names={analysis.optional}
+                render={(v) => `{{${v}?}}`}
+                className="bg-bg-muted text-text-secondary"
+              />
+              <VarGroup
+                label="Sections"
+                names={analysis.sections.map((s) => s.name)}
+                render={(v) => `{{#${v}}}`}
+                className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+              />
             </div>
           )}
 
@@ -316,7 +341,7 @@ export default function TemplateEditorPage() {
                   <iframe
                     title="Email preview"
                     sandbox="allow-same-origin"
-                    srcDoc={bodyHtml}
+                    srcDoc={previewHtml}
                     className="h-full w-full"
                   />
                 </div>
@@ -324,6 +349,9 @@ export default function TemplateEditorPage() {
             )}
           </div>
         </section>
+
+        {/* --- Syntax & styling reference (collapsible) --- */}
+        <SyntaxCard />
 
         {/* --- API reference (collapsible, no longer a slide-over) --- */}
         <ApiReferenceCard
@@ -392,6 +420,180 @@ function ToggleButton({
       <Icon size={11} />
       {label}
     </button>
+  );
+}
+
+/* ------------------------------- variable chips ------------------------------- */
+
+function VarGroup({
+  label,
+  names,
+  render,
+  className,
+}: {
+  label: string;
+  names: string[];
+  render: (name: string) => string;
+  className: string;
+}) {
+  if (names.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-text-tertiary">
+        {label}
+      </span>
+      {names.map((n) => (
+        <code
+          key={n}
+          className={cn(
+            "rounded-full px-2 py-0.5 font-mono text-[11px]",
+            className,
+          )}
+        >
+          {render(n)}
+        </code>
+      ))}
+    </div>
+  );
+}
+
+/* --------------------------- syntax & styling card --------------------------- */
+
+const SYNTAX_ROWS: Array<{ tag: string; meaning: string }> = [
+  {
+    tag: "{{key}}",
+    meaning: "Value, HTML-escaped. Safe for user-generated content.",
+  },
+  {
+    tag: "{{{key}}}",
+    meaning: "Value, raw. Only for HTML you generated yourself.",
+  },
+  {
+    tag: "{{key?}}",
+    meaning: "Optional — renders empty instead of failing the send.",
+  },
+  { tag: "{{key|nl2br}}", meaning: "Escaped, then newlines become <br>." },
+  {
+    tag: "{{#key}}…{{/key}}",
+    meaning: "Renders if truthy; repeats for each item in an array.",
+  },
+  {
+    tag: "{{^key}}…{{/key}}",
+    meaning: "Renders only if the value is missing or empty.",
+  },
+  {
+    tag: "{{.}}",
+    meaning: "The current item, inside a list of plain strings.",
+  },
+];
+
+const LOOP_SNIPPET = `<table>
+  {{#items}}
+    <tr>
+      <td>{{label}}</td>
+      <td>{{currency}}{{price}}</td>
+    </tr>
+  {{/items}}
+</table>
+{{^items}}
+  <p>Nothing to show yet.</p>
+{{/items}}`;
+
+const MULTILINE_SNIPPET = `<div style="white-space: pre-line">
+  {{message}}
+</div>`;
+
+function SyntaxCard() {
+  const [open, setOpen] = useState(false);
+  return (
+    <section className="overflow-hidden rounded-[8px] bg-card ring-1 ring-border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-start justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-bg-muted/30"
+      >
+        <div className="min-w-0">
+          <h2 className="inline-flex items-center gap-1.5 text-sm font-semibold text-text-primary">
+            <BookOpen size={13} className="text-text-tertiary" />
+            Syntax &amp; styling
+          </h2>
+          <p className="mt-0.5 text-xs font-light text-text-secondary">
+            Every tag you can use, and the styles worth knowing about.
+          </p>
+        </div>
+        <ChevronDown
+          size={16}
+          className={cn(
+            "shrink-0 text-text-tertiary transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="space-y-5 border-t border-border px-5 py-5">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <tbody>
+                {SYNTAX_ROWS.map((row) => (
+                  <tr
+                    key={row.tag}
+                    className="border-b border-border/60 last:border-0"
+                  >
+                    <td className="whitespace-nowrap py-2 pr-4 align-top">
+                      <code className="rounded bg-bg-muted px-1.5 py-0.5 font-mono text-[11px]">
+                        {row.tag}
+                      </code>
+                    </td>
+                    <td className="py-2 font-light text-text-secondary">
+                      {row.meaning}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <Field
+            label="Lists and empty states"
+            hint="Names inside a section match the item first, then fall back to the top level — so {{currency}} can live outside {{#items}}."
+          >
+            <CodeBlock value={LOOP_SNIPPET} />
+          </Field>
+
+          <Field
+            label="Multi-line values"
+            hint="HTML collapses newlines to spaces. Use {{message|nl2br}}, or keep the line breaks with a style on the wrapping block."
+          >
+            <CodeBlock value={MULTILINE_SNIPPET} />
+          </Field>
+
+          <div className="rounded-[6px] border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs font-light text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+            <strong className="font-medium">Escaped by default.</strong> A value
+            containing HTML renders as visible text, so content typed by your
+            users can't inject markup into an email signed by your domain. Use{" "}
+            <code className="rounded bg-amber-100 px-1 font-mono dark:bg-amber-500/20">
+              {`{{{key}}}`}
+            </code>{" "}
+            only for HTML your own code produced.
+          </div>
+
+          <div className="rounded-[6px] border border-border bg-bg-subtle/50 px-3 py-2.5 text-xs font-light text-text-secondary">
+            <strong className="font-medium text-text-primary">
+              Adding a variable affects live senders.
+            </strong>{" "}
+            A new{" "}
+            <code className="rounded bg-bg-muted px-1 font-mono">{`{{key}}`}</code>{" "}
+            takes effect the moment you save, and callers that don't send it
+            start failing with 400. Deploy the caller first, or mark it optional
+            with{" "}
+            <code className="rounded bg-bg-muted px-1 font-mono">{`{{key?}}`}</code>
+            .
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/pages/TemplateEditorPage.tsx
+++ b/src/pages/TemplateEditorPage.tsx
@@ -587,12 +587,22 @@ function SyntaxCard() {
 
           <div className="rounded-[6px] border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs font-light text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
             <strong className="font-medium">Escaped by default.</strong> A value
-            containing HTML renders as visible text, so content typed by your
-            users can't inject markup into an email signed by your domain. Use{" "}
+            containing HTML renders as visible text, so it can't introduce tags
+            into an email signed by your domain. Use{" "}
             <code className="rounded bg-amber-100 px-1 font-mono dark:bg-amber-500/20">
               {`{{{key}}}`}
             </code>{" "}
             only for HTML your own code produced.
+            <div className="mt-1.5">
+              Escaping covers <code className="font-mono">{`& < > " '`}</code>{" "}
+              only — it is not a URL check. Keep every attribute quoted (
+              <code className="font-mono">{`href="{{url}}"`}</code>, never{" "}
+              <code className="font-mono">{`href={{url}}`}</code>), and don't
+              put an untrusted value in an{" "}
+              <code className="font-mono">href</code> without checking its
+              scheme: <code className="font-mono">javascript:</code> passes
+              through.
+            </div>
           </div>
 
           <div className="rounded-[6px] border border-border bg-bg-subtle/50 px-3 py-2.5 text-xs font-light text-text-secondary">

--- a/src/pages/TemplateEditorPage.tsx
+++ b/src/pages/TemplateEditorPage.tsx
@@ -238,7 +238,8 @@ export default function TemplateEditorPage() {
                     <code className="rounded bg-bg-muted px-1 py-0.5 font-mono text-[10px]">
                       {`{{variable}}`}
                     </code>{" "}
-                    for placeholders.
+                    for placeholders. Plain text here, not HTML — values are
+                    substituted unescaped, unlike the body.
                   </>
                 }
               >
@@ -291,20 +292,31 @@ export default function TemplateEditorPage() {
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-bg-subtle/40 px-5 py-2.5">
               <VarGroup
                 label="Required"
-                names={analysis.required}
-                render={(v) => `{{${v}}}`}
+                // Section names get their own accurate chip (with the right
+                // sigil) in the Sections group below — showing them again
+                // here as bare `{{name}}` would be a string that never
+                // actually appears in the template.
+                items={analysis.required
+                  .filter((v) => !isSectionName(analysis, v))
+                  .map((v) => ({ name: v, label: `{{${v}}}` }))}
                 className="bg-violet/10 text-[#7c5cfc]"
               />
               <VarGroup
                 label="Optional"
-                names={analysis.optional}
-                render={(v) => `{{${v}?}}`}
+                // Same exclusion: an inverted or `?`-marked section lands in
+                // `analysis.optional` too, but its optionality is already
+                // shown correctly (as ^ or #...?) in the Sections chip.
+                items={analysis.optional
+                  .filter((v) => !isSectionName(analysis, v))
+                  .map((v) => ({ name: v, label: `{{${v}?}}` }))}
                 className="bg-bg-muted text-text-secondary"
               />
               <VarGroup
                 label="Sections"
-                names={analysis.sections.map((s) => s.name)}
-                render={(v) => `{{#${v}}}`}
+                items={analysis.sections.map((s) => ({
+                  name: s.name,
+                  label: sectionChipLabel(s, analysis),
+                }))}
                 className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
               />
             </div>
@@ -425,32 +437,54 @@ function ToggleButton({
 
 /* ------------------------------- variable chips ------------------------------- */
 
+/** Whether `name` belongs to a section, so plain-variable groups can skip it
+ *  — a section already gets its own chip with the correct sigil below. */
+function isSectionName(analysis: TemplateAnalysis, name: string): boolean {
+  return analysis.sections.some((s) => s.name === name);
+}
+
+/**
+ * The exact tag text for a section's chip. Must always be a string that
+ * really appears in the template — never a syntax that contradicts it:
+ *   - inverted (`{{^key}}`) always renders that way, `?` or not, since
+ *     inversion alone already makes it optional.
+ *   - a non-inverted section that's optional (`analysis.optional` includes
+ *     it) got there via a trailing `?`, so it renders as `{{#key?}}`.
+ *   - otherwise it's a plain required section, `{{#key}}`.
+ */
+function sectionChipLabel(
+  section: TemplateAnalysis["sections"][number],
+  analysis: TemplateAnalysis,
+): string {
+  if (section.inverted) return `{{^${section.name}}}`;
+  if (analysis.optional.includes(section.name)) return `{{#${section.name}?}}`;
+  return `{{#${section.name}}}`;
+}
+
 function VarGroup({
   label,
-  names,
-  render,
+  items,
   className,
 }: {
   label: string;
-  names: string[];
-  render: (name: string) => string;
+  items: Array<{ name: string; label: string }>;
   className: string;
 }) {
-  if (names.length === 0) return null;
+  if (items.length === 0) return null;
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <span className="text-[10px] font-medium uppercase tracking-wider text-text-tertiary">
         {label}
       </span>
-      {names.map((n) => (
+      {items.map((item) => (
         <code
-          key={n}
+          key={item.name}
           className={cn(
             "rounded-full px-2 py-0.5 font-mono text-[11px]",
             className,
           )}
         >
-          {render(n)}
+          {item.label}
         </code>
       ))}
     </div>
@@ -462,7 +496,8 @@ function VarGroup({
 const SYNTAX_ROWS: Array<{ tag: string; meaning: string }> = [
   {
     tag: "{{key}}",
-    meaning: "Value, HTML-escaped. Safe for user-generated content.",
+    meaning:
+      "Value, HTML-escaped in the body. The subject is plain text, so it's substituted unescaped there.",
   },
   {
     tag: "{{{key}}}",
@@ -476,6 +511,10 @@ const SYNTAX_ROWS: Array<{ tag: string; meaning: string }> = [
   {
     tag: "{{#key}}…{{/key}}",
     meaning: "Renders if truthy; repeats for each item in an array.",
+  },
+  {
+    tag: "{{#key?}}…{{/key}}",
+    meaning: "Same as {{#key}}, but doesn't fail the send if missing.",
   },
   {
     tag: "{{^key}}…{{/key}}",

--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -4,18 +4,31 @@ import { Plus, FileText, Pencil, Trash2, Hash } from "lucide-react";
 import { fetchTemplates, deleteTemplate } from "@/lib/api";
 import type { EmailTemplate } from "@/lib/api";
 import PageHeader, { PageContainer } from "@/components/PageHeader";
+import { analyzeTemplateClient } from "@/lib/template-syntax";
 
-/** Count {{varName}} tokens in subject + body — shown as a small badge
- *  on each template row so the list hints at template complexity at a
- *  glance without opening the editor. */
+/**
+ * Count the top-level names a caller can supply — shown as a small badge on
+ * each row so the list hints at template complexity without opening the editor.
+ *
+ * Counted with the shared analyzer rather than a `{{(\w+)}}` scan. The regex
+ * was wrong in both directions once sections existed: it counted `{{price}}`
+ * inside a `{{#items}}` body, which resolves per item and is not something a
+ * caller passes, and it missed `{{#items}}` itself, which is required. A
+ * template whose only tags live inside a loop showed a confident, entirely
+ * wrong number.
+ *
+ * Required and optional together, since the badge is about how much a template
+ * asks of its caller, not strictly about what would fail a send. A template
+ * stored before write-time validation existed may not parse; it counts as 0
+ * rather than breaking the list.
+ */
 function countVariables(t: EmailTemplate): number {
-  const re = /\{\{(\w+)\}\}/g;
-  const seen = new Set<string>();
-  for (const src of [t.subject, t.bodyHtml]) {
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(src)) !== null) seen.add(m[1]);
+  try {
+    const analysis = analyzeTemplateClient(t.subject, t.bodyHtml);
+    return new Set([...analysis.required, ...analysis.optional]).size;
+  } catch {
+    return 0;
   }
-  return seen.size;
 }
 
 export default function TemplatesPage() {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,7 @@
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] },
+    "paths": { "@/*": ["./src/*"], "@worker/*": ["./worker/src/*"] },
     "strict": false,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "references": [{ "path": "./tsconfig.app.json" }],
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] },
+    "paths": { "@/*": ["./src/*"], "@worker/*": ["./worker/src/*"] },
     "noImplicitAny": false,
     "skipLibCheck": true,
     "allowJs": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // The template engine is shared with the editor's live preview.
+      // `worker/src/lib/interpolate.ts` imports nothing and touches no
+      // Cloudflare globals, so it bundles for the browser as-is — the
+      // alternative is a second copy of the grammar to keep in sync.
+      "@worker": path.resolve(__dirname, "./worker/src"),
     },
     // Force a single React instance — prevents the "Invalid hook call" error
     // when lazy-loading @paper-design/shaders-react which can otherwise be


### PR DESCRIPTION
## Summary

Final PR in the stack, and the one closest to the original request: **hints on the possible styling, directly on the page that creates the template**.

PRs #228 and #229 built the renderer and the API. The editor had not caught up — it computed its variable list with the old flat regex, so for `{{#items}}{{price}}{{/items}}` it prompted for `price` (which the API does *not* require) and never prompted for `items` (which it does). Following the README produced a 400 with no field to fix it.

Stacked on #229 — review that first.

## Changes

**Variable chips, grouped and honest.** Required / Optional / Sections, each chip rendering the tag *as written in the template*: `{{^promo}}` for an inverted section, `{{#promo?}}` for an opted-out one, `{{name?}}` for an optional variable. A name never appears twice with contradictory syntax.

**A "Syntax & styling" card** beside the body editor, carrying the full tag table plus the guidance the request was really about:

- `white-space: pre-line` for blocks holding multi-line values, with a copyable snippet
- Why escaping is the default, what it actually covers (`& < > " '` — not unquoted attribute values, and not URL schemes: `href={{url}}` and `javascript:` both get through), and when `{{{key}}}` is appropriate
- That adding a variable to a live template breaks in-flight senders, so deploy the caller first or use `{{key?}}`
- A copyable `{{#items}}` / `{{^items}}` loop showing scope fallthrough

**Live preview** substitutes sample values, so a section renders as repeated content instead of literal `{{#items}}`. Guarded so a mid-edit unbalanced section falls back to the source rather than blanking the editor.

**`ReplyComposer`** had a second copy of the stale extractor with the same defect; it now shares the analyzer and labels section variables with the tag the template actually contains, with a note that arrays must be sent via the API.

**The editor now renders with the worker's own renderer.** `src/lib/template-syntax.ts` was a hand-copied duplicate of the whole tokenize → parse → render pipeline, kept in sync by a comment — and it had already drifted: the copy dropped the `escape` argument to `applyFilters` and validated filter names with `in` rather than `hasOwn`, so the editor accepted `{{x|toString}}` that the API rejects. `worker/src/lib/interpolate.ts` imports nothing and touches no Cloudflare globals, so it bundles for the browser as-is behind a `@worker` alias. The client module keeps only what the editor genuinely adds: sample values for the preview, and the chip labels.

**A `/create-saasmail-template` agent skill** (`.claude/skills/`), documenting the grammar as the code implements it rather than as Mustache implies it — strict `\w+` names with no dotted paths, `nl2br` as the only filter, section truthiness, scope fallthrough, the required-vs-optional send contract, and the depth caps. Templates are increasingly written by an agent asked to "add a welcome email", and the only prior guidance was the README table and the editor's own hint card, neither reachable from that context. Every `/variables` contract in its worked examples was produced by running the template through `analyzeTemplate` rather than reasoned about — three of the four differed from what the rules suggested on a first reading, which is also why the skill tells you to verify against `/variables` instead of trusting your own reading.

**Also fixes the API reference card**, which emitted `"items": "<items>"` for a required section. A scalar there passes validation and then renders one row with every field blank — the send succeeds and the email is silently wrong. It now emits an array of the section's own fields.

**Docs:** drops the changelog's "the template editor UI does not recognise sections yet — exercise section templates through the API until the follow-up lands" limitation. This stack *is* that follow-up, and it was the last thing in the release notes still describing the pre-stack editor.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — 6 pre-existing errors, none in files this PR touches. Note: the bare `yarn tsc --noEmit` this repo mandates compiles **zero** files (root `tsconfig.json` has `"files": []`), so it validates nothing; see the review notes.
- [x] `npx vite build` — confirms the `@worker` alias resolves in the browser bundle
- [x] `e2e/specs/templates.spec.ts` — 3/3 against a live dev server
- [x] Chip labels verified in a real browser across `{{#a}}`, `{{^b}}`, `{{#c?}}`, `{{d?}}` — one chip each, matching source verbatim
- [x] Full suite — **green on CI** (`vitest`, `test`, `playwright`, `prettier`, CodeQL all passing)

The analyzer-parity script that previously guarded the duplicated copy is gone, and deliberately so: there is no longer a second implementation to keep in sync, which is a stronger guarantee than a test asserting two copies agree.

## Notes for reviewers

**The duplication this PR originally defended is fully removed.** An earlier revision argued the copy in `src/lib/template-syntax.ts` was a deliberate call, since worker code isn't importable from the browser bundle, and proposed extracting a shared module as a follow-up. The premise was wrong — `interpolate.ts` has no Cloudflare dependencies and bundles as-is — so the follow-up is done here instead — across all four call sites.

**The last two copies of the old `/\{\{(\w+)\}\}/g` extractor are gone.** Review found them still living in `src/pages/SequenceEditorPage.tsx` (the enroll `curl` snippet) and `src/pages/TemplatesPage.tsx` (the variable-count badge). For a section template the old regex is exactly inverted from the contract — given `{{#items}}<td>{{label}}</td><td>{{price}}</td>{{/items}}` it emitted `{"orderId": "<ORDERID>", "label": "<LABEL>", "price": "<PRICE>"}` where the endpoint wants `{"orderId": "<ORDERID>", "items": [{"label": "<LABEL>", "price": "<PRICE>"}]}`: missing the one name the request is rejected for, advertising two the top level ignores. That snippet exists to be copied and run, so it handed the user a guaranteed 400 with no hint which field to add. Both now use the shared analyzer, and both degrade rather than throw on a template stored before write-time validation existed.

**One narrow edge case remains.** A name used as *both* a section and a bare scalar in one template (`{{#items}}x{{/items}}{{items}}`) gets a single `{{#items}}` chip in the Sections group; nothing separately indicates the scalar usage. The template shape is self-contradictory and already renders ambiguously, so surfacing both would arguably be more confusing than less.

The second edge case this PR originally listed — a name inverted in the subject and regular in the body keeping the first-seen `inverted` flag — **is fixed in #228**, which merges polarity across sources. The chip now correctly shows `{{#promo}}` and reports the name as required.

Together with #228 and #229, closes #112 and #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
