### PR TITLE
feat(drafts): autosave compose & reply drafts

### DIFF
--- a/migrations/0034_closed_krista_starr.sql
+++ b/migrations/0034_closed_krista_starr.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `drafts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`context_key` text NOT NULL,
+	`from_address` text,
+	`to_address` text,
+	`cc` text,
+	`subject` text,
+	`body_html` text,
+	`body_text` text,
+	`reply_to_email_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `drafts_user_context_idx` ON `drafts` (`user_id`,`context_key`);

--- a/migrations/meta/0034_snapshot.json
+++ b/migrations/meta/0034_snapshot.json
@@ -1,0 +1,2719 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e01d31ee-372e-4704-81ce-4c0532497391",
+  "prevId": "70883161-a336-4cc4-b070-126fef86ca12",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwkss": {
+      "name": "jwkss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessTokens_clientId_idx": {
+          "name": "oauthAccessTokens_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessTokens_sessionId_idx": {
+          "name": "oauthAccessTokens_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessTokens_userId_idx": {
+          "name": "oauthAccessTokens_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauthAccessTokens_refreshId_idx": {
+          "name": "oauthAccessTokens_refreshId_idx",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_access_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauthClients_userId_idx": {
+          "name": "oauthClients_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthConsents_clientId_idx": {
+          "name": "oauthConsents_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthConsents_userId_idx": {
+          "name": "oauthConsents_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "oauthRefreshTokens_clientId_idx": {
+          "name": "oauthRefreshTokens_clientId_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshTokens_sessionId_idx": {
+          "name": "oauthRefreshTokens_sessionId_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauthRefreshTokens_userId_idx": {
+          "name": "oauthRefreshTokens_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_sessions_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_sessions_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_userId_idx": {
+          "name": "passkeys_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkeys_credentialID_idx": {
+          "name": "passkeys_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_email_at": {
+          "name": "last_email_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "people_last_email_at_idx": {
+          "name": "people_last_email_at_idx",
+          "columns": [
+            "last_email_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emails": {
+      "name": "emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_headers": {
+          "name": "raw_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spf": {
+          "name": "spf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dkim": {
+          "name": "dkim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dmarc": {
+          "name": "dmarc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "emails_message_id_unique": {
+          "name": "emails_message_id_unique",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "emails_person_received_idx": {
+          "name": "emails_person_received_idx",
+          "columns": [
+            "person_id",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_recipient_received_idx": {
+          "name": "emails_recipient_received_idx",
+          "columns": [
+            "recipient",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "emails_conversation_idx": {
+          "name": "emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sent_emails": {
+      "name": "sent_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sent'"
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sent_emails_person_sent_idx": {
+          "name": "sent_emails_person_sent_idx",
+          "columns": [
+            "person_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_conversation_idx": {
+          "name": "sent_emails_conversation_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "sent_emails_from_sent_idx": {
+          "name": "sent_emails_from_sent_idx",
+          "columns": [
+            "from_address",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inbound'"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attachments_email_id_idx": {
+          "name": "attachments_email_id_idx",
+          "columns": [
+            "email_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_templates_slug_unique": {
+          "name": "email_templates_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_used_by_users_id_fk": {
+          "name": "invitations_used_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_unique": {
+          "name": "api_keys_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequences": {
+      "name": "sequences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_enrollments": {
+      "name": "sequence_enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrollments_person_status_idx": {
+          "name": "enrollments_person_status_idx",
+          "columns": [
+            "person_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "enrollments_sequence_status_idx": {
+          "name": "enrollments_sequence_status_idx",
+          "columns": [
+            "sequence_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_emails": {
+      "name": "sequence_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seq_emails_status_scheduled_idx": {
+          "name": "seq_emails_status_scheduled_idx",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "seq_emails_enrollment_id_idx": {
+          "name": "seq_emails_enrollment_id_idx",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sender_identities": {
+      "name": "sender_identities",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'thread'"
+        },
+        "signature_html": {
+          "name": "signature_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forward_to": {
+          "name": "forward_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_permissions": {
+      "name": "inbox_permissions",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inbox_permissions_email_idx": {
+          "name": "inbox_permissions_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_permissions_user_id_users_id_fk": {
+          "name": "inbox_permissions_user_id_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_permissions_created_by_users_id_fk": {
+          "name": "inbox_permissions_created_by_users_id_fk",
+          "tableFrom": "inbox_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "inbox_permissions_user_id_email_pk": {
+          "columns": [
+            "user_id",
+            "email"
+          ],
+          "name": "inbox_permissions_user_id_email_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suppressions": {
+      "name": "suppressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "suppressions_email_unique": {
+          "name": "suppressions_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "suppressions_created_at_idx": {
+          "name": "suppressions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocklist": {
+      "name": "blocklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blocklist_created_at_idx": {
+          "name": "blocklist_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "blocklist_type_value_unique": {
+          "name": "blocklist_type_value_unique",
+          "columns": [
+            "type",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "drafts": {
+      "name": "drafts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_email_id": {
+          "name": "reply_to_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "drafts_user_context_idx": {
+          "name": "drafts_user_context_idx",
+          "columns": [
+            "user_id",
+            "context_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "drafts_user_id_users_id_fk": {
+          "name": "drafts_user_id_users_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1786470226468,
       "tag": "0033_mark_blocked_senders_read",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1788062708146,
+      "tag": "0034_closed_krista_starr",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/InboxToolbar.tsx
+++ b/src/components/InboxToolbar.tsx
@@ -23,6 +23,8 @@ export interface InboxFilters {
   recipient?: string;
   unread?: boolean;
   hasAttachment?: boolean;
+  /** Only conversations where you've started a reply draft. */
+  drafts?: boolean;
 }
 
 export type InboxView = "list" | "table";
@@ -111,7 +113,10 @@ export default function InboxToolbar({
     ? inboxOptionLabel(activeInbox)
     : "All inboxes";
   const hasActiveFilters =
-    !!filters.recipient || !!filters.unread || !!filters.hasAttachment;
+    !!filters.recipient ||
+    !!filters.unread ||
+    !!filters.hasAttachment ||
+    !!filters.drafts;
 
   return (
     <div className="flex flex-wrap items-center gap-1 rounded-[8px] bg-card p-1 ring-1 ring-border">
@@ -220,6 +225,11 @@ export default function InboxToolbar({
         onClick={() => onFiltersChange({ ...filters, unread: !filters.unread })}
       />
       <ToolbarToggle
+        label="Drafts"
+        active={!!filters.drafts}
+        onClick={() => onFiltersChange({ ...filters, drafts: !filters.drafts })}
+      />
+      <ToolbarToggle
         label="Attachments"
         active={!!filters.hasAttachment}
         onClick={() =>
@@ -238,6 +248,7 @@ export default function InboxToolbar({
               recipient: undefined,
               unread: false,
               hasAttachment: false,
+              drafts: false,
             })
           }
           className="inline-flex h-7 items-center gap-1 rounded-[5px] px-1.5 text-xs font-medium text-text-tertiary transition-colors hover:bg-bg-muted hover:text-text-primary"

--- a/src/components/ReplyComposer.tsx
+++ b/src/components/ReplyComposer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   X,
@@ -29,6 +29,7 @@ import {
   type CcEntry,
 } from "@/lib/api";
 import { dispatchEmailSent } from "@/lib/email-events";
+import { useDraftAutosave } from "@/lib/use-draft-autosave";
 import { getFromLabel } from "@/lib/format";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
 import { analyzeTemplateClient, chipLabel } from "@/lib/template-syntax";
@@ -81,6 +82,29 @@ export default function ReplyComposer({
   // Compact tray vs. full-viewport. Toggled by the maximize button.
   const [fullscreen, setFullscreen] = useState(false);
 
+  // Set once a saved reply draft has been restored, so the reply-all CC
+  // default below yields to the draft's own CC regardless of which async
+  // load resolves first.
+  const draftRestoredRef = useRef(false);
+
+  // Autosave the freeform reply so a half-written reply survives closing the
+  // composer, keyed to the email being replied to.
+  const bodyIsEmpty = !bodyHtml || bodyHtml === "<p></p>";
+  const { clear: clearDraft } = useDraftAutosave({
+    contextKey: `reply:${emailId}`,
+    enabled: true,
+    isEmpty: bodyIsEmpty,
+    restore: true,
+    values: { fromAddress, cc, bodyHtml, bodyText, replyToEmailId: emailId },
+    onRestore: (draft) => {
+      draftRestoredRef.current = true;
+      if (draft.bodyHtml) setBodyHtml(draft.bodyHtml);
+      if (draft.bodyText) setBodyText(draft.bodyText);
+      if (draft.cc) setCc(draft.cc);
+      if (draft.fromAddress) setFromAddress(draft.fromAddress);
+    },
+  });
+
   // Sync the signature trail to the active From inbox.
   useEffect(() => {
     if (!fromAddress) {
@@ -127,7 +151,7 @@ export default function ReplyComposer({
       .then(async (email) => {
         if (cancelled) return;
         setOriginalEmail(email);
-        if (email.cc && email.cc.length > 0) {
+        if (email.cc && email.cc.length > 0 && !draftRestoredRef.current) {
           // Drop our own inbox addresses from the suggested CC list — we
           // don't want to CC ourselves on a reply we're sending.
           const ours = new Set(recipients.map((r) => r.toLowerCase()));
@@ -251,6 +275,8 @@ export default function ReplyComposer({
         });
       }
       setFiles([]);
+      // The reply went out — discard its draft so it doesn't reappear.
+      clearDraft();
       // Notify the rest of the app — PersonDetail uses this to
       // auto-switch the active inbox tab when the user replied from a
       // different inbox than the one they were viewing.

--- a/src/lib/__tests__/use-draft-autosave.test.tsx
+++ b/src/lib/__tests__/use-draft-autosave.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useDraftAutosave, type DraftValues } from "@/lib/use-draft-autosave";
+import { fetchDraft, saveDraft, deleteDraft, type Draft } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  fetchDraft: vi.fn(),
+  saveDraft: vi.fn(),
+  deleteDraft: vi.fn(),
+}));
+
+const mFetch = vi.mocked(fetchDraft);
+const mSave = vi.mocked(saveDraft);
+const mDelete = vi.mocked(deleteDraft);
+
+type Props = Parameters<typeof useDraftAutosave>[0];
+const baseProps = (over: Partial<Props> = {}): Props => ({
+  contextKey: "compose",
+  enabled: true,
+  isEmpty: false,
+  restore: false,
+  values: { to: "a@b.com", subject: "Hi", bodyHtml: "<p>x</p>" } as DraftValues,
+  onRestore: () => {},
+  debounceMs: 1000,
+  ...over,
+});
+
+beforeEach(() => {
+  mFetch.mockReset().mockResolvedValue(null);
+  mSave.mockReset().mockResolvedValue({} as Draft);
+  mDelete.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDraftAutosave", () => {
+  it("debounced-saves when there's content", () => {
+    vi.useFakeTimers();
+    renderHook((p: Props) => useDraftAutosave(p), {
+      initialProps: baseProps(),
+    });
+    expect(mSave).not.toHaveBeenCalled(); // not until the debounce elapses
+    act(() => vi.advanceTimersByTime(1000));
+    expect(mSave).toHaveBeenCalledWith({
+      contextKey: "compose",
+      to: "a@b.com",
+      subject: "Hi",
+      bodyHtml: "<p>x</p>",
+    });
+  });
+
+  it("does not save an empty draft", () => {
+    vi.useFakeTimers();
+    renderHook((p: Props) => useDraftAutosave(p), {
+      initialProps: baseProps({ isEmpty: true, values: {} }),
+    });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(mSave).not.toHaveBeenCalled();
+  });
+
+  it("restores a saved draft on open", async () => {
+    const draft: Draft = {
+      id: "d1",
+      contextKey: "compose",
+      fromAddress: null,
+      toAddress: "restored@x.com",
+      cc: null,
+      subject: "Restored",
+      bodyHtml: "<p>restored</p>",
+      bodyText: "restored",
+      replyToEmailId: null,
+      updatedAt: 1,
+    };
+    mFetch.mockResolvedValue(draft);
+    const onRestore = vi.fn();
+    renderHook((p: Props) => useDraftAutosave(p), {
+      initialProps: baseProps({ restore: true, onRestore }),
+    });
+    await waitFor(() => expect(onRestore).toHaveBeenCalledWith(draft));
+    expect(mFetch).toHaveBeenCalledWith("compose");
+  });
+
+  it("keeps (flushes) the draft when the composer closes", () => {
+    vi.useFakeTimers();
+    const { rerender } = renderHook((p: Props) => useDraftAutosave(p), {
+      initialProps: baseProps(),
+    });
+    mSave.mockClear();
+    // Close: enabled → false. The final state is flushed, not discarded.
+    act(() => rerender(baseProps({ enabled: false })));
+    expect(mSave).toHaveBeenCalledWith({
+      contextKey: "compose",
+      to: "a@b.com",
+      subject: "Hi",
+      bodyHtml: "<p>x</p>",
+    });
+    expect(mDelete).not.toHaveBeenCalled();
+  });
+
+  it("clear() deletes the draft and the following close does not re-save it", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook((p: Props) => useDraftAutosave(p), {
+      initialProps: baseProps(),
+    });
+    // Simulate a send: content was autosaved, then cleared.
+    act(() => vi.advanceTimersByTime(1000));
+    mSave.mockClear();
+    mDelete.mockClear();
+    act(() => result.current.clear());
+    expect(mDelete).toHaveBeenCalledWith("compose");
+    // Closing afterwards must NOT resurrect the just-sent draft.
+    act(() => rerender(baseProps({ enabled: false })));
+    expect(mSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -475,6 +475,55 @@ export async function deleteTemplate(
   });
 }
 
+// --- Compose Drafts (autosave) ---
+
+/** An autosaved compose draft, keyed per user by `contextKey`. */
+export interface Draft {
+  id: string;
+  contextKey: string;
+  fromAddress: string | null;
+  toAddress: string | null;
+  cc: CcEntry[] | null;
+  subject: string | null;
+  bodyHtml: string | null;
+  bodyText: string | null;
+  replyToEmailId: string | null;
+  updatedAt: number;
+}
+
+export interface DraftInput {
+  contextKey: string;
+  fromAddress?: string;
+  to?: string;
+  cc?: CcEntry[];
+  subject?: string;
+  bodyHtml?: string;
+  bodyText?: string;
+  replyToEmailId?: string | null;
+}
+
+export async function fetchDraft(contextKey: string): Promise<Draft | null> {
+  const res = await apiFetch<{ draft: Draft | null }>(
+    `/api/drafts?contextKey=${encodeURIComponent(contextKey)}`,
+  );
+  return res.draft;
+}
+
+export async function saveDraft(data: DraftInput): Promise<Draft> {
+  const res = await apiFetch<{ draft: Draft }>("/api/drafts", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.draft;
+}
+
+export async function deleteDraft(contextKey: string): Promise<void> {
+  await apiFetch(`/api/drafts?contextKey=${encodeURIComponent(contextKey)}`, {
+    method: "DELETE",
+  });
+}
+
 // --- User Management Types ---
 
 export interface Invite {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -190,6 +190,7 @@ export async function fetchGroupedPeople(params?: {
   recipient?: string;
   unread?: boolean;
   hasAttachment?: boolean;
+  drafts?: boolean;
   sort?: InboxSort;
   /** Optional explicit direction. Server applies the natural default if omitted. */
   direction?: InboxSortDirection;
@@ -201,6 +202,7 @@ export async function fetchGroupedPeople(params?: {
   if (params?.recipient) qs.set("recipient", params.recipient);
   if (params?.unread) qs.set("unread", "1");
   if (params?.hasAttachment) qs.set("hasAttachment", "1");
+  if (params?.drafts) qs.set("drafts", "1");
   if (params?.sort && params.sort !== "recency") qs.set("sort", params.sort);
   // Only send direction when it differs from the natural default —
   // keeps the URL stable for the common case and avoids cache-busting.

--- a/src/lib/use-draft-autosave.ts
+++ b/src/lib/use-draft-autosave.ts
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from "react";
+import {
+  fetchDraft,
+  saveDraft,
+  deleteDraft,
+  type Draft,
+  type CcEntry,
+} from "@/lib/api";
+
+export interface DraftValues {
+  fromAddress?: string;
+  to?: string;
+  cc?: CcEntry[];
+  subject?: string;
+  bodyHtml?: string;
+  bodyText?: string;
+  replyToEmailId?: string | null;
+}
+
+interface UseDraftAutosaveOptions {
+  /** Identity of the compose surface: "compose" or `reply:<emailId>`. */
+  contextKey: string;
+  /** True while the composer is open. Autosave only runs when enabled. */
+  enabled: boolean;
+  /** Current field values, mirrored on every render. */
+  values: DraftValues;
+  /**
+   * Whether the draft has meaningful content. When false, autosave skips
+   * saving and removes any previously saved draft (implicit discard).
+   */
+  isEmpty: boolean;
+  /**
+   * Hydrate the composer from a saved draft found on open. Called at most
+   * once per open. Skipped entirely when `restore` is false.
+   */
+  onRestore: (draft: Draft) => void;
+  /**
+   * Whether to restore a saved draft on open. Callers pass false when the
+   * composer opens with an explicit prefill that should win.
+   */
+  restore: boolean;
+  /** Debounce before writing, in ms. */
+  debounceMs?: number;
+}
+
+/**
+ * Autosaves a compose/reply draft to the server, debounced, and restores it
+ * when the composer reopens. "Restore on reopen": closing keeps the draft
+ * (a final flush runs on close); sending or clearing all fields removes it.
+ */
+export function useDraftAutosave({
+  contextKey,
+  enabled,
+  values,
+  isEmpty,
+  onRestore,
+  restore,
+  debounceMs = 1500,
+}: UseDraftAutosaveOptions) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest render values/flags, read inside async + cleanup callbacks so they
+  // never operate on stale closure state.
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+  const isEmptyRef = useRef(isEmpty);
+  isEmptyRef.current = isEmpty;
+  const onRestoreRef = useRef(onRestore);
+  onRestoreRef.current = onRestore;
+  // Whether a row currently exists on the server for this surface.
+  const savedRef = useRef(false);
+  // Set by clear() (on send) so the close-flush doesn't re-create the draft.
+  const clearedRef = useRef(false);
+
+  // Open: optionally restore, and reset the per-open flags.
+  useEffect(() => {
+    if (!enabled) return;
+    clearedRef.current = false;
+    savedRef.current = false;
+    let cancelled = false;
+    if (restore) {
+      fetchDraft(contextKey)
+        .then((draft) => {
+          if (cancelled || !draft) return;
+          savedRef.current = true;
+          onRestoreRef.current(draft);
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, contextKey, restore]);
+
+  // Debounced autosave whenever the fields change.
+  useEffect(() => {
+    if (!enabled) return;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      if (clearedRef.current) return;
+      if (isEmptyRef.current) {
+        // Nothing meaningful left — drop any draft we'd previously saved.
+        if (savedRef.current) {
+          savedRef.current = false;
+          deleteDraft(contextKey).catch(() => {});
+        }
+        return;
+      }
+      savedRef.current = true;
+      saveDraft({ contextKey, ...valuesRef.current }).catch(() => {});
+    }, debounceMs);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    enabled,
+    isEmpty,
+    contextKey,
+    values.fromAddress,
+    values.to,
+    JSON.stringify(values.cc),
+    values.subject,
+    values.bodyHtml,
+    values.bodyText,
+    values.replyToEmailId,
+  ]);
+
+  // Close (enabled → false) or surface change: flush the latest state so the
+  // last edits aren't lost, and KEEP the draft. If everything's empty, remove
+  // any stale row instead. Skipped when clear() already ran (post-send).
+  useEffect(() => {
+    if (!enabled) return;
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+      if (clearedRef.current) return;
+      if (!isEmptyRef.current) {
+        savedRef.current = true;
+        saveDraft({ contextKey, ...valuesRef.current }).catch(() => {});
+      } else if (savedRef.current) {
+        savedRef.current = false;
+        deleteDraft(contextKey).catch(() => {});
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, contextKey]);
+
+  /** Delete the draft and suppress the close-flush. Call after a send. */
+  function clear() {
+    if (timer.current) clearTimeout(timer.current);
+    clearedRef.current = true;
+    if (savedRef.current) {
+      savedRef.current = false;
+      deleteDraft(contextKey).catch(() => {});
+    }
+  }
+
+  return { clear };
+}

--- a/src/pages/ComposeModal.tsx
+++ b/src/pages/ComposeModal.tsx
@@ -9,6 +9,7 @@ import {
   trayContentClass,
 } from "@/components/Tray";
 import { sendEmail, fetchStats, type CcEntry } from "@/lib/api";
+import { useDraftAutosave } from "@/lib/use-draft-autosave";
 import { dispatchEmailSent } from "@/lib/email-events";
 import { getFromLabel } from "@/lib/format";
 import { sanitizeEmailHtml } from "@/lib/sanitize-html";
@@ -154,6 +155,33 @@ export default function ComposeModal({
     setSignatureHtml(match?.signatureHtml ?? null);
   }, [fromAddress, senderIdentities]);
 
+  // Autosave a "half-written" draft so it survives closing the composer.
+  // Restore only on a plain open — an explicit prefill (e.g. the chat
+  // "open in compose" handoff) should win over a stale draft.
+  const composeIsEmpty = !to.trim() && !subject.trim() && bodyIsEmpty;
+  const hasPrefill = !!(
+    prefill &&
+    (prefill.to ||
+      prefill.subject ||
+      prefill.bodyHtml ||
+      (prefill.cc && prefill.cc.length > 0))
+  );
+  const { clear: clearDraft } = useDraftAutosave({
+    contextKey: "compose",
+    enabled: open,
+    isEmpty: composeIsEmpty,
+    restore: open && !hasPrefill,
+    values: { fromAddress, to, cc, subject, bodyHtml, bodyText },
+    onRestore: (draft) => {
+      if (draft.toAddress) setTo(draft.toAddress);
+      if (draft.cc) setCc(draft.cc);
+      if (draft.subject) setSubject(draft.subject);
+      if (draft.bodyHtml) setBodyHtml(draft.bodyHtml);
+      if (draft.bodyText) setBodyText(draft.bodyText);
+      if (draft.fromAddress) setFromAddress(draft.fromAddress);
+    },
+  });
+
   async function handleSend() {
     if (!to || bodyIsEmpty) return;
     setSending(true);
@@ -177,6 +205,8 @@ export default function ComposeModal({
         ...(files.length > 0 ? { files: files.map((file) => ({ file })) } : {}),
       });
       dispatchEmailSent({ fromAddress, to, origin: "compose" });
+      // The message went out — discard its draft so it doesn't reappear.
+      clearDraft();
       setFiles([]);
       onClose();
     } catch {

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -136,6 +136,7 @@ export default function InboxPage() {
     filters.recipient,
     filters.unread,
     filters.hasAttachment,
+    filters.drafts,
     sortSpec.key,
   ]);
 
@@ -148,6 +149,7 @@ export default function InboxPage() {
       recipient: filters.recipient,
       unread: filters.unread,
       hasAttachment: filters.hasAttachment,
+      drafts: filters.drafts,
       sort: sortSpec.key,
       direction: sortSpec.direction,
       page: peoplePage,
@@ -158,6 +160,7 @@ export default function InboxPage() {
       filters.recipient,
       filters.unread,
       filters.hasAttachment,
+      filters.drafts,
       sortSpec.key,
       sortSpec.direction,
       peoplePage,

--- a/worker/src/__tests__/drafts-router.test.ts
+++ b/worker/src/__tests__/drafts-router.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  applyMigrations,
+  cleanDb,
+  createTestUser,
+  authFetch,
+  getDb,
+} from "./helpers";
+import { drafts } from "../db/drafts.schema";
+import { eq } from "drizzle-orm";
+
+const q = (contextKey: string) =>
+  `/api/drafts?contextKey=${encodeURIComponent(contextKey)}`;
+
+function save(apiKey: string, body: Record<string, unknown>) {
+  return authFetch("/api/drafts", {
+    apiKey,
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("drafts router", () => {
+  let apiKey: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await cleanDb();
+    ({ apiKey, userId } = await createTestUser());
+  });
+
+  describe("PUT /api/drafts", () => {
+    it("creates a draft and returns it", async () => {
+      const res = await save(apiKey, {
+        contextKey: "compose",
+        to: "alice@example.com",
+        subject: "Hi there",
+        bodyHtml: "<p>Half an email…</p>",
+        bodyText: "Half an email…",
+        cc: [{ email: "cc@example.com", name: "Cc Person" }],
+        fromAddress: "support@givefeedback.dev",
+      });
+      expect(res.status).toBe(200);
+      const { draft } = await res.json();
+      expect(draft.contextKey).toBe("compose");
+      expect(draft.toAddress).toBe("alice@example.com");
+      expect(draft.subject).toBe("Hi there");
+      expect(draft.bodyHtml).toBe("<p>Half an email…</p>");
+      expect(draft.cc).toEqual([
+        { email: "cc@example.com", name: "Cc Person" },
+      ]);
+      expect(draft.replyToEmailId).toBeNull();
+    });
+
+    it("upserts by (user, contextKey) — a second save updates, not duplicates", async () => {
+      await save(apiKey, { contextKey: "compose", subject: "First" });
+      await save(apiKey, { contextKey: "compose", subject: "Second" });
+
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(drafts)
+        .where(eq(drafts.userId, userId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].subject).toBe("Second");
+    });
+
+    it("keeps compose and reply drafts as separate rows", async () => {
+      await save(apiKey, { contextKey: "compose", subject: "New message" });
+      await save(apiKey, {
+        contextKey: "reply:email-1",
+        replyToEmailId: "email-1",
+        bodyHtml: "<p>My reply</p>",
+      });
+
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(drafts)
+        .where(eq(drafts.userId, userId));
+      expect(rows).toHaveLength(2);
+    });
+
+    it("accepts a partial/incomplete To while typing (no email validation)", async () => {
+      const res = await save(apiKey, { contextKey: "compose", to: "ali" });
+      expect(res.status).toBe(200);
+      const { draft } = await res.json();
+      expect(draft.toAddress).toBe("ali");
+    });
+  });
+
+  describe("GET /api/drafts", () => {
+    it("returns the draft for a contextKey", async () => {
+      await save(apiKey, { contextKey: "compose", subject: "Saved" });
+      const res = await authFetch(q("compose"), { apiKey });
+      expect(res.status).toBe(200);
+      const { draft } = await res.json();
+      expect(draft.subject).toBe("Saved");
+    });
+
+    it("returns null when no draft exists for that surface", async () => {
+      const res = await authFetch(q("reply:missing"), { apiKey });
+      expect(res.status).toBe(200);
+      const { draft } = await res.json();
+      expect(draft).toBeNull();
+    });
+  });
+
+  describe("DELETE /api/drafts", () => {
+    it("deletes the draft for a contextKey", async () => {
+      await save(apiKey, { contextKey: "compose", subject: "To discard" });
+      const del = await authFetch(q("compose"), { apiKey, method: "DELETE" });
+      expect(del.status).toBe(200);
+      expect((await del.json()).success).toBe(true);
+
+      const res = await authFetch(q("compose"), { apiKey });
+      expect((await res.json()).draft).toBeNull();
+    });
+  });
+
+  describe("per-user isolation", () => {
+    it("does not leak one user's draft to another", async () => {
+      await save(apiKey, { contextKey: "compose", subject: "User A secret" });
+
+      const { apiKey: apiKeyB } = await createTestUser({
+        id: "user-b",
+        email: "b@example.com",
+      });
+
+      // User B sees no draft on the same contextKey…
+      const bGet = await authFetch(q("compose"), { apiKey: apiKeyB });
+      expect((await bGet.json()).draft).toBeNull();
+
+      // …and B's own save doesn't touch A's row.
+      await save(apiKeyB, { contextKey: "compose", subject: "User B draft" });
+      const aGet = await authFetch(q("compose"), { apiKey });
+      expect((await aGet.json()).draft.subject).toBe("User A secret");
+    });
+  });
+
+  describe("auth", () => {
+    it("rejects unauthenticated requests", async () => {
+      const res = await authFetch(q("compose"));
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/worker/src/__tests__/helpers.ts
+++ b/worker/src/__tests__/helpers.ts
@@ -79,6 +79,8 @@ export async function applyMigrations() {
     `CREATE TABLE IF NOT EXISTS outbox_emails (id TEXT PRIMARY KEY, sent_email_id TEXT NOT NULL, sequence_email_id TEXT, from_address TEXT NOT NULL, to_address TEXT NOT NULL, cc TEXT, subject TEXT NOT NULL, body_html TEXT, body_text TEXT, headers TEXT, transactional INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'pending', attempts INTEGER NOT NULL DEFAULT 0, last_error TEXT, next_retry_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS outbox_status_retry_idx ON outbox_emails(status, next_retry_at)`,
     `CREATE INDEX IF NOT EXISTS outbox_from_idx ON outbox_emails(from_address)`,
+    `CREATE TABLE IF NOT EXISTS drafts (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, context_key TEXT NOT NULL, from_address TEXT, to_address TEXT, cc TEXT, subject TEXT, body_html TEXT, body_text TEXT, reply_to_email_id TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS drafts_user_context_idx ON drafts(user_id, context_key)`,
   ];
 
   for (const sql of statements) {
@@ -270,6 +272,7 @@ export function buildSendForm(
 export async function cleanDb() {
   const db = env.DB;
   await db.exec(`
+    DELETE FROM drafts;
     DELETE FROM outbox_emails;
     DELETE FROM blocklist;
     DELETE FROM suppressions;

--- a/worker/src/__tests__/people-router.test.ts
+++ b/worker/src/__tests__/people-router.test.ts
@@ -9,6 +9,7 @@ import {
   getDb,
 } from "./helpers";
 import { blocklist } from "../db/blocklist.schema";
+import { drafts } from "../db/drafts.schema";
 
 describe("people router", () => {
   let apiKey: string;
@@ -354,6 +355,99 @@ describe("people router", () => {
       expect(groups).toHaveLength(GROUP_COUNT);
       expect(groups[0].participants.length).toBeGreaterThan(0);
       expect(groups[0].ccParticipants.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("GET /api/people/grouped?drafts=1 — reply-draft filter", () => {
+    const replyDraft = (id: string, userId: string, emailId: string) => ({
+      id,
+      userId,
+      contextKey: `reply:${emailId}`,
+      replyToEmailId: emailId,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    it("shows only people with a reply draft", async () => {
+      await createTestPerson({ id: "p-draft", email: "d@test.com" });
+      await createTestEmail({
+        id: "e-draft",
+        personId: "p-draft",
+        messageId: "m-d@test.com",
+      });
+      await createTestPerson({ id: "p-nodraft", email: "n@test.com" });
+      await createTestEmail({
+        id: "e-nodraft",
+        personId: "p-nodraft",
+        messageId: "m-n@test.com",
+      });
+      await getDb()
+        .insert(drafts)
+        .values(replyDraft("dr1", "test-user-1", "e-draft"));
+
+      const res = await authFetch("/api/people/grouped?drafts=1", { apiKey });
+      expect(res.status).toBe(200);
+      const ids = (await res.json()).data.map((r: { id: string }) => r.id);
+      expect(ids).toContain("p-draft");
+      expect(ids).not.toContain("p-nodraft");
+    });
+
+    it("ignores the new-message compose draft (not a reply)", async () => {
+      await createTestPerson({ id: "p1", email: "a@test.com" });
+      await createTestEmail({
+        id: "e1",
+        personId: "p1",
+        messageId: "m1@test.com",
+      });
+      await getDb().insert(drafts).values({
+        id: "dc",
+        userId: "test-user-1",
+        contextKey: "compose",
+        replyToEmailId: null,
+        createdAt: 1,
+        updatedAt: 1,
+      });
+
+      const res = await authFetch("/api/people/grouped?drafts=1", { apiKey });
+      expect((await res.json()).data).toHaveLength(0);
+    });
+
+    it("does not surface another user's reply draft", async () => {
+      await createTestPerson({ id: "p1", email: "a@test.com" });
+      await createTestEmail({
+        id: "e1",
+        personId: "p1",
+        messageId: "m1@test.com",
+      });
+      await createTestUser({ id: "other-user", email: "other@test.com" });
+      await getDb()
+        .insert(drafts)
+        .values(replyDraft("dr-other", "other-user", "e1"));
+
+      // Authenticated as test-user-1 — the other user's draft must not leak.
+      const res = await authFetch("/api/people/grouped?drafts=1", { apiKey });
+      expect((await res.json()).data).toHaveLength(0);
+    });
+
+    it("shows a group conversation with a reply draft", async () => {
+      await createTestPerson({ id: "pg", email: "g@test.com" });
+      await createTestEmail({
+        id: "eg",
+        personId: "pg",
+        conversationId: "conv1",
+        messageId: "mg@test.com",
+      });
+      await getDb()
+        .insert(drafts)
+        .values(replyDraft("drg", "test-user-1", "eg"));
+
+      const res = await authFetch("/api/people/grouped?drafts=1", { apiKey });
+      const data = (await res.json()).data as Array<{
+        id: string;
+        type: string;
+      }>;
+      const group = data.find((r) => r.id === "conv1");
+      expect(group?.type).toBe("group");
     });
   });
 });

--- a/worker/src/db/drafts.schema.ts
+++ b/worker/src/db/drafts.schema.ts
@@ -1,0 +1,44 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { users } from "./auth.schema";
+
+/**
+ * Autosaved compose drafts, scoped per user.
+ *
+ * A draft is identified by `(userId, contextKey)` so there is exactly one
+ * autosaved draft per composing surface:
+ *   - `"compose"`         — the new-message composer (one per user)
+ *   - `"reply:<emailId>"` — a reply to a specific email
+ *
+ * The unique index enforces that identity and lets the router upsert with a
+ * single `onConflictDoUpdate`. Attachments are intentionally not persisted —
+ * they're in-browser File objects re-added when a draft is resumed.
+ */
+export const drafts = sqliteTable(
+  "drafts",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    contextKey: text("context_key").notNull(),
+    fromAddress: text("from_address"),
+    toAddress: text("to_address"),
+    /** JSON-encoded array of { email, name? }. */
+    cc: text("cc"),
+    subject: text("subject"),
+    bodyHtml: text("body_html"),
+    bodyText: text("body_text"),
+    /** The email being replied to, or null for a new-message draft. */
+    replyToEmailId: text("reply_to_email_id"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("drafts_user_context_idx").on(table.userId, table.contextKey),
+  ],
+);

--- a/worker/src/db/index.ts
+++ b/worker/src/db/index.ts
@@ -16,4 +16,5 @@ export * from "./push-subscriptions.schema";
 export * from "./app-settings.schema";
 export * from "./suppressions.schema";
 export * from "./blocklist.schema";
+export * from "./drafts.schema";
 export * from "./schema";

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -16,6 +16,7 @@ import { appSettings } from "./app-settings.schema";
 import { suppressions } from "./suppressions.schema";
 import { blocklist } from "./blocklist.schema";
 import { outboxEmails } from "./outbox-emails.schema";
+import { drafts } from "./drafts.schema";
 
 export const schema = {
   ...authSchema,
@@ -36,4 +37,5 @@ export const schema = {
   suppressions,
   blocklist,
   outboxEmails,
+  drafts,
 } as const;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -38,6 +38,7 @@ import { suppressionsRouter } from "./routers/suppressions-router";
 import { webhooksRouter } from "./routers/webhooks-router";
 import { unsubscribeRouter } from "./routers/unsubscribe-router";
 import { outboxRouter } from "./routers/outbox-router";
+import { draftsRouter } from "./routers/drafts-router";
 import { bootstrapRouter } from "./routers/bootstrap-router";
 export { NotificationsHub } from "./do/notifications";
 import type { Variables } from "./variables";
@@ -242,6 +243,7 @@ app.route("/api/sequences", sequencesRouter);
 app.route("/api/notifications", notificationsRouter);
 app.route("/api/blocklist", blocklistRouter);
 app.route("/api/outbox", outboxRouter);
+app.route("/api/drafts", draftsRouter);
 
 // Admin routes (require admin role)
 app.use("/api/admin/*", requireAdmin);

--- a/worker/src/routers/drafts-router.ts
+++ b/worker/src/routers/drafts-router.ts
@@ -1,0 +1,191 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { drafts } from "../db/drafts.schema";
+import { json200Response } from "../lib/helpers";
+import { bearerSecurity } from "../lib/openapi-auth";
+import type { Variables } from "../variables";
+
+export const draftsRouter = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Variables;
+}>();
+
+const CcEntrySchema = z.object({
+  email: z.string(),
+  name: z.string().nullable().optional(),
+});
+
+/** The shape returned to the client — cc parsed back into an array. */
+const DraftSchema = z.object({
+  id: z.string(),
+  contextKey: z.string(),
+  fromAddress: z.string().nullable(),
+  toAddress: z.string().nullable(),
+  cc: z.array(CcEntrySchema).nullable(),
+  subject: z.string().nullable(),
+  bodyHtml: z.string().nullable(),
+  bodyText: z.string().nullable(),
+  replyToEmailId: z.string().nullable(),
+  updatedAt: z.number(),
+});
+
+type DraftRow = typeof drafts.$inferSelect;
+
+function toDraft(row: DraftRow): z.infer<typeof DraftSchema> {
+  let cc: z.infer<typeof CcEntrySchema>[] | null = null;
+  if (row.cc) {
+    try {
+      const parsed = JSON.parse(row.cc);
+      if (Array.isArray(parsed)) cc = parsed;
+    } catch {
+      cc = null;
+    }
+  }
+  return {
+    id: row.id,
+    contextKey: row.contextKey,
+    fromAddress: row.fromAddress,
+    toAddress: row.toAddress,
+    cc,
+    subject: row.subject,
+    bodyHtml: row.bodyHtml,
+    bodyText: row.bodyText,
+    replyToEmailId: row.replyToEmailId,
+    updatedAt: row.updatedAt,
+  };
+}
+
+const ContextQuery = z.object({
+  contextKey: z.string().min(1).max(200),
+});
+
+// GET /api/drafts?contextKey=… — fetch the draft for a compose surface.
+const getDraftRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Drafts"],
+  security: bearerSecurity,
+  description:
+    "Get the current user's autosaved draft for a compose surface (by contextKey), or null.",
+  request: { query: ContextQuery },
+  responses: {
+    ...json200Response(
+      z.object({ draft: DraftSchema.nullable() }),
+      "The draft, or null if none exists",
+    ),
+  },
+});
+
+draftsRouter.openapi(getDraftRoute, async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const { contextKey } = c.req.valid("query");
+  const rows = await db
+    .select()
+    .from(drafts)
+    .where(and(eq(drafts.userId, user.id), eq(drafts.contextKey, contextKey)))
+    .limit(1);
+  return c.json({ draft: rows[0] ? toDraft(rows[0]) : null }, 200);
+});
+
+// PUT /api/drafts — upsert the draft for a compose surface.
+const SaveDraftBody = z.object({
+  contextKey: z.string().min(1).max(200),
+  fromAddress: z.string().max(320).optional(),
+  // A draft `to` may be a partial/incomplete address while the user types,
+  // so it is deliberately NOT validated as an email here.
+  to: z.string().max(320).optional(),
+  cc: z.array(CcEntrySchema).max(50).optional(),
+  subject: z.string().max(2000).optional(),
+  bodyHtml: z.string().optional(),
+  bodyText: z.string().optional(),
+  replyToEmailId: z.string().nullable().optional(),
+});
+
+const saveDraftRoute = createRoute({
+  method: "put",
+  path: "/",
+  tags: ["Drafts"],
+  security: bearerSecurity,
+  description:
+    "Create or update (upsert) the autosaved draft for a compose surface.",
+  request: {
+    body: {
+      content: { "application/json": { schema: SaveDraftBody } },
+    },
+  },
+  responses: {
+    ...json200Response(z.object({ draft: DraftSchema }), "The saved draft"),
+  },
+});
+
+draftsRouter.openapi(saveDraftRoute, async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const body = c.req.valid("json");
+  const now = Math.floor(Date.now() / 1000);
+  const cc = body.cc ? JSON.stringify(body.cc) : null;
+
+  await db
+    .insert(drafts)
+    .values({
+      id: nanoid(),
+      userId: user.id,
+      contextKey: body.contextKey,
+      fromAddress: body.fromAddress ?? null,
+      toAddress: body.to ?? null,
+      cc,
+      subject: body.subject ?? null,
+      bodyHtml: body.bodyHtml ?? null,
+      bodyText: body.bodyText ?? null,
+      replyToEmailId: body.replyToEmailId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [drafts.userId, drafts.contextKey],
+      set: {
+        fromAddress: body.fromAddress ?? null,
+        toAddress: body.to ?? null,
+        cc,
+        subject: body.subject ?? null,
+        bodyHtml: body.bodyHtml ?? null,
+        bodyText: body.bodyText ?? null,
+        replyToEmailId: body.replyToEmailId ?? null,
+        updatedAt: now,
+      },
+    });
+
+  const rows = await db
+    .select()
+    .from(drafts)
+    .where(
+      and(eq(drafts.userId, user.id), eq(drafts.contextKey, body.contextKey)),
+    )
+    .limit(1);
+  return c.json({ draft: toDraft(rows[0]) }, 200);
+});
+
+// DELETE /api/drafts?contextKey=… — discard a draft (on send or clear).
+const deleteDraftRoute = createRoute({
+  method: "delete",
+  path: "/",
+  tags: ["Drafts"],
+  security: bearerSecurity,
+  description: "Delete the current user's draft for a compose surface.",
+  request: { query: ContextQuery },
+  responses: {
+    ...json200Response(z.object({ success: z.boolean() }), "Draft deleted"),
+  },
+});
+
+draftsRouter.openapi(deleteDraftRoute, async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const { contextKey } = c.req.valid("query");
+  await db
+    .delete(drafts)
+    .where(and(eq(drafts.userId, user.id), eq(drafts.contextKey, contextKey)));
+  return c.json({ success: true }, 200);
+});

--- a/worker/src/routers/people-router.ts
+++ b/worker/src/routers/people-router.ts
@@ -4,6 +4,7 @@ import { people } from "../db/people.schema";
 import { emails } from "../db/emails.schema";
 import { attachments } from "../db/attachments.schema";
 import { sentEmails } from "../db/sent-emails.schema";
+import { drafts } from "../db/drafts.schema";
 import { json200Response, escapeLike, escapeFts } from "../lib/helpers";
 import {
   getPersonScoped,
@@ -99,6 +100,10 @@ const listGroupedPeopleRoute = createRoute({
         .enum(["1", "true"])
         .optional()
         .openapi({ description: "Only people with downloadable attachments" }),
+      drafts: z.enum(["1", "true"]).optional().openapi({
+        description:
+          "Only conversations where the current user has a reply draft",
+      }),
       sort: z
         .enum(["recency", "unread", "inbox", "attachments"])
         .optional()
@@ -145,8 +150,21 @@ const listGroupedPeopleRoute = createRoute({
 
 peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
   const db = c.get("db");
-  const { q, recipient, unread, hasAttachment, sort, direction, page, limit } =
-    c.req.valid("query");
+  const user = c.get("user");
+  const {
+    q,
+    recipient,
+    unread,
+    hasAttachment,
+    drafts: draftsOnly,
+    sort,
+    direction,
+    page,
+    limit,
+  } = c.req.valid("query");
+  // Scope the drafts filter to the signed-in user. Empty id matches no
+  // drafts, so the filter safely yields nothing if the user is somehow absent.
+  const draftsUserId = user?.id ?? "";
   const offset = (page - 1) * limit;
   // Resolve effective direction. Each sort key has a "natural" default
   // (recency/unread/attachments → desc, inbox → asc) so the UI can
@@ -172,6 +190,17 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
   if (hasAttachment) {
     personConditions.push(
       sql`s.id IN (SELECT e2.person_id FROM emails e2 JOIN ${attachments} a ON a.email_id = e2.id WHERE a.content_id IS NULL AND e2.conversation_id IS NULL)`,
+    );
+  }
+  if (draftsOnly) {
+    personConditions.push(
+      sql`s.id IN (
+        SELECT e.person_id FROM emails e
+        JOIN ${drafts} d ON d.reply_to_email_id = e.id
+        WHERE d.user_id = ${draftsUserId}
+          AND d.context_key LIKE 'reply:%'
+          AND e.conversation_id IS NULL
+      )`,
     );
   }
   if (q) {
@@ -286,6 +315,17 @@ peopleRouter.openapi(listGroupedPeopleRoute, async (c) => {
   }
   if (hasAttachment) {
     groupConditions.push(sql`g.hasAttachment = 1`);
+  }
+  if (draftsOnly) {
+    groupConditions.push(
+      sql`g.conversation_id IN (
+        SELECT e.conversation_id FROM emails e
+        JOIN ${drafts} d ON d.reply_to_email_id = e.id
+        WHERE d.user_id = ${draftsUserId}
+          AND d.context_key LIKE 'reply:%'
+          AND e.conversation_id IS NOT NULL
+      )`,
+    );
   }
   if (q) {
     const pattern = `%${escapeLike(q)}%`;


### PR DESCRIPTION
## What

Adds **draft email autosave** — a half-written email survives closing the composer and comes back when you reopen it.

## How it works
- **New per-user `drafts` table** keyed by `(user_id, context_key)`: `"compose"` for the new-message composer and `"reply:<emailId>"` for replies. A unique index enforces one draft per surface and enables upsert.
- **`/api/drafts` router** (`GET` / `PUT` / `DELETE`), every query scoped to the current user; `PUT` upserts via `onConflictDoUpdate`. Mirrors the existing `api-keys-router` per-user CRUD pattern.
- **`useDraftAutosave` hook** wired into `ComposeModal` and `ReplyComposer`:
  - Debounced (~1.5s) autosave as you type.
  - **Restore on reopen** — closing keeps the draft (a final flush runs on close). ComposeModal restores only on a plain open so an explicit prefill (chat "open in compose" handoff) still wins; ReplyComposer restores by the email being replied to and its draft CC beats the reply-all default.
  - **Delete on send**, or when all fields are cleared (implicit discard).
- **Attachments are excluded** (they're in-browser `File` objects) — re-add on resume.

No changes to the send flow beyond deleting the draft after a successful send. The inline one-line `ChatQuickReply` is intentionally left as-is (easy follow-up).

## Migration
`migrations/0034_closed_krista_starr.sql`, generated with `yarn db:generate` (not hand-written). Applies via `yarn db:migrate:dev` / `:prod`.

## Tests
- `worker/src/__tests__/drafts-router.test.ts` — upsert-by-context, per-user isolation, compose vs reply separation, partial-`to` while typing, get/delete, 401. Full worker suite: **777 passed**.
- `src/lib/__tests__/use-draft-autosave.test.tsx` — debounced save, no-save-when-empty, restore-on-open, keep-on-close flush, clear-suppresses-resave. Web suite: **21 passed**.
- `tsc -b`: no new errors. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtTMzcB7PvzyCN3fqohjsf