### PR TITLE
fix(emails): register the bulk route before /{id} so it is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `PATCH /api/emails/bulk` works. It was registered after `PATCH /api/emails/{id}`, and Hono matches in registration order, so the request bound `id: "bulk"`, was answered by the single-email handler, and returned `404` without marking anything — the bulk handler was unreachable dead code. Registering it before the parameterised route makes it live; it applies the same inbox scoping it always contained, silently skipping ids the caller may not access.
 - README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).
 
 ### Added

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -463,10 +463,6 @@ describe("emails router", () => {
       expect(res.status).toBe(404);
     });
   });
-
-  // Note: PATCH /api/emails/bulk is unreachable because PATCH /{id} is
-  // registered first and "bulk" matches as an {id} param. Skipping tests
-  // for this endpoint as it's a known routing issue.
 });
 
 describe("reply stores generated message-id", () => {
@@ -715,9 +711,6 @@ describe("send stores generated message-id", () => {
       });
     }
 
-    // Registration order regression: with PATCH /{id} declared first, this
-    // request bound id="bulk", fell through to the single-email handler, and
-    // came back 404 with nothing marked. The route was unreachable.
     it("is reachable and not shadowed by PATCH /{id}", async () => {
       const { apiKey } = await createTestUser();
       await seedTwoUnread();

--- a/worker/src/__tests__/emails-router.test.ts
+++ b/worker/src/__tests__/emails-router.test.ts
@@ -697,4 +697,104 @@ describe("send stores generated message-id", () => {
       expect(res.status).toBe(404);
     });
   });
+
+  describe("PATCH /api/emails/bulk", () => {
+    async function seedTwoUnread(recipient = "inbox@saasmail.test") {
+      await createTestPerson({ id: "p-bulk", unreadCount: 2, totalCount: 2 });
+      await createTestEmail({
+        id: "b1",
+        personId: "p-bulk",
+        recipient,
+        messageId: "b1@example.com",
+      });
+      await createTestEmail({
+        id: "b2",
+        personId: "p-bulk",
+        recipient,
+        messageId: "b2@example.com",
+      });
+    }
+
+    // Registration order regression: with PATCH /{id} declared first, this
+    // request bound id="bulk", fell through to the single-email handler, and
+    // came back 404 with nothing marked. The route was unreachable.
+    it("is reachable and not shadowed by PATCH /{id}", async () => {
+      const { apiKey } = await createTestUser();
+      await seedTwoUnread();
+
+      const res = await authFetch("/api/emails/bulk", {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ ids: ["b1", "b2"], isRead: true }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ success: true });
+
+      const rows = await getDb()
+        .select({ id: emails.id, isRead: emails.isRead })
+        .from(emails);
+      expect(rows.every((r) => r.isRead === 1)).toBe(true);
+
+      const person = await getDb()
+        .select({ unreadCount: people.unreadCount })
+        .from(people)
+        .where(eq(people.id, "p-bulk"));
+      expect(person[0].unreadCount).toBe(0);
+    });
+
+    it("skips emails in inboxes the caller may not access", async () => {
+      const { userId, apiKey } = await createTestUser({
+        id: "member-bulk",
+        role: "member",
+        email: "member@test.com",
+      });
+      await grantInbox(userId, "mine@saasmail.test");
+
+      await createTestPerson({ id: "p-bulk", unreadCount: 2, totalCount: 2 });
+      await createTestEmail({
+        id: "mine",
+        personId: "p-bulk",
+        recipient: "mine@saasmail.test",
+        messageId: "m@example.com",
+      });
+      await createTestEmail({
+        id: "theirs",
+        personId: "p-bulk",
+        recipient: "theirs@saasmail.test",
+        messageId: "t@example.com",
+      });
+
+      const res = await authFetch("/api/emails/bulk", {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ ids: ["mine", "theirs"], isRead: true }),
+      });
+      expect(res.status).toBe(200);
+
+      const rows = await getDb()
+        .select({ id: emails.id, isRead: emails.isRead })
+        .from(emails);
+      expect(rows.find((r) => r.id === "mine")!.isRead).toBe(1);
+      expect(rows.find((r) => r.id === "theirs")!.isRead).toBe(0);
+    });
+
+    it("still routes a single-email PATCH to the id handler", async () => {
+      const { apiKey } = await createTestUser();
+      await seedTwoUnread();
+
+      const res = await authFetch("/api/emails/b1", {
+        apiKey,
+        method: "PATCH",
+        body: JSON.stringify({ isRead: true }),
+      });
+      expect(res.status).toBe(200);
+
+      const rows = await getDb()
+        .select({ id: emails.id, isRead: emails.isRead })
+        .from(emails);
+      expect(rows.find((r) => r.id === "b1")!.isRead).toBe(1);
+      expect(rows.find((r) => r.id === "b2")!.isRead).toBe(0);
+    });
+  });
 });

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -196,12 +196,8 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
   return c.json(email, 200);
 });
 
-// Bulk mark read/unread.
-//
-// Registered before PATCH /{id}: Hono matches in registration order, so with
-// the parameterised route first, `PATCH /api/emails/bulk` binds id="bulk" and
-// is answered by the single-email handler — which looks up an email with that
-// id, finds none, and returns 404. This route was unreachable.
+// Bulk mark read/unread. Must stay above PATCH /{id}: Hono matches in
+// registration order, so /{id} first swallows "bulk" as an id.
 const bulkPatchRoute = createRoute({
   method: "patch",
   path: "/bulk",

--- a/worker/src/routers/emails-router.ts
+++ b/worker/src/routers/emails-router.ts
@@ -196,45 +196,12 @@ emailsRouter.openapi(getEmailRoute, async (c) => {
   return c.json(email, 200);
 });
 
-// Mark email read/unread
-const patchEmailRoute = createRoute({
-  method: "patch",
-  path: "/{id}",
-  tags: ["Emails"],
-  description: "Mark an email as read or unread.",
-  request: {
-    params: z.object({ id: z.string() }),
-    body: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            isRead: z.boolean(),
-          }),
-        },
-      },
-    },
-  },
-  responses: {
-    ...json200Response(z.object({ success: z.boolean() }), "Updated"),
-  },
-});
-
-emailsRouter.openapi(patchEmailRoute, async (c) => {
-  const db = c.get("db");
-  const { id } = c.req.valid("param");
-  const { isRead } = c.req.valid("json");
-  const allowed = c.get("allowedInboxes")!;
-
-  const result = await setEmailRead(db, id, isRead, allowed);
-
-  if (!result) {
-    return c.json({ error: "Email not found" }, 404);
-  }
-
-  return c.json({ success: true }, 200);
-});
-
-// Bulk mark read/unread
+// Bulk mark read/unread.
+//
+// Registered before PATCH /{id}: Hono matches in registration order, so with
+// the parameterised route first, `PATCH /api/emails/bulk` binds id="bulk" and
+// is answered by the single-email handler — which looks up an email with that
+// id, finds none, and returns 404. This route was unreachable.
 const bulkPatchRoute = createRoute({
   method: "patch",
   path: "/bulk",
@@ -289,6 +256,44 @@ emailsRouter.openapi(bulkPatchRoute, async (c) => {
         .set({ unreadCount: sql`${people.unreadCount} + ${delta}` })
         .where(eq(people.id, email[0].personId));
     }
+  }
+
+  return c.json({ success: true }, 200);
+});
+
+// Mark email read/unread
+const patchEmailRoute = createRoute({
+  method: "patch",
+  path: "/{id}",
+  tags: ["Emails"],
+  description: "Mark an email as read or unread.",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            isRead: z.boolean(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...json200Response(z.object({ success: z.boolean() }), "Updated"),
+  },
+});
+
+emailsRouter.openapi(patchEmailRoute, async (c) => {
+  const db = c.get("db");
+  const { id } = c.req.valid("param");
+  const { isRead } = c.req.valid("json");
+  const allowed = c.get("allowedInboxes")!;
+
+  const result = await setEmailRead(db, id, isRead, allowed);
+
+  if (!result) {
+    return c.json({ error: "Email not found" }, 404);
   }
 
   return c.json({ success: true }, 200);


### PR DESCRIPTION
## Summary

`PATCH /api/emails/bulk` is declared after `PATCH /api/emails/{id}`. Hono matches routes in registration order, so the parameterised route wins: a bulk request binds `id: "bulk"`, runs the single-email handler, finds no email with that id and returns 404. Nothing is marked, and the bulk handler has never run — it is unreachable dead code.

## Changes

- Move the bulk route's registration above `/{id}`. The handler itself is unchanged.

## Release impact

- [x] Patch — bug fix or internal change, no new behaviour

- [x] Bug Fix

## Test plan

- [x] `yarn test worker/src/__tests__/emails-router.test.ts` — 27 passed
- [x] Verified the two new behavioural tests **fail against the previous ordering**
- [x] `prettier --check` clean

## Notes for reviewers

The handler was already scoped correctly — it skips ids the caller has no inbox permission for rather than failing the whole request — so making it reachable does not widen access. There is a test covering that, since a route that has never executed deserves one before it starts.

Reordering a route table is exactly the kind of fix that repairs one path by breaking another, so there is also a test asserting a single-email `PATCH /api/emails/{id}` still reaches the id handler.

Since this route has never worked, nothing can depend on its current 404 behaviour — but it does mean any client that was silently getting 404s here will now start actually marking mail read.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed — n/a
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Updated docs — n/a
