### PR TITLE
fix(auth): keep the pending OAuth request across sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- README: correct OpenAPI doc URLs (`/doc` and `/swagger-ui`, not `/api/doc`) and OpenAPI version (3.0).
+- **Signing in no longer abandons a pending OAuth authorization.** When a client starts an authorization while the browser has no session, the provider redirects to `/login` carrying the request as signed, time-bounded query parameters — but both sign-in paths then navigated to `/`, discarding it. The client waited for a callback that never arrived. Sign-in now hands those parameters back to `/api/auth/oauth2/authorize` and the flow continues to consent. This is the path every third-party client takes on first connect, since it always arrives logged out; the existing OAuth tests all authenticate before calling authorize, so the branch had no coverage.
 
 ### Added
 

--- a/e2e/specs/oauth-login-continuation.spec.ts
+++ b/e2e/specs/oauth-login-continuation.spec.ts
@@ -1,0 +1,116 @@
+// e2e/specs/oauth-login-continuation.spec.ts
+// Covers: a third-party client starting an OAuth authorization while logged
+// out, and the flow surviving the trip through the login page.
+//
+// This is the path every native and third-party client takes on first connect,
+// and the only one where the browser has no session yet. The worker-side tests
+// all sign in before calling authorize, so without this the login page could
+// drop the pending request and nothing would notice.
+import { test, expect } from "../fixtures/test";
+import { ADMIN, BASE_URL } from "../support/login";
+
+// Start unauthenticated — the whole point is arriving without a session.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+/**
+ * Register a client the way an unknown client does: RFC 7591 dynamic
+ * registration, which this deployment leaves open so MCP clients can self
+ * register.
+ */
+async function registerClient(request: any): Promise<string> {
+  const res = await request.post(`${BASE_URL}/api/auth/oauth2/register`, {
+    data: {
+      client_name: "E2E Continuation Client",
+      redirect_uris: [`${BASE_URL}/e2e-callback`],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: "openid email:read",
+    },
+  });
+  expect([200, 201]).toContain(res.status());
+  const body = await res.json();
+  expect(body.client_id).toBeTruthy();
+  return body.client_id;
+}
+
+function authorizeUrl(clientId: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${BASE_URL}/e2e-callback`,
+    response_type: "code",
+    scope: "openid email:read",
+    // A fixed challenge is fine here: this spec stops at the consent screen and
+    // never exchanges the code, so the verifier is never needed.
+    code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    code_challenge_method: "S256",
+    state: "e2e-state",
+  });
+  return `${BASE_URL}/api/auth/oauth2/authorize?${params}`;
+}
+
+test.describe("OAuth authorization started while logged out", () => {
+  test("keeps the pending request across sign-in instead of landing on the inbox", async ({
+    page,
+    request,
+  }) => {
+    const clientId = await registerClient(request);
+
+    await page.goto(authorizeUrl(clientId));
+
+    // The provider bounces to the login page, carrying the signed request.
+    await page.waitForURL(/\/login/);
+    const loginUrl = new URL(page.url());
+    expect(loginUrl.searchParams.get("client_id")).toBe(clientId);
+    expect(
+      loginUrl.searchParams.get("sig"),
+      "login redirect was not signed",
+    ).toBeTruthy();
+
+    await page
+      .getByRole("button", { name: "Sign in with email instead" })
+      .click();
+    await page.getByPlaceholder("Email").fill(ADMIN.email);
+    await page.getByPlaceholder("Password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+    // The regression: sign-in used to navigate to "/", stranding the client,
+    // which then waited for a callback that never arrived.
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+      timeout: 15_000,
+    });
+
+    const after = new URL(page.url());
+    expect(
+      after.pathname,
+      `sign-in dropped the pending authorization and landed on ${after.pathname}`,
+    ).not.toBe("/");
+
+    // It should now be at consent, or already back at the client with a code.
+    const arrived =
+      after.pathname.startsWith("/consent") ||
+      after.pathname.startsWith("/e2e-callback") ||
+      after.searchParams.has("code");
+    expect(
+      arrived,
+      `expected the consent screen or the client callback, got ${page.url()}`,
+    ).toBe(true);
+  });
+
+  test("still sends an ordinary sign-in to the inbox", async ({ page }) => {
+    // Guard against fixing the OAuth path by breaking the normal one.
+    await page.goto(`${BASE_URL}/login`);
+
+    await page
+      .getByRole("button", { name: "Sign in with email instead" })
+      .click();
+    await page.getByPlaceholder("Email").fill(ADMIN.email);
+    await page.getByPlaceholder("Password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+      timeout: 15_000,
+    });
+    expect(new URL(page.url()).pathname).toBe("/");
+  });
+});

--- a/e2e/specs/oauth-login-continuation.spec.ts
+++ b/e2e/specs/oauth-login-continuation.spec.ts
@@ -1,22 +1,12 @@
 // e2e/specs/oauth-login-continuation.spec.ts
 // Covers: a third-party client starting an OAuth authorization while logged
 // out, and the flow surviving the trip through the login page.
-//
-// This is the path every native and third-party client takes on first connect,
-// and the only one where the browser has no session yet. The worker-side tests
-// all sign in before calling authorize, so without this the login page could
-// drop the pending request and nothing would notice.
 import { test, expect } from "../fixtures/test";
 import { ADMIN, BASE_URL } from "../support/login";
 
-// Start unauthenticated — the whole point is arriving without a session.
+// The shared fixture is signed in; this flow must start without a session.
 test.use({ storageState: { cookies: [], origins: [] } });
 
-/**
- * Register a client the way an unknown client does: RFC 7591 dynamic
- * registration, which this deployment leaves open so MCP clients can self
- * register.
- */
 async function registerClient(request: any): Promise<string> {
   const res = await request.post(`${BASE_URL}/api/auth/oauth2/register`, {
     data: {
@@ -40,8 +30,8 @@ function authorizeUrl(clientId: string): string {
     redirect_uri: `${BASE_URL}/e2e-callback`,
     response_type: "code",
     scope: "openid email:read",
-    // A fixed challenge is fine here: this spec stops at the consent screen and
-    // never exchanges the code, so the verifier is never needed.
+    // Fixed challenge: this spec stops at consent and never exchanges the code,
+    // so no verifier is needed.
     code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
     code_challenge_method: "S256",
     state: "e2e-state",
@@ -58,7 +48,6 @@ test.describe("OAuth authorization started while logged out", () => {
 
     await page.goto(authorizeUrl(clientId));
 
-    // The provider bounces to the login page, carrying the signed request.
     await page.waitForURL(/\/login/);
     const loginUrl = new URL(page.url());
     expect(loginUrl.searchParams.get("client_id")).toBe(clientId);
@@ -74,8 +63,7 @@ test.describe("OAuth authorization started while logged out", () => {
     await page.getByPlaceholder("Password").fill(ADMIN.password);
     await page.getByRole("button", { name: "Sign in", exact: true }).click();
 
-    // The regression: sign-in used to navigate to "/", stranding the client,
-    // which then waited for a callback that never arrived.
+    // The regression: sign-in navigated to "/", stranding the client.
     await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
       timeout: 15_000,
     });
@@ -86,7 +74,6 @@ test.describe("OAuth authorization started while logged out", () => {
       `sign-in dropped the pending authorization and landed on ${after.pathname}`,
     ).not.toBe("/");
 
-    // It should now be at consent, or already back at the client with a code.
     const arrived =
       after.pathname.startsWith("/consent") ||
       after.pathname.startsWith("/e2e-callback") ||

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,6 +4,25 @@ import { Mail, Fingerprint, ArrowRight } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { useBranding } from "@/lib/branding";
 
+/**
+ * When the OAuth provider needs a session it redirects here with the pending
+ * authorization request in the query string, signed (`sig`) and time-bounded
+ * (`exp`) by the server. Sending the user to "/" after sign-in throws that
+ * away, so the client that started the flow never receives its code and simply
+ * hangs — the case a native or third-party client hits every time, since it
+ * always arrives logged out.
+ *
+ * Handing the same parameters straight back to `/api/auth/oauth2/authorize`
+ * resumes the request. This is not an open redirect: the destination is always
+ * our own authorize endpoint, never a URL taken from the query, and the server
+ * re-verifies the signature and expiry before acting on it.
+ */
+function pendingAuthorizeUrl(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has("client_id") || !params.has("sig")) return null;
+  return `/api/auth/oauth2/authorize${window.location.search}`;
+}
+
 export default function LoginPage() {
   const { brandName } = useBranding();
   const [error, setError] = useState("");
@@ -49,7 +68,7 @@ export default function LoginPage() {
       if (result?.error) {
         setError(result.error.message || "Passkey sign-in failed");
       } else {
-        window.location.href = "/";
+        window.location.href = pendingAuthorizeUrl() ?? "/";
       }
     } catch {
       setError("Passkey sign-in failed. Please try again.");
@@ -67,7 +86,7 @@ export default function LoginPage() {
       if (result?.error) {
         setError(result.error.message || "Sign-in failed");
       } else {
-        window.location.href = "/";
+        window.location.href = pendingAuthorizeUrl() ?? "/";
       }
     } catch {
       setError("Sign-in failed. Please try again.");

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,19 +4,9 @@ import { Mail, Fingerprint, ArrowRight } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { useBranding } from "@/lib/branding";
 
-/**
- * When the OAuth provider needs a session it redirects here with the pending
- * authorization request in the query string, signed (`sig`) and time-bounded
- * (`exp`) by the server. Sending the user to "/" after sign-in throws that
- * away, so the client that started the flow never receives its code and simply
- * hangs — the case a native or third-party client hits every time, since it
- * always arrives logged out.
- *
- * Handing the same parameters straight back to `/api/auth/oauth2/authorize`
- * resumes the request. This is not an open redirect: the destination is always
- * our own authorize endpoint, never a URL taken from the query, and the server
- * re-verifies the signature and expiry before acting on it.
- */
+// Sign-in must hand a parked OAuth request back or the client hangs. Not an
+// open redirect: always our own authorize endpoint, and the server re-verifies
+// `sig`/`exp`.
 function pendingAuthorizeUrl(): string | null {
   const params = new URLSearchParams(window.location.search);
   if (!params.has("client_id") || !params.has("sig")) return null;

--- a/worker/src/__tests__/oauth-logged-out-authorize.test.ts
+++ b/worker/src/__tests__/oauth-logged-out-authorize.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The logged-out leg of the authorization-code flow.
+ *
+ * Every other OAuth test signs in *before* calling authorize (see `runFlow` in
+ * mcp-helpers), so the branch a real client actually takes — arriving with no
+ * session, being sent to the login page, and coming back — has no coverage.
+ * That is the branch a native or third-party client hits on every first
+ * connection, since it never has a browser session to begin with.
+ *
+ * These assert the contract `LoginPage` depends on: authorize hands the pending
+ * request to the login page as signed query parameters, and replaying those
+ * exact parameters once a session exists resumes the flow rather than starting
+ * a new one.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { applyMigrations, cleanDb } from "./helpers";
+import {
+  ALL_SCOPES,
+  Jar,
+  REDIRECT_URI,
+  type Credentials,
+  createUserWithPassword,
+  pkce,
+  registerClient,
+  req,
+  signIn,
+} from "./mcp-helpers";
+
+const USER: Credentials = {
+  name: "Owner",
+  email: "owner@saasmail.test",
+  password: "correct-horse-battery",
+};
+
+/** Start an authorization request with whatever session the jar holds. */
+async function authorize(jar: Jar, params: Record<string, string>) {
+  return jar.absorb(
+    await req(`/api/auth/oauth2/authorize?${new URLSearchParams(params)}`, {
+      headers: { cookie: jar.header },
+      redirect: "manual",
+    }),
+  );
+}
+
+async function buildParams() {
+  const { client_id } = await registerClient(ALL_SCOPES);
+  const { challenge, verifier } = await pkce();
+  return {
+    verifier,
+    params: {
+      client_id,
+      redirect_uri: REDIRECT_URI,
+      response_type: "code",
+      scope: ALL_SCOPES,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      state: "test-state",
+    } as Record<string, string>,
+  };
+}
+
+describe("authorize with no session", () => {
+  beforeAll(applyMigrations);
+
+  beforeEach(async () => {
+    await cleanDb();
+    await createUserWithPassword(USER, "admin");
+  });
+
+  it("redirects an unauthenticated request to the login page", async () => {
+    const { params } = await buildParams();
+    const res = await authorize(new Jar(), params);
+
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+
+    const location = res.headers.get("location") ?? "";
+    expect(location, "expected a redirect to the login page").toContain(
+      "/login",
+    );
+  });
+
+  it("carries the pending request to the login page as signed parameters", async () => {
+    const { params } = await buildParams();
+    const res = await authorize(new Jar(), params);
+
+    const location = res.headers.get("location") ?? "";
+    const query = new URLSearchParams(
+      location.slice(location.indexOf("?") + 1),
+    );
+
+    // These two are exactly what LoginPage keys on to decide that a pending
+    // authorization exists and must be resumed rather than dropped.
+    expect(query.get("client_id")).toBe(params.client_id);
+    expect(query.get("sig"), "login redirect was not signed").toBeTruthy();
+
+    // Signed *and* bounded, so replaying it later is not an open-ended grant.
+    expect(query.get("exp"), "login redirect had no expiry").toBeTruthy();
+    expect(Number(query.get("exp"))).toBeGreaterThan(Date.now() / 1000);
+
+    // The rest of the request survives the round trip, or resuming would
+    // silently change what the user is consenting to.
+    expect(query.get("scope")).toBe(params.scope);
+    expect(query.get("redirect_uri")).toBe(REDIRECT_URI);
+    expect(query.get("state")).toBe("test-state");
+    expect(query.get("code_challenge")).toBe(params.code_challenge);
+  });
+
+  it("resumes the flow when those parameters are replayed with a session", async () => {
+    const { params } = await buildParams();
+
+    // 1. Arrive logged out and get bounced to the login page.
+    const jar = new Jar();
+    const first = await authorize(jar, params);
+    const location = first.headers.get("location") ?? "";
+    const pending = location.slice(location.indexOf("?") + 1);
+    expect(pending).toBeTruthy();
+
+    // 2. Sign in, as the user does on that page.
+    await signIn(jar, USER);
+
+    // 3. Hand the same parameters straight back — what LoginPage now does
+    //    instead of navigating to "/".
+    const resumed = jar.absorb(
+      await req(`/api/auth/oauth2/authorize?${pending}`, {
+        headers: { cookie: jar.header },
+        redirect: "manual",
+      }),
+    );
+
+    // The flow moves on: either straight to the client with a code, or to the
+    // consent screen. What matters is that it is no longer asking for a login.
+    const next = resumed.headers.get("location") ?? "";
+    expect(
+      next,
+      `unexpected destination after resuming: ${next}`,
+    ).not.toContain("/login");
+    expect(
+      next.startsWith(REDIRECT_URI) || next.includes("/consent"),
+      `expected a code or the consent screen, got: ${next}`,
+    ).toBe(true);
+  });
+
+  it("does not issue a code to an unauthenticated caller", async () => {
+    const { params } = await buildParams();
+    const res = await authorize(new Jar(), params);
+
+    const location = res.headers.get("location") ?? "";
+    expect(location.startsWith(REDIRECT_URI)).toBe(false);
+    expect(location).not.toContain("code=");
+  });
+});

--- a/worker/src/__tests__/oauth-logged-out-authorize.test.ts
+++ b/worker/src/__tests__/oauth-logged-out-authorize.test.ts
@@ -1,17 +1,5 @@
-/**
- * The logged-out leg of the authorization-code flow.
- *
- * Every other OAuth test signs in *before* calling authorize (see `runFlow` in
- * mcp-helpers), so the branch a real client actually takes — arriving with no
- * session, being sent to the login page, and coming back — has no coverage.
- * That is the branch a native or third-party client hits on every first
- * connection, since it never has a browser session to begin with.
- *
- * These assert the contract `LoginPage` depends on: authorize hands the pending
- * request to the login page as signed query parameters, and replaying those
- * exact parameters once a session exists resumes the flow rather than starting
- * a new one.
- */
+// The logged-out leg of authorize: every other OAuth test signs in first (see
+// `runFlow` in mcp-helpers), so this branch is otherwise uncovered.
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { applyMigrations, cleanDb } from "./helpers";
 import {
@@ -32,7 +20,6 @@ const USER: Credentials = {
   password: "correct-horse-battery",
 };
 
-/** Start an authorization request with whatever session the jar holds. */
 async function authorize(jar: Jar, params: Record<string, string>) {
   return jar.absorb(
     await req(`/api/auth/oauth2/authorize?${new URLSearchParams(params)}`, {
@@ -89,17 +76,13 @@ describe("authorize with no session", () => {
       location.slice(location.indexOf("?") + 1),
     );
 
-    // These two are exactly what LoginPage keys on to decide that a pending
-    // authorization exists and must be resumed rather than dropped.
+    // LoginPage keys on these two to detect a pending authorization.
     expect(query.get("client_id")).toBe(params.client_id);
     expect(query.get("sig"), "login redirect was not signed").toBeTruthy();
 
-    // Signed *and* bounded, so replaying it later is not an open-ended grant.
     expect(query.get("exp"), "login redirect had no expiry").toBeTruthy();
     expect(Number(query.get("exp"))).toBeGreaterThan(Date.now() / 1000);
 
-    // The rest of the request survives the round trip, or resuming would
-    // silently change what the user is consenting to.
     expect(query.get("scope")).toBe(params.scope);
     expect(query.get("redirect_uri")).toBe(REDIRECT_URI);
     expect(query.get("state")).toBe("test-state");
@@ -109,18 +92,15 @@ describe("authorize with no session", () => {
   it("resumes the flow when those parameters are replayed with a session", async () => {
     const { params } = await buildParams();
 
-    // 1. Arrive logged out and get bounced to the login page.
     const jar = new Jar();
     const first = await authorize(jar, params);
     const location = first.headers.get("location") ?? "";
     const pending = location.slice(location.indexOf("?") + 1);
     expect(pending).toBeTruthy();
 
-    // 2. Sign in, as the user does on that page.
     await signIn(jar, USER);
 
-    // 3. Hand the same parameters straight back — what LoginPage now does
-    //    instead of navigating to "/".
+    // Replay the same parameters, as LoginPage now does.
     const resumed = jar.absorb(
       await req(`/api/auth/oauth2/authorize?${pending}`, {
         headers: { cookie: jar.header },
@@ -128,8 +108,6 @@ describe("authorize with no session", () => {
       }),
     );
 
-    // The flow moves on: either straight to the client with a code, or to the
-    // consent screen. What matters is that it is no longer asking for a login.
     const next = resumed.headers.get("location") ?? "";
     expect(
       next,


### PR DESCRIPTION
## Summary

When a client starts an OAuth authorization and the browser has no session, the provider redirects to `/login` with the pending request in the query string, signed and time-bounded by the server. Both sign-in handlers then run `window.location.href = "/"`, discarding it. The user lands on the inbox and **the client that started the flow waits for a callback that never arrives.**

This is the path every third-party and native client takes on first connect, since such a client never has a browser session to begin with.

Two reasons it went unnoticed: every existing OAuth test signs in *before* calling authorize (`runFlow` in `mcp-helpers.ts`), so the logged-out branch has no coverage; and `/login` and `/consent` sit outside `AuthGuard`, so nothing else routes through it either.

## Changes

- Sign-in hands the pending parameters back to `/api/auth/oauth2/authorize` instead of navigating to `/`. Applies to both the passkey and the password path.
- An ordinary sign-in with no pending request still goes to `/`, unchanged.

## Release impact

- [x] Patch — bug fix or internal change, no new behaviour

- [x] Bug Fix

## Test plan

- [x] `yarn test worker/src/__tests__/oauth-logged-out-authorize.test.ts` — 4 passed
- [x] `npx playwright test e2e/specs/oauth-login-continuation.spec.ts` — 2 passed
- [x] **Verified the e2e test fails against the previous handler**, with `sign-in dropped the pending authorization and landed on /`
- [x] `prettier --check` clean

## Notes for reviewers

**On the redirect being safe.** It is not an open redirect. The destination is always this deployment's own `/api/auth/oauth2/authorize`, never a URL read out of the query; only the parameters are carried over, and the server re-verifies its own `sig` and `exp` before acting on them. The gate is the presence of both `client_id` and `sig`, so an arbitrary query string does not trigger it.

**On the two test layers.** The failure spans the browser and the server, so I covered both. The worker test pins the contract the page depends on — authorize redirects an unauthenticated request to the login page with signed, expiring parameters; replaying them with a session resumes rather than restarts; and no code is ever issued to an unauthenticated caller. Those pass on `main` too, which is the point: they document a previously untested branch rather than chase the bug. The e2e spec is the one that actually fails without the fix.

The e2e spec registers its client through RFC 7591 dynamic registration, exactly as an unknown client would, so it exercises the real path rather than a fixture.

**Local environment note, in case it helps anyone else:** running the e2e suite on macOS needed `CHOKIDAR_USEPOLLING=1` — miniflare's file watcher hits `EMFILE: too many open files` against `node_modules` otherwise. CI is unaffected. Happy to add that to the README if you'd find it useful.

## Checklist

- [ ] Added or updated a migration (`yarn db:generate`) if the schema changed — n/a
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Updated docs — n/a
