### PR TITLE
fix(notifications): stop notifying users who may not read mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Notifications are no longer delivered to users who may not read mail. Inbound fanout selected recipients from `inbox_permissions` plus admins and checked nothing else, so a **banned** user — refused everywhere else as "account suspended" — and a user with **no registered passkey** — refused by `requirePasskey` on every `/api/*` call — both kept receiving WebSocket frames and Web Push carrying the sender's name, the subject, and a 140-character body preview. That is mail content, not merely a signal that mail arrived, so it made "passkey registration is required to access data" false for anyone holding a subscription. Both conditions are now applied before delivery, with the passkey condition skipped in development exactly as `requirePasskey` and the MCP handler skip it.
+
 ### Fixed
 
 - README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).

--- a/worker/src/__tests__/notification-fanout.test.ts
+++ b/worker/src/__tests__/notification-fanout.test.ts
@@ -93,15 +93,8 @@ describe("computeFanoutTargets", () => {
   });
 });
 
-/**
- * `computeFanoutTargets` decides who is *interested*; this decides who is
- * *permitted*. The notification payload carries sender, subject and a body
- * preview, so a user the API refuses must not be sent one.
- *
- * The env is passed explicitly rather than taken from the ambient test
- * bindings, which set DISABLE_PASSKEY_GATE="true" — under those the passkey
- * branch never runs, so a test relying on them would assert nothing.
- */
+// Env is passed explicitly: the ambient test bindings set
+// DISABLE_PASSKEY_GATE="true", under which the passkey branch never runs.
 describe("filterNotifiableUsers", () => {
   const GATE_ON = { DISABLE_PASSKEY_GATE: "false" } as any;
   const GATE_OFF = { DISABLE_PASSKEY_GATE: "true" } as any;

--- a/worker/src/__tests__/notification-fanout.test.ts
+++ b/worker/src/__tests__/notification-fanout.test.ts
@@ -4,8 +4,10 @@
  * pure logic (union, dedupe, admin cap) that decides *who* gets notified.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { inArray } from "drizzle-orm";
 import {
   MAX_ADMIN_FANOUT,
+  ID_CHUNK_SIZE,
   computeFanoutTargets,
   filterNotifiableUsers,
 } from "../lib/notification-fanout";
@@ -190,5 +192,43 @@ describe("filterNotifiableUsers", () => {
 
   it("returns an empty list for no candidates without querying", async () => {
     expect(await filterNotifiableUsers(getDb(), GATE_ON, [])).toEqual([]);
+  });
+
+  // 250 spans three chunks, and the assertion below proves it breaks one query.
+  const OVER_CEILING = 250;
+  const overCeilingIds = Array.from(
+    { length: OVER_CEILING },
+    (_, i) => `bulk-${i}`,
+  );
+
+  it("cannot be queried in one statement at this size", async () => {
+    expect(OVER_CEILING).toBeGreaterThan(ID_CHUNK_SIZE);
+    await expect(
+      getDb()
+        .select({ id: users.id })
+        .from(users)
+        .where(inArray(users.id, overCeilingIds)),
+    ).rejects.toThrow();
+  });
+
+  it("notifies every eligible user past the ceiling", async () => {
+    const banned = new Set(["bulk-3", "bulk-101", "bulk-249"]);
+    const noPasskey = new Set(["bulk-7", "bulk-150", "bulk-200"]);
+    for (const id of overCeilingIds) {
+      await insertUser(id, { banned: banned.has(id) });
+      if (!noPasskey.has(id)) await givePasskey(id);
+    }
+
+    const result = await filterNotifiableUsers(
+      getDb(),
+      GATE_ON,
+      overCeilingIds,
+    );
+
+    const expected = overCeilingIds.filter(
+      (id) => !banned.has(id) && !noPasskey.has(id),
+    );
+    expect(result).toHaveLength(OVER_CEILING - 6);
+    expect(new Set(result)).toEqual(new Set(expected));
   });
 });

--- a/worker/src/__tests__/notification-fanout.test.ts
+++ b/worker/src/__tests__/notification-fanout.test.ts
@@ -3,11 +3,14 @@
  * itself is exercised indirectly via the router tests — this file covers the
  * pure logic (union, dedupe, admin cap) that decides *who* gets notified.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import {
   MAX_ADMIN_FANOUT,
   computeFanoutTargets,
+  filterNotifiableUsers,
 } from "../lib/notification-fanout";
+import { applyMigrations, cleanDb, getDb } from "./helpers";
+import { users, passkeys } from "../db/auth.schema";
 
 describe("computeFanoutTargets", () => {
   it("unions permission users and admins", () => {
@@ -87,5 +90,112 @@ describe("computeFanoutTargets", () => {
     });
     expect(userIds).toHaveLength(MAX_ADMIN_FANOUT);
     expect(adminTruncated).toBe(false);
+  });
+});
+
+/**
+ * `computeFanoutTargets` decides who is *interested*; this decides who is
+ * *permitted*. The notification payload carries sender, subject and a body
+ * preview, so a user the API refuses must not be sent one.
+ *
+ * The env is passed explicitly rather than taken from the ambient test
+ * bindings, which set DISABLE_PASSKEY_GATE="true" — under those the passkey
+ * branch never runs, so a test relying on them would assert nothing.
+ */
+describe("filterNotifiableUsers", () => {
+  const GATE_ON = { DISABLE_PASSKEY_GATE: "false" } as any;
+  const GATE_OFF = { DISABLE_PASSKEY_GATE: "true" } as any;
+
+  beforeAll(applyMigrations);
+  beforeEach(cleanDb);
+
+  async function insertUser(
+    id: string,
+    opts: { banned?: boolean; banExpires?: Date | null } = {},
+  ) {
+    const now = Date.now();
+    await getDb()
+      .insert(users)
+      .values({
+        id,
+        name: id,
+        email: `${id}@test.local`,
+        emailVerified: false,
+        createdAt: new Date(now),
+        updatedAt: new Date(now),
+        role: "member",
+        banned: opts.banned ?? false,
+        banExpires: opts.banExpires ?? null,
+      });
+  }
+
+  async function givePasskey(userId: string) {
+    await getDb()
+      .insert(passkeys)
+      .values({
+        id: `pk-${userId}`,
+        userId,
+        publicKey: "x",
+        credentialID: `cred-${userId}`,
+        counter: 0,
+        deviceType: "singleDevice",
+        backedUp: false,
+        transports: null,
+        createdAt: new Date(),
+      });
+  }
+
+  it("drops a banned user even in dev", async () => {
+    await insertUser("ok");
+    await insertUser("banned", { banned: true });
+
+    const result = await filterNotifiableUsers(getDb(), GATE_OFF, [
+      "ok",
+      "banned",
+    ]);
+    expect(result).toEqual(["ok"]);
+  });
+
+  it("keeps a user whose ban has expired", async () => {
+    await insertUser("expired", {
+      banned: true,
+      banExpires: new Date(Date.now() - 60_000),
+    });
+
+    const result = await filterNotifiableUsers(getDb(), GATE_OFF, ["expired"]);
+    expect(result).toEqual(["expired"]);
+  });
+
+  it("drops a user with no passkey when the gate is enforced", async () => {
+    await insertUser("enrolled");
+    await givePasskey("enrolled");
+    await insertUser("no-passkey");
+
+    const result = await filterNotifiableUsers(getDb(), GATE_ON, [
+      "enrolled",
+      "no-passkey",
+    ]);
+    expect(result).toEqual(["enrolled"]);
+  });
+
+  it("keeps a passkey-less user in dev, matching requirePasskey", async () => {
+    await insertUser("no-passkey");
+
+    const result = await filterNotifiableUsers(getDb(), GATE_OFF, [
+      "no-passkey",
+    ]);
+    expect(result).toEqual(["no-passkey"]);
+  });
+
+  it("drops a banned user who does have a passkey", async () => {
+    await insertUser("banned", { banned: true });
+    await givePasskey("banned");
+
+    const result = await filterNotifiableUsers(getDb(), GATE_ON, ["banned"]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty list for no candidates without querying", async () => {
+    expect(await filterNotifiableUsers(getDb(), GATE_ON, [])).toEqual([]);
   });
 });

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -244,8 +244,8 @@ export async function handleEmail(
             `Admin count exceeds notification fanout cap (${MAX_ADMIN_FANOUT}); truncating.`,
           );
         }
-        // The payload carries the sender, subject and a body preview, so a
-        // recipient who may not read mail must not receive it either.
+        // Payload carries subject and a body preview, so drop anyone the API
+        // would refuse.
         const userIds = await filterNotifiableUsers(db, env, candidates);
         if (userIds.length < candidates.length) {
           console.log(

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -15,6 +15,7 @@ import { cancelSequencesForPerson } from "./lib/cancel-sequence";
 import {
   MAX_ADMIN_FANOUT,
   computeFanoutTargets,
+  filterNotifiableUsers,
 } from "./lib/notification-fanout";
 import { sanitizeFilename } from "./lib/sanitize-filename";
 import { buildWebhookPayload, deliverWebhook } from "./lib/webhook-delivery";
@@ -234,13 +235,21 @@ export async function handleEmail(
             .where(eq(users.role, "admin"))
             .limit(MAX_ADMIN_FANOUT + 1),
         ]);
-        const { userIds, adminTruncated } = computeFanoutTargets({
+        const { userIds: candidates, adminTruncated } = computeFanoutTargets({
           permissionUserIds: permRows.map((r) => r.userId),
           adminUserIds: adminRows.map((r) => r.id),
         });
         if (adminTruncated) {
           console.warn(
             `Admin count exceeds notification fanout cap (${MAX_ADMIN_FANOUT}); truncating.`,
+          );
+        }
+        // The payload carries the sender, subject and a body preview, so a
+        // recipient who may not read mail must not receive it either.
+        const userIds = await filterNotifiableUsers(db, env, candidates);
+        if (userIds.length < candidates.length) {
+          console.log(
+            `[notify] skipped ${candidates.length - userIds.length} ineligible recipient(s) (banned or no passkey)`,
           );
         }
         const deliverPayload = JSON.stringify({

--- a/worker/src/email-handler.ts
+++ b/worker/src/email-handler.ts
@@ -281,8 +281,11 @@ export async function handleEmail(
           );
         }
       } catch (err) {
-        // Non-fatal: real-time push is best-effort.
-        console.warn("Real-time fanout error:", err);
+        // Still non-fatal, but logged as an error so it is not read as "no recipients".
+        console.error(
+          `[notify] fanout failed for ${recipientCanonical} (email ${emailId}) — recipients were not notified:`,
+          err,
+        );
       }
     })(),
   );

--- a/worker/src/lib/notification-fanout.ts
+++ b/worker/src/lib/notification-fanout.ts
@@ -1,3 +1,8 @@
+import { inArray } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { users, passkeys } from "../db/auth.schema";
+import { isDevEnvironment } from "./is-dev";
+
 // Cap admin WebSocket fanout so a deployment with many admin accounts does
 // not incur unbounded DO RPCs on every inbound email. A presence-aware
 // implementation (only notifying users with an active stream) would be the
@@ -24,4 +29,55 @@ export function computeFanoutTargets(args: {
     ...args.adminUserIds.slice(0, cap),
   ]);
   return { userIds: [...userIds], adminTruncated };
+}
+
+/**
+ * Narrow a fanout target list to users who are actually allowed to read mail.
+ *
+ * A notification carries the sender's name, the subject, and a 140-character
+ * body preview — that is mail content, not merely a signal that mail arrived.
+ * Membership of `inbox_permissions` is therefore not sufficient on its own:
+ *
+ *  - A **banned** user is refused everywhere else (`/mcp` answers "account
+ *    suspended"), so pushing them the contents of new mail contradicts the ban.
+ *  - A user with **no registered passkey** is refused by `requirePasskey`,
+ *    whose stated purpose is that "passkey registration is actually required to
+ *    access data". Delivering a subject and preview to them would make that
+ *    false, which is the same reason `/mcp` re-checks passkeys on bearer
+ *    requests rather than exempting itself.
+ *
+ * The passkey condition is skipped in development, matching `requirePasskey`
+ * and the MCP handler, so local dev and e2e (which run with the gate disabled)
+ * still receive notifications.
+ */
+export async function filterNotifiableUsers(
+  db: DrizzleD1Database<any>,
+  env: CloudflareBindings,
+  userIds: string[],
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+
+  const now = new Date();
+  const userRows = await db
+    .select({
+      id: users.id,
+      banned: users.banned,
+      banExpires: users.banExpires,
+    })
+    .from(users)
+    .where(inArray(users.id, userIds));
+
+  const notBanned = userRows
+    .filter((u) => !(u.banned && (!u.banExpires || u.banExpires > now)))
+    .map((u) => u.id);
+
+  if (isDevEnvironment(env) || notBanned.length === 0) return notBanned;
+
+  const withPasskey = await db
+    .select({ userId: passkeys.userId })
+    .from(passkeys)
+    .where(inArray(passkeys.userId, notBanned));
+
+  const enrolled = new Set(withPasskey.map((p) => p.userId));
+  return notBanned.filter((id) => enrolled.has(id));
 }

--- a/worker/src/lib/notification-fanout.ts
+++ b/worker/src/lib/notification-fanout.ts
@@ -9,6 +9,20 @@ import { isDevEnvironment } from "./is-dev";
 // proper long-term fix; until then this keeps worst-case cost predictable.
 export const MAX_ADMIN_FANOUT = 50;
 
+// D1 rejects a query carrying more than 100 bound parameters; 90 leaves headroom.
+export const ID_CHUNK_SIZE = 90;
+
+async function selectByIdChunks<T>(
+  ids: string[],
+  run: (chunk: string[]) => Promise<T[]>,
+): Promise<T[]> {
+  const pending: Promise<T[]>[] = [];
+  for (let i = 0; i < ids.length; i += ID_CHUNK_SIZE) {
+    pending.push(run(ids.slice(i, i + ID_CHUNK_SIZE)));
+  }
+  return (await Promise.all(pending)).flat();
+}
+
 /**
  * Compute the deduplicated set of user IDs that should receive a real-time
  * notification for an inbound email: users with an explicit `inbox_permissions`
@@ -40,14 +54,16 @@ export async function filterNotifiableUsers(
   if (userIds.length === 0) return [];
 
   const now = new Date();
-  const userRows = await db
-    .select({
-      id: users.id,
-      banned: users.banned,
-      banExpires: users.banExpires,
-    })
-    .from(users)
-    .where(inArray(users.id, userIds));
+  const userRows = await selectByIdChunks(userIds, (chunk) =>
+    db
+      .select({
+        id: users.id,
+        banned: users.banned,
+        banExpires: users.banExpires,
+      })
+      .from(users)
+      .where(inArray(users.id, chunk)),
+  );
 
   const notBanned = userRows
     .filter((u) => !(u.banned && (!u.banExpires || u.banExpires > now)))
@@ -55,10 +71,12 @@ export async function filterNotifiableUsers(
 
   if (isDevEnvironment(env) || notBanned.length === 0) return notBanned;
 
-  const withPasskey = await db
-    .select({ userId: passkeys.userId })
-    .from(passkeys)
-    .where(inArray(passkeys.userId, notBanned));
+  const withPasskey = await selectByIdChunks(notBanned, (chunk) =>
+    db
+      .select({ userId: passkeys.userId })
+      .from(passkeys)
+      .where(inArray(passkeys.userId, chunk)),
+  );
 
   const enrolled = new Set(withPasskey.map((p) => p.userId));
   return notBanned.filter((id) => enrolled.has(id));

--- a/worker/src/lib/notification-fanout.ts
+++ b/worker/src/lib/notification-fanout.ts
@@ -31,25 +31,7 @@ export function computeFanoutTargets(args: {
   return { userIds: [...userIds], adminTruncated };
 }
 
-/**
- * Narrow a fanout target list to users who are actually allowed to read mail.
- *
- * A notification carries the sender's name, the subject, and a 140-character
- * body preview — that is mail content, not merely a signal that mail arrived.
- * Membership of `inbox_permissions` is therefore not sufficient on its own:
- *
- *  - A **banned** user is refused everywhere else (`/mcp` answers "account
- *    suspended"), so pushing them the contents of new mail contradicts the ban.
- *  - A user with **no registered passkey** is refused by `requirePasskey`,
- *    whose stated purpose is that "passkey registration is actually required to
- *    access data". Delivering a subject and preview to them would make that
- *    false, which is the same reason `/mcp` re-checks passkeys on bearer
- *    requests rather than exempting itself.
- *
- * The passkey condition is skipped in development, matching `requirePasskey`
- * and the MCP handler, so local dev and e2e (which run with the gate disabled)
- * still receive notifications.
- */
+// The passkey condition is skipped in development, matching `requirePasskey`.
 export async function filterNotifiableUsers(
   db: DrizzleD1Database<any>,
   env: CloudflareBindings,


### PR DESCRIPTION
## Summary

Inbound fanout picks recipients from `inbox_permissions` plus admins and applies no further check, so two kinds of user keep receiving notifications after being cut off from the API:

- A **banned** user. `/mcp` refuses them outright as "account suspended", but their subscriptions are still delivered to.
- A user with **no registered passkey**. `requirePasskey` 403s every `/api/*` request they make, so they cannot open the message — yet the notification still arrives.

This matters because the payload is not a bare "you have mail" ping. It carries the sender's name, the subject, and a 140-character body preview (`do/notifications.ts`), so delivering it to a user the API refuses hands them mail content through a side channel.

## Changes

- `filterNotifiableUsers` applies both conditions between target computation and delivery, so `computeFanoutTargets` stays pure and separately testable.
- Ban check mirrors the MCP handler's (`banned && (!banExpires || banExpires > now)`), so an expired ban still notifies.
- The passkey condition is skipped in development via `isDevEnvironment`, matching `requirePasskey` and the MCP handler, so local dev and e2e still receive notifications.
- Logs a count when recipients are skipped.

## Release impact

- [x] Patch — bug fix or internal change, no new behaviour

- [x] Bug Fix

## Test plan

- [x] `yarn test` on notification-fanout, do-notifications, notifications-router, inbound-forward — 56 passed
- [x] Verified the new tests fail when the filter is stubbed to a pass-through (3 failures), so they assert real behaviour
- [x] `prettier --check` clean

## Notes for reviewers

The passkey half is the debatable one, so I want to be explicit about the reasoning rather than slip it in. My first instinct was that a passkey-less user is merely mid-onboarding and should still be told mail arrived. What changed my mind is `require-passkey.ts`'s own stated purpose — *"so passkey registration is actually required to access data"* — and a subject line plus body preview is data. It is the same argument `mcp/http.ts` makes for re-checking passkeys on bearer requests instead of exempting itself. If you read that differently I am happy to gate only on `banned` and drop the passkey condition; it is a two-line change.

One test detail worth noting: the tests pass `env` explicitly rather than relying on the ambient bindings, which set `DISABLE_PASSKEY_GATE="true"`. Under those the passkey branch never executes, so a test written against them would silently assert nothing.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed — n/a
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Updated docs — n/a
