### PR TITLE
fix(attachments): scope attachment reads to the caller's allowed inboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Attachment reads are scoped to the caller's allowed inboxes. `GET /api/attachments/{id}` and `/{id}/inline` looked the attachment up by id alone and never consulted `allowedInboxes`, so any authenticated user could read any attachment in the deployment — including from inboxes they hold no permission on — given only its id. Both routes now resolve the owning inbox through the attachment's message and apply the same check the email detail routes make: an inbound attachment is scoped by `emails.recipient`, a sent one by `sent_emails.from_address` (the external `to_address` is not an inbox anyone holds). An attachment the caller may not read answers `404`, not `403`, so the response does not confirm that the id exists. Every existing test in the suite authenticated as an admin, for whom `resolveAllowedInboxes` short-circuits, which is why this went unnoticed.
-- Inline attachments are no longer served with `Cache-Control: public`. The responses are authenticated mailbox content, and `public` licenses shared caches and proxies in front of the worker to store them and serve them to a different caller. They are now `private`, keeping the immutable long-lived caching in the requesting browser only.
+- Attachment reads are scoped to the caller's allowed inboxes. `GET /api/attachments/{id}` and `/{id}/inline` looked the attachment up by id alone, so any authenticated user could read any attachment in the deployment given only its id. Both routes now resolve the owning inbox through the attachment's message — `emails.recipient` for inbound, `sent_emails.from_address` for sent — and answer `404` when it is not allowed, so the response does not confirm the id exists.
+- Inline attachments are served with `Cache-Control: private` instead of `public`, so shared caches in front of the worker cannot store authenticated mailbox content and hand it to a different caller.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Attachment reads are scoped to the caller's allowed inboxes. `GET /api/attachments/{id}` and `/{id}/inline` looked the attachment up by id alone and never consulted `allowedInboxes`, so any authenticated user could read any attachment in the deployment — including from inboxes they hold no permission on — given only its id. Both routes now resolve the owning inbox through the attachment's message and apply the same check the email detail routes make: an inbound attachment is scoped by `emails.recipient`, a sent one by `sent_emails.from_address` (the external `to_address` is not an inbox anyone holds). An attachment the caller may not read answers `404`, not `403`, so the response does not confirm that the id exists. Every existing test in the suite authenticated as an admin, for whom `resolveAllowedInboxes` short-circuits, which is why this went unnoticed.
+- Inline attachments are no longer served with `Cache-Control: public`. The responses are authenticated mailbox content, and `public` licenses shared caches and proxies in front of the worker to store them and serve them to a different caller. They are now `private`, keeping the immutable long-lived caching in the requesting browser only.
+
 ### Fixed
 
 - README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Attachment reads are scoped to the caller's allowed inboxes. `GET /api/attachments/{id}` and `/{id}/inline` looked the attachment up by id alone, so any authenticated user could read any attachment in the deployment given only its id. Both routes now resolve the owning inbox through the attachment's message — `emails.recipient` for inbound, `sent_emails.from_address` for sent — and answer `404` when it is not allowed, so the response does not confirm the id exists.
 - Inline attachments are served with `Cache-Control: private` instead of `public`, so shared caches in front of the worker cannot store authenticated mailbox content and hand it to a different caller.
+- Attachment downloads sanitize the filename before interpolating it into `Content-Disposition` and add an RFC 5987 `filename*` field, so a stored filename carrying quotes or CR/LF can no longer inject headers or split the response.
 
 ### Fixed
 

--- a/worker/src/__tests__/attachments-router.test.ts
+++ b/worker/src/__tests__/attachments-router.test.ts
@@ -117,14 +117,12 @@ describe("attachments router", () => {
     });
   });
 
-  // Every test above authenticates as an admin, for whom resolveAllowedInboxes
-  // short-circuits to { isAdmin: true } — which is why an unscoped attachment
-  // read passed a full suite unnoticed. These exercise a member.
+  // Every test above authenticates as an admin, for whom scoping
+  // short-circuits. These need a member.
   describe("inbox scoping", () => {
     const MINE = "mine@saasmail.test";
     const THEIRS = "theirs@saasmail.test";
 
-    /** A member who may read MINE and nothing else. */
     async function createMember() {
       const { userId, apiKey: memberKey } = await createTestUser({
         id: "member1",
@@ -187,11 +185,7 @@ describe("attachments router", () => {
       });
     }
 
-    /**
-     * A sent attachment belongs to the inbox it was sent FROM. Scoping it by
-     * the external to_address instead would deny everything, and scoping it by
-     * nothing at all is the bug this suite covers.
-     */
+    // A sent attachment belongs to the inbox it was sent FROM.
     async function seedSent() {
       const now = Math.floor(Date.now() / 1000);
       await getDb()

--- a/worker/src/__tests__/attachments-router.test.ts
+++ b/worker/src/__tests__/attachments-router.test.ts
@@ -10,6 +10,8 @@ import {
   getDb,
 } from "./helpers";
 import { attachments } from "../db/attachments.schema";
+import { inboxPermissions } from "../db/inbox-permissions.schema";
+import { sentEmails } from "../db/sent-emails.schema";
 
 describe("attachments router", () => {
   let apiKey: string;
@@ -103,6 +105,181 @@ describe("attachments router", () => {
         apiKey,
       });
       expect(res.status).toBe(404);
+    });
+
+    it("does not license shared caches to store mailbox content", async () => {
+      await createTestAttachment();
+
+      const res = await authFetch("/api/attachments/att-1/inline", { apiKey });
+      const cacheControl = res.headers.get("Cache-Control") ?? "";
+      expect(cacheControl).toContain("private");
+      expect(cacheControl).not.toContain("public");
+    });
+  });
+
+  // Every test above authenticates as an admin, for whom resolveAllowedInboxes
+  // short-circuits to { isAdmin: true } — which is why an unscoped attachment
+  // read passed a full suite unnoticed. These exercise a member.
+  describe("inbox scoping", () => {
+    const MINE = "mine@saasmail.test";
+    const THEIRS = "theirs@saasmail.test";
+
+    /** A member who may read MINE and nothing else. */
+    async function createMember() {
+      const { userId, apiKey: memberKey } = await createTestUser({
+        id: "member1",
+        role: "member",
+        email: "member@test.com",
+      });
+      await getDb()
+        .insert(inboxPermissions)
+        .values({
+          userId,
+          email: MINE,
+          createdAt: Math.floor(Date.now() / 1000),
+          createdBy: null,
+        });
+      return memberKey;
+    }
+
+    async function putAttachment(opts: {
+      id: string;
+      emailId: string;
+      kind: "inbound" | "sent";
+    }) {
+      const r2Key = `attachments/${opts.emailId}/f.pdf`;
+      await env.R2.put(r2Key, new TextEncoder().encode("x"), {
+        httpMetadata: { contentType: "application/pdf" },
+      });
+      await getDb()
+        .insert(attachments)
+        .values({
+          id: opts.id,
+          emailId: opts.emailId,
+          kind: opts.kind,
+          filename: "f.pdf",
+          contentType: "application/pdf",
+          size: 1,
+          r2Key,
+          contentId: null,
+          createdAt: Math.floor(Date.now() / 1000),
+        });
+    }
+
+    async function seedInbound() {
+      await createTestPerson({ id: "s1", email: "ext@test.com" });
+      await createTestEmail({ id: "mine-1", personId: "s1", recipient: MINE });
+      await createTestEmail({
+        id: "theirs-1",
+        personId: "s1",
+        recipient: THEIRS,
+        messageId: "msg-2@example.com",
+      });
+      await putAttachment({
+        id: "att-mine",
+        emailId: "mine-1",
+        kind: "inbound",
+      });
+      await putAttachment({
+        id: "att-theirs",
+        emailId: "theirs-1",
+        kind: "inbound",
+      });
+    }
+
+    /**
+     * A sent attachment belongs to the inbox it was sent FROM. Scoping it by
+     * the external to_address instead would deny everything, and scoping it by
+     * nothing at all is the bug this suite covers.
+     */
+    async function seedSent() {
+      const now = Math.floor(Date.now() / 1000);
+      await getDb()
+        .insert(sentEmails)
+        .values([
+          {
+            id: "sent-mine",
+            personId: null,
+            fromAddress: MINE,
+            toAddress: "ext@test.com",
+            subject: "s",
+            sentAt: now,
+            createdAt: now,
+          },
+          {
+            id: "sent-theirs",
+            personId: null,
+            fromAddress: THEIRS,
+            toAddress: "ext@test.com",
+            subject: "s",
+            sentAt: now,
+            createdAt: now,
+          },
+        ]);
+      await putAttachment({
+        id: "att-sent-mine",
+        emailId: "sent-mine",
+        kind: "sent",
+      });
+      await putAttachment({
+        id: "att-sent-theirs",
+        emailId: "sent-theirs",
+        kind: "sent",
+      });
+    }
+
+    it("serves an inbound attachment from an inbox the member holds", async () => {
+      await seedInbound();
+      const memberKey = await createMember();
+
+      const res = await authFetch("/api/attachments/att-mine", {
+        apiKey: memberKey,
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("hides an inbound attachment from an inbox the member does not hold", async () => {
+      await seedInbound();
+      const memberKey = await createMember();
+
+      const res = await authFetch("/api/attachments/att-theirs", {
+        apiKey: memberKey,
+      });
+      expect(res.status).toBe(404);
+      // 404, not 403 — a 403 would confirm the id exists.
+      expect(await res.json()).toEqual({ error: "Attachment not found" });
+    });
+
+    it("hides an unauthorized attachment on the inline route too", async () => {
+      await seedInbound();
+      const memberKey = await createMember();
+
+      const res = await authFetch("/api/attachments/att-theirs/inline", {
+        apiKey: memberKey,
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("scopes a sent attachment by the inbox it was sent from", async () => {
+      await seedSent();
+      const memberKey = await createMember();
+
+      const mine = await authFetch("/api/attachments/att-sent-mine", {
+        apiKey: memberKey,
+      });
+      expect(mine.status).toBe(200);
+
+      const theirs = await authFetch("/api/attachments/att-sent-theirs", {
+        apiKey: memberKey,
+      });
+      expect(theirs.status).toBe(404);
+    });
+
+    it("still serves everything to an admin", async () => {
+      await seedInbound();
+
+      const res = await authFetch("/api/attachments/att-theirs", { apiKey });
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/worker/src/__tests__/attachments-router.test.ts
+++ b/worker/src/__tests__/attachments-router.test.ts
@@ -25,7 +25,7 @@ describe("attachments router", () => {
     ({ apiKey } = await createTestUser());
   });
 
-  async function createTestAttachment() {
+  async function createTestAttachment(filename = "test.pdf") {
     const db = getDb();
     await createTestPerson({ id: "s1", email: "a@test.com" });
     await createTestEmail({ id: "e1", personId: "s1" });
@@ -39,7 +39,7 @@ describe("attachments router", () => {
     await db.insert(attachments).values({
       id: "att-1",
       emailId: "e1",
-      filename: "test.pdf",
+      filename,
       contentType: "application/pdf",
       size: content.byteLength,
       r2Key,
@@ -63,6 +63,19 @@ describe("attachments router", () => {
         apiKey,
       });
       expect(res.status).toBe(404);
+    });
+
+    it("sanitizes filename in content-disposition header", async () => {
+      await createTestAttachment('te"st\r\nx.pdf');
+
+      const res = await authFetch("/api/attachments/att-1", { apiKey });
+      expect(res.status).toBe(200);
+      const contentDisposition = res.headers.get("Content-Disposition");
+      expect(contentDisposition).toBeTruthy();
+      expect(contentDisposition).toContain(`filename="te_stx.pdf"`);
+      expect(contentDisposition).toContain("filename*=UTF-8''te_stx.pdf");
+      expect(contentDisposition).not.toContain("\r");
+      expect(contentDisposition).not.toContain("\n");
     });
 
     it("returns 404 when R2 object missing", async () => {

--- a/worker/src/routers/attachments-router.ts
+++ b/worker/src/routers/attachments-router.ts
@@ -11,21 +11,10 @@ export const attachmentsRouter = new OpenAPIHono<{
   Variables: Variables;
 }>();
 
-/**
- * Fetch an attachment only if the caller owns the inbox of the message it
- * belongs to.
- *
- * The owning inbox differs by kind, and getting this backwards silently grants
- * access: an inbound attachment belongs to `emails.recipient` (the inbox that
- * received it), while a sent one belongs to `sent_emails.from_address` (the
- * inbox it was sent from) — the external `to_address` is not an inbox anyone
- * holds permission on. This mirrors the pair of checks the email detail routes
- * already make.
- *
- * Returns null both when the attachment does not exist and when the caller may
- * not read it, so callers answer 404 either way. A 403 would confirm that an
- * attachment id exists, which is most of what an id-guessing attacker wants.
- */
+// The owning inbox is `emails.recipient` for inbound and
+// `sent_emails.from_address` for sent — the external `to_address` is nobody's
+// inbox. Null covers both "missing" and "not allowed" so both answer 404; a 403
+// would confirm the id exists.
 async function findReadableAttachment(
   db: Variables["db"],
   allowed: NonNullable<Variables["allowedInboxes"]>,
@@ -52,7 +41,7 @@ async function findReadableAttachment(
           .where(eq(emails.id, att.emailId))
           .limit(1);
 
-  // An attachment whose message row is gone is unreachable rather than public.
+  // Orphaned attachment (message row gone) fails closed.
   if (owner.length === 0) return null;
   if (!isInboxAllowed(allowed, owner[0].inbox)) return null;
 
@@ -135,10 +124,8 @@ attachmentsRouter.openapi(inlineRoute, async (c) => {
       "Content-Type": att.contentType,
       "Content-Disposition": "inline",
       "Content-Length": att.size.toString(),
-      // `private`, not `public`: this is authenticated mailbox content, and
-      // `public` licenses shared caches and proxies in front of the worker to
-      // store it and hand it to a different caller. The body is immutable for
-      // a given id, so the requesting browser's own cache can still keep it.
+      // `public` would let shared caches serve this mailbox content to another
+      // caller.
       "Cache-Control": "private, max-age=31536000, immutable",
     },
   });

--- a/worker/src/routers/attachments-router.ts
+++ b/worker/src/routers/attachments-router.ts
@@ -1,6 +1,9 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { eq } from "drizzle-orm";
 import { attachments } from "../db/attachments.schema";
+import { emails } from "../db/emails.schema";
+import { sentEmails } from "../db/sent-emails.schema";
+import { isInboxAllowed } from "../lib/inbox-permissions";
 import type { Variables } from "../variables";
 
 export const attachmentsRouter = new OpenAPIHono<{
@@ -8,43 +11,90 @@ export const attachmentsRouter = new OpenAPIHono<{
   Variables: Variables;
 }>();
 
+/**
+ * Fetch an attachment only if the caller owns the inbox of the message it
+ * belongs to.
+ *
+ * The owning inbox differs by kind, and getting this backwards silently grants
+ * access: an inbound attachment belongs to `emails.recipient` (the inbox that
+ * received it), while a sent one belongs to `sent_emails.from_address` (the
+ * inbox it was sent from) — the external `to_address` is not an inbox anyone
+ * holds permission on. This mirrors the pair of checks the email detail routes
+ * already make.
+ *
+ * Returns null both when the attachment does not exist and when the caller may
+ * not read it, so callers answer 404 either way. A 403 would confirm that an
+ * attachment id exists, which is most of what an id-guessing attacker wants.
+ */
+async function findReadableAttachment(
+  db: Variables["db"],
+  allowed: NonNullable<Variables["allowedInboxes"]>,
+  id: string,
+) {
+  const rows = await db
+    .select()
+    .from(attachments)
+    .where(eq(attachments.id, id))
+    .limit(1);
+  if (rows.length === 0) return null;
+  const att = rows[0];
+
+  const owner =
+    att.kind === "sent"
+      ? await db
+          .select({ inbox: sentEmails.fromAddress })
+          .from(sentEmails)
+          .where(eq(sentEmails.id, att.emailId))
+          .limit(1)
+      : await db
+          .select({ inbox: emails.recipient })
+          .from(emails)
+          .where(eq(emails.id, att.emailId))
+          .limit(1);
+
+  // An attachment whose message row is gone is unreachable rather than public.
+  if (owner.length === 0) return null;
+  if (!isInboxAllowed(allowed, owner[0].inbox)) return null;
+
+  return att;
+}
+
 const downloadRoute = createRoute({
   method: "get",
   path: "/{id}",
   tags: ["Attachments"],
-  description: "Download an attachment from R2.",
+  description:
+    "Download an attachment from R2. Scoped to the caller's allowed inboxes.",
   request: {
     params: z.object({ id: z.string() }),
   },
   responses: {
     200: { description: "Attachment file" },
+    404: { description: "Attachment not found, or not in an allowed inbox" },
   },
 });
 
 attachmentsRouter.openapi(downloadRoute, async (c) => {
   const db = c.get("db");
+  const allowed = c.get("allowedInboxes")!;
   const { id } = c.req.valid("param");
 
-  const att = await db
-    .select()
-    .from(attachments)
-    .where(eq(attachments.id, id))
-    .limit(1);
-
-  if (att.length === 0) {
+  const att = await findReadableAttachment(db, allowed, id);
+  if (!att) {
     return c.json({ error: "Attachment not found" }, 404);
   }
 
-  const object = await c.env.R2.get(att[0].r2Key);
+  const object = await c.env.R2.get(att.r2Key);
   if (!object) {
     return c.json({ error: "File not found in storage" }, 404);
   }
 
   return new Response(object.body, {
     headers: {
-      "Content-Type": att[0].contentType,
-      "Content-Disposition": `attachment; filename="${att[0].filename}"`,
-      "Content-Length": att[0].size.toString(),
+      "Content-Type": att.contentType,
+      "Content-Disposition": `attachment; filename="${att.filename}"`,
+      "Content-Length": att.size.toString(),
+      "Cache-Control": "private, max-age=31536000, immutable",
     },
   });
 });
@@ -54,40 +104,42 @@ const inlineRoute = createRoute({
   method: "get",
   path: "/{id}/inline",
   tags: ["Attachments"],
-  description: "Serve an attachment inline (for embedded images).",
+  description:
+    "Serve an attachment inline (for embedded images). Scoped to the caller's allowed inboxes.",
   request: {
     params: z.object({ id: z.string() }),
   },
   responses: {
     200: { description: "Inline attachment" },
+    404: { description: "Attachment not found, or not in an allowed inbox" },
   },
 });
 
 attachmentsRouter.openapi(inlineRoute, async (c) => {
   const db = c.get("db");
+  const allowed = c.get("allowedInboxes")!;
   const { id } = c.req.valid("param");
 
-  const att = await db
-    .select()
-    .from(attachments)
-    .where(eq(attachments.id, id))
-    .limit(1);
-
-  if (att.length === 0) {
+  const att = await findReadableAttachment(db, allowed, id);
+  if (!att) {
     return c.json({ error: "Attachment not found" }, 404);
   }
 
-  const object = await c.env.R2.get(att[0].r2Key);
+  const object = await c.env.R2.get(att.r2Key);
   if (!object) {
     return c.json({ error: "File not found in storage" }, 404);
   }
 
   return new Response(object.body, {
     headers: {
-      "Content-Type": att[0].contentType,
+      "Content-Type": att.contentType,
       "Content-Disposition": "inline",
-      "Content-Length": att[0].size.toString(),
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Length": att.size.toString(),
+      // `private`, not `public`: this is authenticated mailbox content, and
+      // `public` licenses shared caches and proxies in front of the worker to
+      // store it and hand it to a different caller. The body is immutable for
+      // a given id, so the requesting browser's own cache can still keep it.
+      "Cache-Control": "private, max-age=31536000, immutable",
     },
   });
 });

--- a/worker/src/routers/attachments-router.ts
+++ b/worker/src/routers/attachments-router.ts
@@ -1,9 +1,10 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { attachments } from "../db/attachments.schema";
 import { emails } from "../db/emails.schema";
 import { sentEmails } from "../db/sent-emails.schema";
 import { isInboxAllowed } from "../lib/inbox-permissions";
+import { sanitizeFilename } from "../lib/sanitize-filename";
 import type { Variables } from "../variables";
 
 export const attachmentsRouter = new OpenAPIHono<{
@@ -13,39 +14,40 @@ export const attachmentsRouter = new OpenAPIHono<{
 
 // The owning inbox is `emails.recipient` for inbound and
 // `sent_emails.from_address` for sent — the external `to_address` is nobody's
-// inbox. Null covers both "missing" and "not allowed" so both answer 404; a 403
-// would confirm the id exists.
+// inbox. A single query left-joins the owner from whichever table `kind`
+// selects; the join predicate carries the `kind` test so only one side ever
+// matches. Null covers both "message row gone" (orphaned, fails closed) and
+// "not allowed" so both answer 404; a 403 would confirm the id exists.
 async function findReadableAttachment(
   db: Variables["db"],
   allowed: NonNullable<Variables["allowedInboxes"]>,
   id: string,
 ) {
   const rows = await db
-    .select()
+    .select({
+      attachment: attachments,
+      sentInbox: sentEmails.fromAddress,
+      inboundInbox: emails.recipient,
+    })
     .from(attachments)
+    .leftJoin(
+      emails,
+      and(ne(attachments.kind, "sent"), eq(emails.id, attachments.emailId)),
+    )
+    .leftJoin(
+      sentEmails,
+      and(eq(attachments.kind, "sent"), eq(sentEmails.id, attachments.emailId)),
+    )
     .where(eq(attachments.id, id))
     .limit(1);
   if (rows.length === 0) return null;
-  const att = rows[0];
+  const { attachment, sentInbox, inboundInbox } = rows[0];
 
-  const owner =
-    att.kind === "sent"
-      ? await db
-          .select({ inbox: sentEmails.fromAddress })
-          .from(sentEmails)
-          .where(eq(sentEmails.id, att.emailId))
-          .limit(1)
-      : await db
-          .select({ inbox: emails.recipient })
-          .from(emails)
-          .where(eq(emails.id, att.emailId))
-          .limit(1);
+  const owner = attachment.kind === "sent" ? sentInbox : inboundInbox;
+  // Null owner = orphaned message row (or unset address). Fail closed.
+  if (owner === null || !isInboxAllowed(allowed, owner)) return null;
 
-  // Orphaned attachment (message row gone) fails closed.
-  if (owner.length === 0) return null;
-  if (!isInboxAllowed(allowed, owner[0].inbox)) return null;
-
-  return att;
+  return attachment;
 }
 
 const downloadRoute = createRoute({
@@ -78,10 +80,15 @@ attachmentsRouter.openapi(downloadRoute, async (c) => {
     return c.json({ error: "File not found in storage" }, 404);
   }
 
+  // Sanitize before interpolating into the header: a raw filename can carry
+  // quotes or CR/LF and split the response. `filename*` (RFC 5987) carries the
+  // full value for clients that honour it.
+  const safeFilename = sanitizeFilename(att.filename).replaceAll('"', "_");
+
   return new Response(object.body, {
     headers: {
       "Content-Type": att.contentType,
-      "Content-Disposition": `attachment; filename="${att.filename}"`,
+      "Content-Disposition": `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodeURIComponent(safeFilename)}`,
       "Content-Length": att.size.toString(),
       "Cache-Control": "private, max-age=31536000, immutable",
     },


### PR DESCRIPTION
## Summary

`GET /api/attachments/{id}` and `/{id}/inline` looked an attachment up by id and served it, without ever consulting `allowedInboxes`. **Any authenticated user could read any attachment in the deployment given only its id**, including from inboxes they hold no permission on. It appears to be the one place in the API where inbox scoping is absent rather than enforced.

Found while reading the API surface; I have not tried it against a live deployment beyond the added tests.

## Changes

- Both routes resolve the owning inbox through the attachment's message and apply the same predicate the email detail routes use (`isInboxAllowed`).
- The owning inbox depends on `kind`. An inbound attachment belongs to `emails.recipient`; a **sent** one belongs to `sent_emails.from_address` — its `to_address` is the external correspondent, not an inbox anyone holds permission on. Scoping sent attachments by recipient would have been wrong in both directions.
- An attachment the caller may not read answers **404, not 403**, matching what `emails-router` already returns for the same reason: a 403 confirms the id exists.
- Inline responses stop advertising `Cache-Control: public`. These are authenticated mailbox bytes, and `public` licenses shared caches and proxies in front of the worker to store one caller's mail and serve it to another. Now `private`, keeping the immutable long-lived caching in the requesting browser where it is useful and harmless.

## Release impact

- [x] Patch — bug fix or internal change, no new behaviour

- [x] Bug Fix

## Test plan

- [x] `yarn test worker/src/__tests__/attachments-router.test.ts` — 11 passed
- [x] Verified the new tests **fail against the previous handler** (4 failures), so they actually cover the gap rather than just passing
- [x] Ran the full blast radius — attachments, emails, conversations, people, send, delete-email, delete-person, openapi-email-schemas — 82 passed
- [x] `prettier --check` clean

## Notes for reviewers

Worth knowing why a full suite never caught this: **every existing test in `attachments-router.test.ts` authenticates as an admin**, and `resolveAllowedInboxes` short-circuits to `{ isAdmin: true }` for admins, skipping all scoping. The path was structurally invisible to the tests that existed. The added cases run as a member with a single inbox grant and cover both routes and both kinds, plus an admin case to confirm nothing narrowed for them.

Happy to split the `Cache-Control` change into its own PR if you'd rather keep this to the authorization fix.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed — n/a
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Updated docs — n/a
