### PR TITLE
fix(inbox): confirm and reset selection after blocking a sender

### DIFF
--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -383,6 +383,14 @@ export default function InboxPage() {
     );
   }
 
+  // The open thread's sender (or their whole domain) was just blocked, so it
+  // no longer belongs in the inbox. Drop the selection back to "no mail
+  // selected" and refresh the list so the hidden thread disappears.
+  function handlePersonBlocked() {
+    setSelectedPerson(null);
+    refreshPeople();
+  }
+
   function handleEmailDelete(personId: string, wasUnread: boolean) {
     setItems((prev) =>
       prev.map((it) =>
@@ -553,6 +561,7 @@ export default function InboxPage() {
                   onEmailDelete={handleEmailDelete}
                   refreshKey={refreshKey}
                   onOpenCompose={onCompose}
+                  onBlock={handlePersonBlocked}
                 />
               </div>
             </div>
@@ -701,6 +710,7 @@ export default function InboxPage() {
                       onEmailDelete={handleEmailDelete}
                       refreshKey={refreshKey}
                       onOpenCompose={onCompose}
+                      onBlock={handlePersonBlocked}
                     />
                   </div>
                 </div>

--- a/src/pages/PersonDetail.tsx
+++ b/src/pages/PersonDetail.tsx
@@ -48,6 +48,12 @@ interface PersonDetailProps {
    * subject) so the drawer opens with the reply context applied.
    */
   onOpenCompose?: (prefill?: ComposePrefill) => void;
+  /**
+   * Called after the sender (or their whole domain) is blocked. The parent
+   * uses this to clear the current selection so the view falls back to
+   * "no mail selected" — the thread is now hidden from the inbox.
+   */
+  onBlock?: () => void;
 }
 
 function inboxOf(email: Email): string {
@@ -115,6 +121,7 @@ export default function PersonDetail({
   onEmailDelete,
   refreshKey,
   onOpenCompose,
+  onBlock,
 }: PersonDetailProps) {
   const navigate = useNavigate();
   const [emails, setEmails] = useState<Email[]>([]);
@@ -143,9 +150,31 @@ export default function PersonDetail({
     if (!value) return;
     try {
       await addBlock({ type, value });
-      navigate("/"); // thread is now hidden; return to the inbox
+      showToast({
+        kind: "success",
+        message: `Blocked ${value}`,
+        description:
+          type === "domain"
+            ? "Future mail from this domain is dropped and its threads are hidden."
+            : "Future mail from this address is dropped and its threads are hidden.",
+        durationMs: 5000,
+      });
+      // The thread is now hidden. Clear the parent's selection so the view
+      // falls back to "no mail selected"; fall back to a route change when
+      // the component is used standalone.
+      if (onBlock) onBlock();
+      else navigate("/");
     } catch {
-      // Most likely a self-block guard rejection; leave the user on the thread.
+      // Most likely a self-block guard rejection; leave the user on the
+      // thread, but tell them the block didn't go through.
+      showToast({
+        kind: "error",
+        message: "Couldn't block",
+        description:
+          type === "domain"
+            ? "This domain couldn't be blocked. It may be one of your own."
+            : "This address couldn't be blocked. It may be one of your own.",
+      });
     }
   }
 


### PR DESCRIPTION
## What

Clicking **Block entire domain** (or **Block <email>**) from the thread header now:

1. **Shows a success toast** confirming the block landed.
2. **Resets the inbox back to "no mail selected"** so the just-blocked thread disappears instead of lingering on screen.

## Why

`handleBlock` in `PersonDetail` called `navigate("/")` after a successful block. But in the inbox the component is embedded and selection is tracked by `InboxPage`'s own `selectedPerson` state, which `navigate("/")` never cleared — so the blocked thread stayed visible and there was no confirmation anything happened.

## How

- `PersonDetail` gained an `onBlock?` callback and now fires a success toast on block (and an error toast if the block is rejected, e.g. a self-block guard, instead of failing silently).
- `InboxPage` passes `onBlock={handlePersonBlocked}`, which clears the selection and refreshes the people list. `navigate("/")` is kept as a fallback for standalone use.

## Testing

- `yarn tsc --noEmit` — passes
- `yarn test` — 76 files, 749 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)