### PR TITLE
ci(release-drafter): apply version labels on fork pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,26 @@
 
 -
 
+## Release impact
+
+<!--
+Tick exactly one version bump. This applies the label that "Check PR labels"
+requires — without it the check stays red. Tick the change type too, so the
+release notes file this PR under the right heading.
+-->
+
+- [ ] Patch — bug fix or internal change, no new behaviour
+- [ ] Minor — new backwards-compatible behaviour
+- [ ] Major — breaking change
+
+<!-- Change type (optional, categorises the release notes): -->
+
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore
+
 ## Test plan
 
 <!-- How did you verify this works? Include commands run and/or scenarios exercised. -->

--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -1,0 +1,36 @@
+name: Autolabel PRs
+
+# Applies the major/minor/patch label that "Check PR labels" requires, based on
+# the checkboxes in the PR body (see .github/release-drafter.yml autolabeler).
+#
+# This is deliberately separate from the Release Drafter workflow, which runs on
+# `push` to main. On `pull_request`, the GITHUB_TOKEN is read-only for pull
+# requests opened from a fork, so the autolabeler silently cannot apply a label
+# and every outside contributor's PR stays red until a maintainer labels it by
+# hand. `pull_request_target` runs in the context of the base repository, so the
+# token can write labels — the same mechanism "Check PR labels" already uses.
+#
+# Safety: this job never checks out the pull request's code. It only reads PR
+# metadata through the API, so untrusted code from the fork is never executed.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  autolabel:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,7 +5,10 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
-  test:
+  # Named for what it checks. As `test` it surfaced on the PR page as a failing
+  # check called "test", which reads as the test suite having broken — when the
+  # actual message is only that a version label is missing.
+  verify-label:
     runs-on: ubuntu-latest
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,10 @@
 name: Release Drafter
 
+# Drafts the next release from merged PRs. Labelling happens in
+# pr-autolabel.yml, which needs `pull_request_target` to be able to write labels
+# on pull requests opened from a fork.
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, reopened, synchronize]
     branches:
       - main
 
@@ -20,5 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
+        with:
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Autolabelling now works on pull requests from forks.** `Check PR labels` requires one of `major`/`minor`/`patch`, but the autolabeler ran on `pull_request`, where the `GITHUB_TOKEN` is read-only for fork pull requests — so it could never apply the label, and an outside contributor's PR stayed red until a maintainer labelled it by hand. The autolabeler moves to its own `pull_request_target` workflow (the same event `Check PR labels` already uses) and the pull request template gains the version-bump checkboxes its regexes look for. The job checks out no pull request code, so untrusted code is never executed.
 - README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Autolabelling now works on pull requests from forks.** `Check PR labels` requires one of `major`/`minor`/`patch`, but the autolabeler ran on `pull_request`, where the `GITHUB_TOKEN` is read-only for fork pull requests — so it could never apply the label, and an outside contributor's PR stayed red until a maintainer labelled it by hand. The autolabeler moves to its own `pull_request_target` workflow (the same event `Check PR labels` already uses) and the pull request template gains the version-bump checkboxes its regexes look for. The job checks out no pull request code, so untrusted code is never executed.
+- The label check reports under its own name. Its job was called `test`, so a missing version label surfaced on the pull request page as a failing check named "test" — indistinguishable at a glance from the test suite going red, on a pull request where the suite had not run at all. It is now `verify-label`.
 - README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).
 
 ### Added


### PR DESCRIPTION
## Summary

`Check PR labels` fails any PR that carries none of `major`/`minor`/`patch`. Those labels are supposed to come from release-drafter's autolabeler — but it runs on `pull_request`, where the `GITHUB_TOKEN` is **read-only for pull requests opened from a fork**. So the labeler cannot write a label on exactly the PRs that need one, and an outside contributor (who also cannot self-label) is blocked until a maintainer intervenes by hand.

I hit this opening the other PRs in this batch, so it seemed worth fixing first.

## Changes

- Move autolabelling into its own workflow on `pull_request_target`, which runs in the base repository's context and can write labels. This is the same event `Check PR labels` already uses. The job **checks out no PR code** and only reads PR metadata through the API, so untrusted code from a fork is never executed.
- Release Drafter keeps drafting on `push` to main, now with `disable-autolabeler: true` so the two roles do not overlap.
- Add the version-bump checkboxes to the PR template. The autolabeler matches `/\[x] Patch/`, `/\[x] Minor/` and `/\[x] Major/` against the body and the template contained none of them, so there was nothing to match even where it had permission. Change-type checkboxes are included too, so merged PRs file under the right release-notes heading.

## Release impact

- [x] Patch — bug fix or internal change, no new behaviour

- [x] Chore

## Test plan

- [x] `yarn test`
- [x] Workflow YAML parsed and validated (triggers/jobs assert as expected)
- [x] `prettier --check` clean
- Behaviour itself is only observable on a real fork PR — this PR is one, so the checkboxes above should exercise it once merged.

## Notes for reviewers

`pull_request_target` deserves scrutiny, so to be explicit about the safety argument: the risk with that event is checking out and executing PR-head code with a privileged token. This job has no `actions/checkout` step at all and runs only `release-drafter` against the API. Permissions are `contents: read` + `pull-requests: write` and nothing else.

I split it from `release-drafter.yml` rather than adding a trigger there, so the release-drafting job keeps `contents: write` on `push` only and the fork-facing job never gets it.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed — n/a
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Updated docs — n/a
