### PR TITLE
fix(security): deleting a user re-armed their spent invitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Deleting a user no longer re-arms the invitation they signed up with.** `invitations.used_by` is `ON DELETE SET NULL`, and both redeem paths read a null `usedBy` as "never used" — so `DELETE /api/admin/users/{id}`, which issues a bare `DELETE FROM users`, silently returned that user's spent invite token to circulation. The token is still in whatever inbox it was mailed to, `POST /api/invites/accept` is public and unauthenticated, and the invite carries the role it was minted with, so removing an admin re-opened an admin-role signup link for whatever remained of the original expiry (up to 30 days). Removing someone's access is precisely when it must not come back. The user's redeemed invitations are now deleted with them; unredeemed invitations and other users' invitations are untouched.
 - Closed stored-XSS surface on per-inbox signatures: a new HTMLRewriter-based sanitizer (`worker/src/lib/sanitize-signature.ts`) strips dangerous tags (`script`, `style`, `iframe`, etc.), every `on*` event handler, `style` attributes, and unsafe URL schemes (`javascript:`, `vbscript:`, non-image `data:`). Signatures are sanitized at write time in the PATCH inbox endpoint (with a 20 000-character schema cap) and on the client in `ComposeModal` and `ReplyComposer` as defense-in-depth.
 - `inbox-permissions.ts` lowercases addresses at resolution time, closing a latent permission-check bypass for mixed-case `inbox_permissions.email` rows.
 

--- a/worker/src/__tests__/spent-invite-rearm.test.ts
+++ b/worker/src/__tests__/spent-invite-rearm.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  applyMigrations,
+  authFetch,
+  cleanDb,
+  createTestUser,
+  getDb,
+} from "./helpers";
+import { users } from "../db/auth.schema";
+import { invitations } from "../db/invitations.schema";
+
+/**
+ * Deleting a user must not resurrect the invitation they signed up with.
+ *
+ * `invitations.used_by` is `ON DELETE SET NULL` (migration 0004), and both
+ * redeem paths treat a null `usedBy` as "never used". So a bare
+ * `DELETE FROM users` silently returns a spent invite to circulation — while
+ * the token is still sitting in whoever's inbox it was mailed to, while
+ * `POST /api/invites/accept` is public, and carrying whatever role it was
+ * minted with.
+ */
+describe("deleting a user does not re-arm their invitation", () => {
+  let adminKey: string;
+  let adminId: string;
+
+  beforeAll(applyMigrations);
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey: adminKey, userId: adminId } = await createTestUser({
+      id: "admin-1",
+      role: "admin",
+      email: "admin@x.com",
+    }));
+  });
+
+  /** An invite that has already been redeemed by `usedBy`. */
+  async function seedSpentInvite(opts: {
+    token: string;
+    role: "admin" | "member";
+    usedBy: string | null;
+    email?: string | null;
+    expiresInDays?: number;
+  }) {
+    const now = Date.now();
+    await getDb()
+      .insert(invitations)
+      .values({
+        id: `inv-${opts.token}`,
+        token: opts.token,
+        role: opts.role,
+        email: opts.email ?? null,
+        expiresAt: new Date(now + (opts.expiresInDays ?? 7) * 86400_000),
+        usedBy: opts.usedBy,
+        usedAt: opts.usedBy ? new Date(now) : null,
+        createdBy: adminId,
+        createdAt: new Date(now),
+      });
+  }
+
+  it("removes the invitation the deleted user redeemed", async () => {
+    const { userId: victimId } = await createTestUser({
+      id: "u-victim",
+      role: "admin",
+      email: "victim@x.com",
+    });
+    await seedSpentInvite({
+      token: "tok-spent",
+      role: "admin",
+      usedBy: victimId,
+    });
+
+    const res = await authFetch(`/api/admin/users/${victimId}`, {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+
+    const rows = await getDb()
+      .select()
+      .from(invitations)
+      .where(eq(invitations.token, "tok-spent"));
+    expect(rows).toHaveLength(0);
+  });
+
+  /**
+   * The one that matters: the public accept endpoint, exercised end to end.
+   * Without the fix this returns 200 and mints a fresh admin account.
+   */
+  it("does not let the spent token create a new admin account afterwards", async () => {
+    const { userId: victimId } = await createTestUser({
+      id: "u-victim",
+      role: "admin",
+      email: "victim@x.com",
+    });
+    await seedSpentInvite({
+      token: "tok-admin",
+      role: "admin",
+      usedBy: victimId,
+    });
+
+    await authFetch(`/api/admin/users/${victimId}`, {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+
+    const accept = await authFetch("/api/invites/accept", {
+      method: "POST",
+      body: JSON.stringify({
+        token: "tok-admin",
+        email: "attacker@x.com",
+        password: "correct-horse-battery-staple",
+        name: "Attacker",
+      }),
+    });
+
+    expect(accept.status).not.toBe(200);
+
+    const created = await getDb()
+      .select()
+      .from(users)
+      .where(eq(users.email, "attacker@x.com"));
+    expect(created).toHaveLength(0);
+  });
+
+  it("reports the token as invalid rather than valid", async () => {
+    const { userId: victimId } = await createTestUser({
+      id: "u-victim",
+      role: "member",
+      email: "victim@x.com",
+    });
+    await seedSpentInvite({
+      token: "tok-check",
+      role: "member",
+      usedBy: victimId,
+    });
+
+    await authFetch(`/api/admin/users/${victimId}`, {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+
+    const res = await authFetch("/api/invites/tok-check");
+    const body = (await res.json()) as { valid: boolean };
+    expect(body.valid).toBe(false);
+  });
+
+  it("leaves an unredeemed invitation alone", async () => {
+    const { userId: victimId } = await createTestUser({
+      id: "u-victim",
+      role: "member",
+      email: "victim@x.com",
+    });
+    // Nobody has used this one; deleting an unrelated user must not touch it.
+    await seedSpentInvite({ token: "tok-open", role: "member", usedBy: null });
+
+    await authFetch(`/api/admin/users/${victimId}`, {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+
+    const res = await authFetch("/api/invites/tok-open");
+    const body = (await res.json()) as { valid: boolean };
+    expect(body.valid).toBe(true);
+  });
+
+  it("does not touch invitations redeemed by other users", async () => {
+    const { userId: victimId } = await createTestUser({
+      id: "u-victim",
+      role: "member",
+      email: "victim@x.com",
+    });
+    const { userId: keeperId } = await createTestUser({
+      id: "u-keeper",
+      role: "member",
+      email: "keeper@x.com",
+    });
+    await seedSpentInvite({
+      token: "tok-victim",
+      role: "member",
+      usedBy: victimId,
+    });
+    await seedSpentInvite({
+      token: "tok-keeper",
+      role: "member",
+      usedBy: keeperId,
+    });
+
+    await authFetch(`/api/admin/users/${victimId}`, {
+      apiKey: adminKey,
+      method: "DELETE",
+    });
+
+    const remaining = await getDb().select().from(invitations);
+    expect(remaining.map((r) => r.token)).toEqual(["tok-keeper"]);
+  });
+});

--- a/worker/src/__tests__/spent-invite-rearm.test.ts
+++ b/worker/src/__tests__/spent-invite-rearm.test.ts
@@ -10,16 +10,8 @@ import {
 import { users } from "../db/auth.schema";
 import { invitations } from "../db/invitations.schema";
 
-/**
- * Deleting a user must not resurrect the invitation they signed up with.
- *
- * `invitations.used_by` is `ON DELETE SET NULL` (migration 0004), and both
- * redeem paths treat a null `usedBy` as "never used". So a bare
- * `DELETE FROM users` silently returns a spent invite to circulation — while
- * the token is still sitting in whoever's inbox it was mailed to, while
- * `POST /api/invites/accept` is public, and carrying whatever role it was
- * minted with.
- */
+// `invitations.used_by` is ON DELETE SET NULL (migration 0004) and a null
+// `usedBy` reads as "never used", so deleting a user un-spends their invite.
 describe("deleting a user does not re-arm their invitation", () => {
   let adminKey: string;
   let adminId: string;
@@ -35,7 +27,6 @@ describe("deleting a user does not re-arm their invitation", () => {
     }));
   });
 
-  /** An invite that has already been redeemed by `usedBy`. */
   async function seedSpentInvite(opts: {
     token: string;
     role: "admin" | "member";
@@ -84,10 +75,6 @@ describe("deleting a user does not re-arm their invitation", () => {
     expect(rows).toHaveLength(0);
   });
 
-  /**
-   * The one that matters: the public accept endpoint, exercised end to end.
-   * Without the fix this returns 200 and mints a fresh admin account.
-   */
   it("does not let the spent token create a new admin account afterwards", async () => {
     const { userId: victimId } = await createTestUser({
       id: "u-victim",
@@ -152,7 +139,6 @@ describe("deleting a user does not re-arm their invitation", () => {
       role: "member",
       email: "victim@x.com",
     });
-    // Nobody has used this one; deleting an unrelated user must not touch it.
     await seedSpentInvite({ token: "tok-open", role: "member", usedBy: null });
 
     await authFetch(`/api/admin/users/${victimId}`, {

--- a/worker/src/routers/admin-router.ts
+++ b/worker/src/routers/admin-router.ts
@@ -296,6 +296,23 @@ adminRouter.openapi(deleteUserRoute, async (c) => {
     return c.json({ error: "User not found" }, 404);
   }
 
+  // Burn the invitations this user redeemed, before the row goes.
+  //
+  // `invitations.used_by` is ON DELETE SET NULL, and both redeem paths read a
+  // null `usedBy` as "never used" — so without this, deleting a user hands
+  // their spent invite token back its validity. The token is still in whatever
+  // inbox it was mailed to, `POST /api/invites/accept` is public, and the
+  // invite carries the role it was created with. Removing an admin would
+  // therefore re-arm an admin-role signup link for as long as the original
+  // expiry had left to run, which is the exact opposite of what the operator
+  // just asked for.
+  //
+  // Deleted rather than tombstoned because the schema has nowhere to record
+  // "spent but its user is gone": the only marker of consumption *is* the
+  // foreign key the delete nulls. A spent invite that survives its user is an
+  // open credential, and keeping it for audit is not worth that.
+  await db.delete(invitations).where(eq(invitations.usedBy, id));
+
   await db.delete(users).where(eq(users.id, id));
   return c.json({ success: true as const }, 200);
 });

--- a/worker/src/routers/admin-router.ts
+++ b/worker/src/routers/admin-router.ts
@@ -296,21 +296,9 @@ adminRouter.openapi(deleteUserRoute, async (c) => {
     return c.json({ error: "User not found" }, 404);
   }
 
-  // Burn the invitations this user redeemed, before the row goes.
-  //
-  // `invitations.used_by` is ON DELETE SET NULL, and both redeem paths read a
-  // null `usedBy` as "never used" — so without this, deleting a user hands
-  // their spent invite token back its validity. The token is still in whatever
-  // inbox it was mailed to, `POST /api/invites/accept` is public, and the
-  // invite carries the role it was created with. Removing an admin would
-  // therefore re-arm an admin-role signup link for as long as the original
-  // expiry had left to run, which is the exact opposite of what the operator
-  // just asked for.
-  //
-  // Deleted rather than tombstoned because the schema has nowhere to record
-  // "spent but its user is gone": the only marker of consumption *is* the
-  // foreign key the delete nulls. A spent invite that survives its user is an
-  // open credential, and keeping it for audit is not worth that.
+  // `invitations.used_by` is ON DELETE SET NULL and a null `usedBy` reads as
+  // "never used", so the cascade would put this user's spent invite tokens back
+  // in circulation. Must run before the users delete nulls the column.
   await db.delete(invitations).where(eq(invitations.usedBy, id));
 
   await db.delete(users).where(eq(users.id, id));


### PR DESCRIPTION
Independent of my other open PRs — branches from `main`, one commit.

## The bug

`invitations.used_by` is declared `ON DELETE SET NULL` ([`migrations/0004_material_shiver_man.sql:12`](https://github.com/choyiny/saasmail/blob/main/migrations/0004_material_shiver_man.sql#L12)), and both redeem paths decide whether an invite is spent by testing that column:

```ts
if (invite.usedBy || expiresAt < new Date()) return c.json({ valid: false }, 200);  // invites-router.ts:62
if (invite.usedBy) return c.json({ error: "Invitation has already been used" }, 400);  // invites-router.ts:113
```

`DELETE /api/admin/users/{id}` issues a bare `DELETE FROM users`, so the foreign key nulls `used_by` and the invitation the deleted user signed up with becomes valid again.

## Why it is reachable

Every precondition is already true:

- The token is still sitting in whatever inbox it was originally mailed to.
- `POST /api/invites/accept` is in `isUnauthenticatedPath` — no session, no API key, no rate limit.
- The invitation carries the `role` it was minted with, so an admin invite re-opens as an **admin** signup link.
- The window is whatever is left of the original expiry, up to 30 days.

The shape is what makes it worth fixing rather than noting: an operator removes someone precisely when they want that access gone, and this hands part of it back at exactly that moment — silently, and to the person just removed, who is the one most likely to still have the link.

## The fix

Delete the user's redeemed invitations before deleting the user, scoped by `used_by` so unredeemed invites and other users' invites are untouched.

Deleted rather than tombstoned because the schema has nowhere to record "spent, but its user is gone" — the only marker of consumption *is* the foreign key the cascade nulls. A spent invite that outlives its user is an open credential, and keeping the row for audit is not worth that. If you would rather preserve the audit trail, the alternative is a migration adding a `revoked_at` (or making `used_by` `ON DELETE RESTRICT` and cleaning up explicitly) — happy to redo it that way, but that is a schema change and this is not.

## Tests

`worker/src/__tests__/spent-invite-rearm.test.ts`, 5 tests. **4 fail without the fix**, including the one that matters:

```
× does not let the spent token create a new admin account afterwards
```

That test calls the public accept endpoint with the resurrected token and asserts no user is created. Without the fix it returns 200 and mints a fresh admin.

The 5th — an invite nobody has redeemed must survive an unrelated user being deleted — passes either way, as a negative control should.

```
Test Files  3 passed (3)
     Tests  35 passed (35)
```
(this suite, `admin-router`, `invites-router`.) `yarn tsc --noEmit` clean.

## Related, not fixed here

While reading this path I also noticed `PATCH /api/admin/users/{id}/role` has no last-admin guard, and combined with the existing self-edit block (`"Cannot change your own role"`) an instance can be left with no reachable admin. Separate concern, separate PR — say the word if you want it.