### PR TITLE
fix(ui): put mark-all-read in the same place on both thread types

### DIFF
--- a/src/components/MarkAllReadButton.tsx
+++ b/src/components/MarkAllReadButton.tsx
@@ -1,0 +1,43 @@
+import { CheckCheck } from "lucide-react";
+
+interface MarkAllReadButtonProps {
+  /** Number of unread received emails in scope. Renders nothing at 0. */
+  unreadCount: number;
+  /**
+   * What "all" covers, for the tooltip — e.g. `support@example.com` on a
+   * person's inbox tab, or the conversation's inbox on a group thread.
+   * The button label stays the same either way; only the tooltip narrows it.
+   */
+  scopeLabel: string;
+  onMarkAllRead: () => void;
+}
+
+/**
+ * The single mark-all-read affordance. Both thread surfaces (a person's
+ * inbox tab and a group conversation) render this in the same slot — the
+ * trailing end of the header row — so the control doesn't move depending
+ * on which kind of thread is open.
+ */
+export default function MarkAllReadButton({
+  unreadCount,
+  scopeLabel,
+  onMarkAllRead,
+}: MarkAllReadButtonProps) {
+  if (unreadCount <= 0) return null;
+
+  return (
+    <button
+      type="button"
+      data-testid="mark-all-read"
+      onClick={onMarkAllRead}
+      title={`Mark all ${unreadCount} unread in ${scopeLabel} as read`}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-[6px] border border-border bg-card px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
+    >
+      <CheckCheck size={13} />
+      Mark all read
+      <span className="ml-0.5 rounded-full bg-text-primary/[0.06] px-1.5 text-[10px] font-bold tabular-nums text-text-secondary">
+        {unreadCount}
+      </span>
+    </button>
+  );
+}

--- a/src/pages/ConversationDetail.tsx
+++ b/src/pages/ConversationDetail.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { Users, CheckCheck } from "lucide-react";
+import { Users } from "lucide-react";
+import MarkAllReadButton from "@/components/MarkAllReadButton";
 import {
   fetchConversationEmails,
   markEmailRead,
@@ -189,10 +190,11 @@ export default function ConversationDetail({
               {conversation.participants.length} participants
             </span>
           </div>
-          {totalUnread > 0 && (
-            <button
-              type="button"
-              onClick={() => {
+          <div className="flex shrink-0 items-center gap-2">
+            <MarkAllReadButton
+              unreadCount={totalUnread}
+              scopeLabel={conversation.inbox}
+              onMarkAllRead={() => {
                 // Mark every unread received email read sequentially.
                 for (const e of data.emails) {
                   if (e.type === "received" && e.isRead === 0) {
@@ -200,12 +202,8 @@ export default function ConversationDetail({
                   }
                 }
               }}
-              className="inline-flex items-center gap-1.5 rounded-[6px] border border-border bg-card px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
-            >
-              <CheckCheck size={12} />
-              Mark all read
-            </button>
-          )}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/pages/PersonDetail.tsx
+++ b/src/pages/PersonDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { CheckCheck, ShieldBan } from "lucide-react";
+import { ShieldBan } from "lucide-react";
 import {
   fetchPersonEmails,
   markEmailRead,
@@ -31,6 +31,7 @@ import ThreadInboxSection, {
   type ThreadInboxGroup,
 } from "@/components/ThreadInboxSection";
 import ChatInboxSection from "@/components/ChatInboxSection";
+import MarkAllReadButton from "@/components/MarkAllReadButton";
 import type { ComposePrefill } from "@/pages/ComposeModal";
 import { onEmailSent } from "@/lib/email-events";
 import { showToast } from "@/lib/toast";
@@ -401,6 +402,13 @@ export default function PersonDetail({
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
+            {activeGroup && (
+              <MarkAllReadButton
+                unreadCount={unreadIn(activeGroup)}
+                scopeLabel={activeGroup.inbox}
+                onMarkAllRead={() => handleMarkInboxRead(activeGroup.inbox)}
+              />
+            )}
             {enrollmentInfo?.enrollment ? (
               <SequenceStatus
                 personId={person.id}
@@ -499,23 +507,6 @@ export default function PersonDetail({
               );
             })}
           </div>
-        </div>
-      )}
-
-      {/* Per-inbox action row — visible when the active tab has unread emails */}
-      {activeGroup && unreadIn(activeGroup) > 0 && (
-        <div className="shrink-0 border-b border-border bg-bg-subtle/40 px-4 py-2">
-          <button
-            type="button"
-            onClick={() => handleMarkInboxRead(activeGroup.inbox)}
-            className="inline-flex items-center gap-1.5 rounded-[6px] px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-muted hover:text-text-primary"
-          >
-            <CheckCheck size={12} />
-            Mark all in {inboxLabel(activeGroup.inbox)} as read
-            <span className="ml-1 rounded-full bg-text-primary/[0.06] px-1.5 text-[10px] font-bold tabular-nums text-text-secondary">
-              {unreadIn(activeGroup)}
-            </span>
-          </button>
         </div>
       )}
 


### PR DESCRIPTION
Opening a thread, I could never predict where the mark-all-read control would be. It turns out it isn't just left-vs-right — the two thread surfaces disagree on four things at once:

| | Person thread | Group conversation |
|---|---|---|
| Position | Left | Right |
| Row | Its own full-width strip below the inbox tabs | Inside the header row |
| Style | Borderless text button | Outlined button |
| Label | `Mark all in support as read` + count | `Mark all read`, no count |

So it's a re-find every time, and the strip on the person view costs a row of vertical space on every thread that has unread mail.

![Before and after](https://raw.githubusercontent.com/mattgwagner/saasmail/assets/mark-all-read-ux/mark-all-read-comparison.png)

**What this does:** extracts the affordance into a single `MarkAllReadButton` and renders it from the same slot on both surfaces — the trailing action cluster of the header row. One component means the two can't drift apart again. The person view loses the extra strip entirely.

**What this deliberately does not change:** scope. The person view still marks only the *active inbox tab* read; the group view still marks the whole thread. Those are correct for their respective surfaces — a person has multiple inbox tabs, a group conversation is keyed to one inbox. The button label no longer tries to carry the scope; the tooltip does (`Mark all 7 unread in support@example.com as read`).

One honest note on "same place": on the group view the button is flush right (it's the only header action); on the person view it sits first in the existing `[mark read] [add to sequence] [block]` cluster, so it isn't pixel-identical. I kept that order rather than pushing it past `Block` — benign action before destructive one. Same row, same cluster, same style, which is what made it findable.

Screenshots are from `seeds/demo.sql`, not real mail.

Typecheck clean, `yarn test` green (76 files / 746 tests).
