### PR TITLE
docs: add AGENTS.md (prettier, drizzle --custom migrations)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,76 @@
 # Agent / contributor notes
 
-Conventions for humans and coding agents working in this repo. Product docs stay in `README.md`; Claude Code skills stay in `CLAUDE.md`.
+Conventions for coding agents (and humans) working in this repo. Product docs live in [`README.md`](./README.md); licensing and human contribution flow in [`CONTRIBUTING.md`](./CONTRIBUTING.md); Claude Code skills in [`CLAUDE.md`](./CLAUDE.md).
+
+## Doc map
+
+| Doc                                                                      | Use for                                |
+| ------------------------------------------------------------------------ | -------------------------------------- |
+| [`README.md`](./README.md)                                               | Setup, deploy, local dev, API overview |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                                   | Fork/PR process, Apache 2.0, CoC       |
+| [`migrations/README.md`](./migrations/README.md)                         | drizzle-kit generate / apply details   |
+| [`.github/pull_request_template.md`](./.github/pull_request_template.md) | PR checklist CI reviewers expect       |
 
 ## Tooling
 
-- Use **yarn**, not npm.
-- **Format:** `yarn format` before push; CI runs `yarn format:check` (Prettier) on every PR.
+- Use **yarn**, not npm (`yarn install --frozen-lockfile` in CI).
+- **Format:** `yarn format` before push. Husky runs `lint-staged` → Prettier on commit; CI runs `yarn format:check`.
 - **Typecheck:** `yarn tsc --noEmit`
-- **Tests:** `yarn test` (uses `vitest.config.test.ts` — not bare `vitest run`)
+- **Unit tests:** `yarn test` (always with `vitest.config.test.ts` — bare `vitest run` breaks in this pool).
+- **E2E:** `yarn test:e2e` (Playwright; **wipes local D1** — re-seed with `yarn db:seed:dev` afterward). Needs `DEMO_MODE=1` + `DISABLE_PASSKEY_GATE=true` in `.dev.vars` (see `.dev.vars.example`).
+
+### Local `yarn test` prerequisites
+
+Vitest uses `@cloudflare/vitest-pool-workers`, which requires a present `wrangler.jsonc` (gitignored) and `dist/client/`. CI does:
+
+```bash
+cp wrangler.jsonc.ci wrangler.jsonc
+mkdir -p dist/client
+yarn tsc --noEmit
+yarn test
+```
+
+Fresh clones can also start from `wrangler.jsonc.example`.
+
+## CI gates on every PR
+
+| Workflow        | What fails the PR                                      |
+| --------------- | ------------------------------------------------------ |
+| Format          | `yarn format:check`                                    |
+| Test            | `yarn tsc --noEmit` + `yarn test`                      |
+| e2e             | `yarn test:e2e`                                        |
+| Check PR labels | Missing **exactly one** of `major` / `minor` / `patch` |
+| CodeQL          | Security/quality findings (advisory)                   |
+
+Semver labels drive [release-drafter](./.github/release-drafter.yml). Dependabot PRs already get `patch`. For human PRs, apply one of `major`/`minor`/`patch` (docs-only → `patch`). The `hold` label is invalid for merge via that check.
+
+## Pull requests
+
+From [`CONTRIBUTING.md`](./CONTRIBUTING.md) + the PR template:
+
+1. Focused change; branch off `main`.
+2. `yarn format` / `yarn tsc --noEmit` / `yarn test` (and `yarn test:e2e` if UI or HTTP surface changed).
+3. User-visible change → entry under `## [Unreleased]` in `CHANGELOG.md`.
+4. Schema or data migration → see below; include the generated files.
+5. Label the PR `major`, `minor`, or `patch`.
+6. Behavior/setup change → update `README.md` (or other docs) when relevant.
 
 ## Migrations (D1 / drizzle-kit)
 
 Do **not** hand-author `migrations/*.sql` or edit `migrations/meta/_journal.json` / snapshots by hand — that desyncs the drizzle-kit journal.
 
-| Change type                                  | Command                                                                         |
-| -------------------------------------------- | ------------------------------------------------------------------------------- |
-| Schema change in `worker/src/db/*.schema.ts` | `yarn db:generate`                                                              |
-| Data-only backfill (no schema change)        | `yarn db:generate -- --custom --name=<slug>` then paste SQL into the empty file |
+| Change type                           | Command                                                                         |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| Schema in `worker/src/db/*.schema.ts` | `yarn db:generate`                                                              |
+| Auth tables (better-auth)             | change config → `yarn auth:generate` → then `yarn db:generate`                  |
+| Data-only backfill (no schema change) | `yarn db:generate -- --custom --name=<slug>` then paste SQL into the empty file |
 
 Plain `yarn db:generate` emits nothing for data-only work ("No schema changes, nothing to migrate"). `--custom` creates a journaled empty migration **and** the matching `meta/NNNN_snapshot.json`; paste `UPDATE`/`INSERT` SQL into the generated `.sql`.
 
+`yarn db:generate` needs a local D1 under `.wrangler/` (run `yarn dev` once, or e2e setup, if it says `D1 directory not found`).
+
 Details: [`migrations/README.md`](./migrations/README.md). Apply with `yarn db:migrate:dev` / `yarn db:migrate:prod`.
+
+## API surface
+
+Backend routes are Hono + Zod OpenAPI under `worker/src/routers/`. Spec is served at `/doc` (JSON) and `/swagger-ui` (not `/openapi.json` / `/api/doc`). When changing request/response shapes, update the zod-openapi schemas so `/doc` stays accurate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ From [`CONTRIBUTING.md`](./CONTRIBUTING.md) + the PR template:
 2. `yarn format` / `yarn tsc --noEmit` / `yarn test` (and `yarn test:e2e` if UI or HTTP surface changed).
 3. User-visible change → entry under `## [Unreleased]` in `CHANGELOG.md`.
 4. Schema or data migration → see below; include the generated files.
-5. Label the PR `major`, `minor`, or `patch`.
-6. Behavior/setup change → update `README.md` (or other docs) when relevant.
+5. Behavior/setup change → update `README.md` (or other docs) when relevant.
+
+A maintainer will add the required `major` / `minor` / `patch` label for release-drafter (fork openers cannot set labels on this repo).
 
 ## Migrations (D1 / drizzle-kit)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,24 +4,24 @@ Conventions for coding agents (and humans) working in this repo. Product docs li
 
 ## Doc map
 
-| Doc                                                                      | Use for                                |
-| ------------------------------------------------------------------------ | -------------------------------------- |
-| [`README.md`](./README.md)                                               | Setup, deploy, local dev, API overview |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                                   | Fork/PR process, Apache 2.0, CoC       |
-| [`migrations/README.md`](./migrations/README.md)                         | drizzle-kit generate / apply details   |
-| [`.github/pull_request_template.md`](./.github/pull_request_template.md) | PR checklist CI reviewers expect       |
+| Doc                                                                      | Use for                                             |
+| ------------------------------------------------------------------------ | --------------------------------------------------- |
+| [`README.md`](./README.md)                                               | Setup, deploy, local dev, API overview              |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                                   | Fork/PR process, Apache 2.0, CoC                    |
+| [`migrations/README.md`](./migrations/README.md)                         | drizzle-kit generate / apply details                |
+| [`.github/pull_request_template.md`](./.github/pull_request_template.md) | PR checklist maintainers expect (not a CI enforcer) |
 
 ## Tooling
 
 - Use **yarn**, not npm (`yarn install --frozen-lockfile` in CI).
-- **Format:** `yarn format` before push. Husky runs `lint-staged` → Prettier on commit; CI runs `yarn format:check`.
+- **Format:** `yarn format` before push. Husky runs `lint-staged` → Prettier on staged `*.{js,jsx,ts,tsx,json,css,md,html}` at commit; CI runs full-tree `yarn format:check` (so husky alone is not enough if you skip staging a dirty file).
 - **Typecheck:** `yarn tsc --noEmit`
-- **Unit tests:** `yarn test` (always with `vitest.config.test.ts` — bare `vitest run` breaks in this pool).
-- **E2E:** `yarn test:e2e` (Playwright; **wipes local D1** — re-seed with `yarn db:seed:dev` afterward). Needs `DEMO_MODE=1` + `DISABLE_PASSKEY_GATE=true` in `.dev.vars` (see `.dev.vars.example`).
+- **Unit tests:** `yarn test` (invokes `vitest run --config vitest.config.test.ts` — bare `vitest run` hits the wrong pool config and fails to start).
+- **E2E:** `yarn test:e2e` (Playwright; **wipes local D1** — re-seed with `yarn db:seed:dev` afterward). Needs `DEMO_MODE=1` + `DISABLE_PASSKEY_GATE=true` in `.dev.vars`, and `http://localhost:8788` in `TRUSTED_ORIGINS` in `wrangler.jsonc` (see `.dev.vars.example` / `wrangler.jsonc.example` and README “End-to-end tests”).
 
 ### Local `yarn test` prerequisites
 
-Vitest uses `@cloudflare/vitest-pool-workers`, which requires a present `wrangler.jsonc` (gitignored) and `dist/client/`. CI does:
+Vitest uses `@cloudflare/vitest-pool-workers`, which requires a present `wrangler.jsonc` (gitignored) and `dist/client/`. Match CI:
 
 ```bash
 cp wrangler.jsonc.ci wrangler.jsonc
@@ -30,19 +30,20 @@ yarn tsc --noEmit
 yarn test
 ```
 
-Fresh clones can also start from `wrangler.jsonc.example`.
+Prefer `wrangler.jsonc.ci` for unit tests (placeholders tuned for the pool). Use `wrangler.jsonc.example` when setting up local `yarn dev` / deploy, not as a guaranteed drop-in for vitest.
 
-## CI gates on every PR
+## CI on every PR
 
-| Workflow        | What fails the PR                                      |
-| --------------- | ------------------------------------------------------ |
-| Format          | `yarn format:check`                                    |
-| Test            | `yarn tsc --noEmit` + `yarn test`                      |
-| e2e             | `yarn test:e2e`                                        |
-| Check PR labels | Missing **exactly one** of `major` / `minor` / `patch` |
-| CodeQL          | Security/quality findings (advisory)                   |
+| Workflow / check name                               | Merge impact                                                                                                                                                                                                                                           |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Format → `prettier`                                 | Fails if `yarn format:check` fails                                                                                                                                                                                                                     |
+| Test → `vitest` (+ typecheck step in that workflow) | Fails on `yarn tsc --noEmit` or `yarn test`                                                                                                                                                                                                            |
+| e2e → `playwright`                                  | Fails on `yarn test:e2e`                                                                                                                                                                                                                               |
+| Check PR labels → job named `test`                  | Fails unless the PR has **at least one** of `major` / `minor` / `patch`; also fails if `hold` is present (`disable-reviews: true`, so this is a failing check — not a review). Note the job is named `test`, distinct from the Test/`vitest` workflow. |
+| CodeQL → `Analyze (javascript-typescript)`          | Runs on PRs to `main`; findings are uploaded via codeql-action (do not treat SARIF alerts as an automatic red X unless the Analyze job itself fails)                                                                                                   |
+| Release Drafter → `update_release_draft`            | Updates draft release notes; not a content gate                                                                                                                                                                                                        |
 
-Semver labels drive [release-drafter](./.github/release-drafter.yml). Dependabot PRs already get `patch`. For human PRs, apply one of `major`/`minor`/`patch` (docs-only → `patch`). The `hold` label is invalid for merge via that check.
+Semver labels drive [release-drafter](./.github/release-drafter.yml). Dependabot PRs already get `patch`. **Maintainers** apply `major` / `minor` / `patch` on human PRs — external fork openers generally cannot set labels on `choyiny/saasmail`. Docs-only → `patch`.
 
 ## Pull requests
 
@@ -54,19 +55,19 @@ From [`CONTRIBUTING.md`](./CONTRIBUTING.md) + the PR template:
 4. Schema or data migration → see below; include the generated files.
 5. Behavior/setup change → update `README.md` (or other docs) when relevant.
 
-A maintainer will add the required `major` / `minor` / `patch` label for release-drafter (fork openers cannot set labels on this repo).
+A maintainer will add the required semver label so the Check PR labels check goes green.
 
 ## Migrations (D1 / drizzle-kit)
 
 Do **not** hand-author `migrations/*.sql` or edit `migrations/meta/_journal.json` / snapshots by hand — that desyncs the drizzle-kit journal.
 
-| Change type                           | Command                                                                         |
-| ------------------------------------- | ------------------------------------------------------------------------------- |
-| Schema in `worker/src/db/*.schema.ts` | `yarn db:generate`                                                              |
-| Auth tables (better-auth)             | change config → `yarn auth:generate` → then `yarn db:generate`                  |
-| Data-only backfill (no schema change) | `yarn db:generate -- --custom --name=<slug>` then paste SQL into the empty file |
+| Change type                           | Command                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------- |
+| Schema in `worker/src/db/*.schema.ts` | `yarn db:generate`                                                           |
+| Auth tables (better-auth)             | change config → `yarn auth:generate` → then `yarn db:generate`               |
+| Data-only backfill (no schema change) | `yarn db:generate --custom --name=<slug>` then paste SQL into the empty file |
 
-Plain `yarn db:generate` emits nothing for data-only work ("No schema changes, nothing to migrate"). `--custom` creates a journaled empty migration **and** the matching `meta/NNNN_snapshot.json`; paste `UPDATE`/`INSERT` SQL into the generated `.sql`.
+(`yarn db:generate` is `drizzle-kit generate`; `--custom` / `--name` are drizzle-kit flags. Plain generate emits nothing for data-only work: "No schema changes, nothing to migrate". `--custom` creates a journaled empty migration **and** the matching `meta/NNNN_snapshot.json`.)
 
 `yarn db:generate` needs a local D1 under `.wrangler/` (run `yarn dev` once, or e2e setup, if it says `D1 directory not found`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent / contributor notes
+
+Conventions for humans and coding agents working in this repo. Product docs stay in `README.md`; Claude Code skills stay in `CLAUDE.md`.
+
+## Tooling
+
+- Use **yarn**, not npm.
+- **Format:** `yarn format` before push; CI runs `yarn format:check` (Prettier) on every PR.
+- **Typecheck:** `yarn tsc --noEmit`
+- **Tests:** `yarn test` (uses `vitest.config.test.ts` — not bare `vitest run`)
+
+## Migrations (D1 / drizzle-kit)
+
+Do **not** hand-author `migrations/*.sql` or edit `migrations/meta/_journal.json` / snapshots by hand — that desyncs the drizzle-kit journal.
+
+| Change type                                  | Command                                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------------------- |
+| Schema change in `worker/src/db/*.schema.ts` | `yarn db:generate`                                                              |
+| Data-only backfill (no schema change)        | `yarn db:generate -- --custom --name=<slug>` then paste SQL into the empty file |
+
+Plain `yarn db:generate` emits nothing for data-only work ("No schema changes, nothing to migrate"). `--custom` creates a journaled empty migration **and** the matching `meta/NNNN_snapshot.json`; paste `UPDATE`/`INSERT` SQL into the generated `.sql`.
+
+Details: [`migrations/README.md`](./migrations/README.md). Apply with `yarn db:migrate:dev` / `yarn db:migrate:prod`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Self-hosted email server on Cloudflare Workers. See README.md for full documentation.
 
-Contributor and coding-agent conventions (format check, tests, drizzle migrations including data-only `--custom`): see **[AGENTS.md](./AGENTS.md)**.
+Contributor and coding-agent conventions (CI gates, Prettier, PR semver labels, drizzle migrations including data-only `--custom`): see **[AGENTS.md](./AGENTS.md)**.
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Self-hosted email server on Cloudflare Workers. See README.md for full documentation.
 
+Contributor and coding-agent conventions (format check, tests, drizzle migrations including data-only `--custom`): see **[AGENTS.md](./AGENTS.md)**.
+
 ## Development
 
 - Use `yarn` for all dependency commands (not npm)
@@ -10,6 +12,7 @@ Self-hosted email server on Cloudflare Workers. See README.md for full documenta
 - Database: Drizzle ORM with D1 in `worker/src/db/`
 - Run `yarn tsc --noEmit` to type-check before committing
 - Run `yarn test` for tests
+- Run `yarn format` / `yarn format:check` before pushing (CI enforces Prettier)
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,4 @@ Contributor and coding-agent conventions (CI gates, Prettier, PR semver labels, 
 - `/saasmail-onboarding` — Interactive setup wizard for deploying a new saasmail instance
 - `/use-saasmail` — How to call a deployed saasmail instance's HTTP API to send emails (raw or via templates) and enroll recipients in sequences
 - `/create-saasmail-template` — Authoring email templates: the `{{variable}}` grammar, conditional and repeating `{{#section}}` rules, escaping, and the required-vs-optional send contract
+- `/update-saasmail` — Rebase a fork onto `upstream/main` (links the upstream remote if needed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ saasmail is licensed under [Apache License 2.0](LICENSE). There is **no CLA**. B
 6. If you changed the schema, generate a migration: `yarn db:generate` (data-only backfills: see [AGENTS.md](AGENTS.md) / [migrations/README.md](migrations/README.md))
 7. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for any user-visible change
 8. Commit and push your branch
-9. Open a pull request against `main` and label it `major`, `minor`, or `patch` (required by CI)
+9. Open a pull request against `main` (a maintainer adds the `major` / `minor` / `patch` label CI requires)
 
 > Note: [AGENTS.md](AGENTS.md) holds contributor/CI notes used by coding agents (and humans). [CLAUDE.md](CLAUDE.md) is optional [Claude Code](https://claude.ai/claude-code) skill context — you don't need Claude Code to contribute.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ saasmail is licensed under [Apache License 2.0](LICENSE). There is **no CLA**. B
 
 - Describe what your PR does and why
 - Keep PRs focused — one feature or fix per PR
-- Include any relevant migration files if you changed the database schema (`yarn db:generate`)
+- Include any relevant migration files if you changed the database schema (`yarn db:generate`) or added a data-only migration (`yarn db:generate --custom --name=…`)
+- A maintainer will attach `major` / `minor` / `patch` so the label check can pass
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ saasmail is licensed under [Apache License 2.0](LICENSE). There is **no CLA**. B
 8. Commit and push your branch
 9. Open a pull request against `main` and label it `major`, `minor`, or `patch` (required by CI)
 
-> Note: a `CLAUDE.md` at the repo root contains notes the maintainer uses with [Claude Code](https://claude.ai/claude-code). It's optional context — you don't need Claude Code to contribute.
+> Note: [AGENTS.md](AGENTS.md) holds contributor/CI notes used by coding agents (and humans). [CLAUDE.md](CLAUDE.md) is optional [Claude Code](https://claude.ai/claude-code) skill context — you don't need Claude Code to contribute.
 
 ## Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to saasmail. Please also read the [Code of Conduct](CODE_OF_CONDUCT.md) — it applies in every project space.
 
+Coding-agent and CI conventions (Prettier, PR semver labels, drizzle `--custom` data migrations, local test prerequisites) live in **[AGENTS.md](AGENTS.md)** — same rules apply to human contributors.
+
 ## Licensing of contributions
 
 saasmail is licensed under [Apache License 2.0](LICENSE). There is **no CLA**. By opening a pull request you agree that your contribution is licensed under the same Apache 2.0 license as the rest of the project, and that you have the right to license it.
@@ -17,12 +19,13 @@ saasmail is licensed under [Apache License 2.0](LICENSE). There is **no CLA**. B
 
 1. Create a branch from `main`: `git checkout -b my-feature`
 2. Make your changes
-3. Run tests: `yarn test`
-4. Run type checking: `yarn tsc --noEmit`
-5. If you changed the schema, generate a migration: `yarn db:generate`
-6. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for any user-visible change
-7. Commit and push your branch
-8. Open a pull request against `main`
+3. Format: `yarn format` (CI runs `yarn format:check`)
+4. Run tests: `yarn test`
+5. Run type checking: `yarn tsc --noEmit`
+6. If you changed the schema, generate a migration: `yarn db:generate` (data-only backfills: see [AGENTS.md](AGENTS.md) / [migrations/README.md](migrations/README.md))
+7. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for any user-visible change
+8. Commit and push your branch
+9. Open a pull request against `main` and label it `major`, `minor`, or `patch` (required by CI)
 
 > Note: a `CLAUDE.md` at the repo root contains notes the maintainer uses with [Claude Code](https://claude.ai/claude-code). It's optional context — you don't need Claude Code to contribute.
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -38,7 +38,7 @@ one-shot backfill / `UPDATE` migration, generate a custom empty file
 through the CLI, then paste the SQL:
 
 ```
-yarn db:generate -- --custom --name=mark_blocked_senders_read
+yarn db:generate --custom --name=mark_blocked_senders_read
 # -> migrations/NNNN_mark_blocked_senders_read.sql (empty)
 # -> migrations/meta/NNNN_snapshot.json + journal entry
 # edit the .sql with your UPDATE/INSERT statements

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -9,9 +9,11 @@ next change).
 
 ## Generating a migration
 
-The normal drizzle-kit workflow. **Do not hand-write migration SQL** —
-edit the schema and let the generator produce the file, so the
+The normal drizzle-kit workflow. **Do not hand-write migration SQL or
+journal/snapshot entries** — let the generator produce the files so the
 snapshot chain stays consistent.
+
+### Schema changes
 
 ```
 # 1. edit the schema in worker/src/db/*.schema.ts
@@ -27,6 +29,24 @@ dev branch resolves the local D1 file under `.wrangler/`. If you
 haven't started the dev server yet it errors with
 `D1 directory not found … Run 'wrangler dev' first` — run the dev
 server once (or the e2e setup) so the local D1 exists, then generate.
+
+### Data-only migrations (no schema change)
+
+Plain `yarn db:generate` diffs the schema and emits nothing when only
+data needs updating ("No schema changes, nothing to migrate"). For a
+one-shot backfill / `UPDATE` migration, generate a custom empty file
+through the CLI, then paste the SQL:
+
+```
+yarn db:generate -- --custom --name=mark_blocked_senders_read
+# -> migrations/NNNN_mark_blocked_senders_read.sql (empty)
+# -> migrations/meta/NNNN_snapshot.json + journal entry
+# edit the .sql with your UPDATE/INSERT statements
+yarn db:migrate:dev
+```
+
+Do not invent `NNNN_*.sql` + a `_journal.json` row by hand — that
+skips the snapshot and breaks later `drizzle-kit generate` runs.
 
 ## Apply path
 


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with lean contributor/agent conventions: yarn, Prettier (`format:check`), tests, and the drizzle-kit migration table (schema vs data-only `--custom`).
- Point `CLAUDE.md` at `AGENTS.md` and mention the format check CI gate.
- Document data-only migrations in `migrations/README.md` — plain `db:generate` emits nothing for UPDATE-only backfills; `yarn db:generate -- --custom --name=<slug>` journals an empty file + snapshot to paste SQL into.

## Test plan
- [ ] Skim AGENTS.md / CLAUDE.md for accuracy against `package.json` scripts
- [ ] Confirm `yarn db:generate -- --custom --name=…` still matches drizzle-kit CLI on current yarn scripts


Made with [Cursor](https://cursor.com)