### PR TITLE
fix(webmcp): open_contact always failed — resolve contact inbox correctly

### DIFF
--- a/src/webmcp/__tests__/action-tools.test.ts
+++ b/src/webmcp/__tests__/action-tools.test.ts
@@ -10,9 +10,12 @@ function makeDeps(overrides: any = {}) {
   };
   return {
     bridge,
-    fetchPerson: vi
-      .fn()
-      .mockResolvedValue({ id: "p1", recipient: "team@x.com" }),
+    // /api/people?personId=… returns per-(person,inbox) rows carrying a real
+    // recipient inbox — unlike GET /api/people/:id, which has none.
+    fetchPeople: vi.fn().mockResolvedValue({
+      data: [{ id: "p1", email: "bob@ext.com", recipient: "team@x.com" }],
+      total: 1,
+    }),
     fetchEmail: vi.fn().mockResolvedValue({
       id: "e1",
       type: "received",
@@ -39,11 +42,29 @@ const t = (tools: any[], n: string) => tools.find((x) => x.name === n)!;
 const sig = { signal: new AbortController().signal };
 
 describe("action tools", () => {
-  it("open_contact navigates to the person's inbox thread", async () => {
+  it("open_contact resolves the contact's inbox and navigates (URL-encoded)", async () => {
     const deps = makeDeps();
     const tools = createActionTools(deps as any);
     await t(tools, "open_contact").execute({ personId: "p1" }, sig);
-    expect(deps.bridge.navigate).toHaveBeenCalledWith("/inbox/team@x.com/p1");
+    expect(deps.fetchPeople).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: "p1" }),
+    );
+    // recipient + personId are encoded — the "@" in the inbox must not sit raw
+    // in the path segment.
+    expect(deps.bridge.navigate).toHaveBeenCalledWith("/inbox/team%40x.com/p1");
+  });
+
+  it("open_contact fails cleanly when the contact has no visible inbox", async () => {
+    const deps = makeDeps({
+      fetchPeople: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+    });
+    const tools = createActionTools(deps as any);
+    const res = await t(tools, "open_contact").execute(
+      { personId: "ghost" },
+      sig,
+    );
+    expect(deps.bridge.navigate).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toContain("not found");
   });
 
   it("compose_email opens the compose drawer pre-filled (no send)", async () => {

--- a/src/webmcp/registerTools.tsx
+++ b/src/webmcp/registerTools.tsx
@@ -5,6 +5,7 @@ import { renderPreview } from "@/lib/template-syntax";
 import {
   fetchGroupedPeople,
   fetchPerson,
+  fetchPeople,
   fetchPersonEmails,
   fetchConversationEmails,
   fetchEmail,
@@ -54,7 +55,7 @@ export function WebMcpTools({ enabled = true }: { enabled?: boolean }) {
     });
     const actions = createActionTools({
       bridge,
-      fetchPerson,
+      fetchPeople,
       fetchEmail,
       markEmailRead,
       deleteEmail,

--- a/src/webmcp/tools/actions.ts
+++ b/src/webmcp/tools/actions.ts
@@ -4,7 +4,7 @@ import { ok, okJson, fail } from "../result";
 
 export interface ActionDeps {
   bridge: WebMcpBridge;
-  fetchPerson: (id: string) => Promise<any>;
+  fetchPeople: (params: { personId?: string; limit?: number }) => Promise<any>;
   fetchEmail: (id: string) => Promise<any>;
   markEmailRead: (id: string, isRead: boolean) => Promise<void>;
   deleteEmail: (id: string) => Promise<any>;
@@ -26,11 +26,20 @@ export function createActionTools(deps: ActionDeps): WebMcpToolDescriptor[] {
         required: ["personId"],
       },
       execute: async (args) => {
-        const person = await deps.fetchPerson(args.personId);
-        if (!person?.recipient)
-          return fail("Contact not found or has no inbox.");
-        deps.bridge.navigate(`/inbox/${person.recipient}/${person.id}`);
-        return ok(`Opened ${person.email ?? person.id} in the inbox.`);
+        // GET /api/people/:id has no `recipient` — that inbox address is a
+        // per-(person,inbox) value only the list query computes. Resolve the
+        // contact's most-recent inbox pair the same way the inbox list does,
+        // then drive the router so the user watches the thread open.
+        const { data } = await deps.fetchPeople({
+          personId: args.personId,
+          limit: 1,
+        });
+        const row = data?.[0];
+        if (!row?.recipient) return fail("Contact not found or has no inbox.");
+        deps.bridge.navigate(
+          `/inbox/${encodeURIComponent(row.recipient)}/${encodeURIComponent(row.id)}`,
+        );
+        return ok(`Opened ${row.email ?? row.id} in the inbox.`);
       },
     },
     {


### PR DESCRIPTION
## Problem

The WebMCP `open_contact` tool **always** failed with *"Contact not found or has no inbox."* — for every contact.

### Root cause

`open_contact` read `recipient` off `GET /api/people/:id` (`fetchPerson`):

```js
const person = await deps.fetchPerson(args.personId);
if (!person?.recipient) return fail("Contact not found or has no inbox.");
```

But that endpoint returns the bare `people` row, and the `people` table **has no `recipient` column**. `recipient` is a per-`(person, inbox)` value — a contact can be reached at several inboxes — computed only by the *list*/grouped queries via a `GROUP BY` over `emails`. So `person.recipient` was `undefined` on every call and the guard tripped 100% of the time.

The existing unit test masked this: it mocked `fetchPerson` to return `{ recipient: "team@x.com" }`, a field the real endpoint never sends.

## Fix

- Resolve the contact's most-recent inbox via `GET /api/people?personId=…` (the same list query the grouped inbox uses), whose rows carry a real `recipient` + `email`. Returns 200-with-empty-data for a missing/invisible contact, so the not-found path is handled cleanly.
- URL-encode both path segments so the `@` in the inbox address doesn't sit raw in `/inbox/:inbox/:personId` — matching how the UI builds thread links (`MessageLinkPage.tsx`).
- `open_contact` continues to drive the router (`bridge.navigate`), so the user watches the thread open in the browser — consistent with WebMCP's visible-UI model.

## Tests

- Rewrote the `open_contact` test to the real API contract (was asserting against a fabricated `recipient`).
- Added a not-found case (empty `data` → clean failure, no navigation).
- Full `src/webmcp` web suite green (22 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtTMzcB7PvzyCN3fqohjsf