### PR TITLE
feat(agents): capability-tier parity policy + templates/sequences discovery on MCP & WebMCP

### DIFF
--- a/docs/specs/2026-08-30-agent-entrypoint-parity-design.md
+++ b/docs/specs/2026-08-30-agent-entrypoint-parity-design.md
@@ -61,10 +61,12 @@ MCP tool at the same tier, **including the admin tier** (behind `email:admin`). 
 complete mirror of the API, not a curated subset. _Rationale: agents shouldn't hit a capability
 cliff where they must fall back to raw HTTP._
 
-**P3 — WebMCP reaches functional + autonomous parity.** WebMCP exposes the same capability set and
-— per the target state — can send / reply / enroll / delete autonomously, matching MCP, rather
-than always staging behind a human confirmation. _Rationale: the user's decision is that all three
-surfaces converge equally. See R1 for the risk this accepts._
+**P3 — WebMCP reaches functional parity; autonomy is configurable per capability.** WebMCP exposes
+the same capability set as MCP. Autonomy is **off by default and opt-in per tier**: a user can
+enable autonomous send / reply / enroll, but destructive capabilities (delete / reassign / CRUD)
+and the admin tier stay confirm-gated even then. Read stays always-autonomous. _Rationale: full
+functional convergence without accepting R1's blast radius by default. Amended from blanket
+autonomy after weighing R1._
 
 **P4 — Credential unification.** An `sk_` API key is a valid MCP bearer token. A single credential
 authenticates against both `/api/*` and `/mcp`, carrying the same scope set on both. _Rationale:
@@ -122,22 +124,22 @@ otherwise; cells already ✅ need no work.
 
 ### Manage tier (`email:manage`)
 
-| Capability                          | API | MCP                 | WebMCP                        | Gap → target                          |
-| ----------------------------------- | --- | ------------------- | ----------------------------- | ------------------------------------- |
-| Mark read/unread (single)           | ✅  | ✅ `mark_read`      | ✅ `mark_read`/`mark_unread`  | —                                     |
-| Bulk mark emails                    | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant            |
-| Bulk mark people/conversations read | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant            |
-| Patch single email flags (archive)  | ✅  | 🔶 (read flag only) | 🔶                            | MCP + WebMCP: full flag patch         |
-| Delete email                        | ✅  | ✅ `delete_email`   | 🔶 `delete_email` (confirmed) | WebMCP: autonomous per P3             |
-| Reassign email → person             | ✅  | ❌                  | ❌                            | MCP + WebMCP: `reassign_email`        |
-| Delete contact                      | ✅  | ❌                  | ❌                            | MCP + WebMCP: `delete_person`         |
-| Template create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: template CRUD           |
-| Sequence create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: sequence CRUD           |
-| Cancel enrollment                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: `cancel_enrollment`     |
-| Draft save/delete                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: draft write/delete      |
-| Outbox retry / cancel               | ✅  | ❌                  | ❌                            | MCP + WebMCP: outbox actions          |
-| Notifications / web push            | ✅  | ❌                  | ❌                            | Decide: in-scope for agents? (see Q1) |
-| Self-service API-key mgmt           | ✅  | ❌                  | ❌                            | **Excluded from agents** — see Q2     |
+| Capability                          | API | MCP                 | WebMCP                        | Gap → target                      |
+| ----------------------------------- | --- | ------------------- | ----------------------------- | --------------------------------- |
+| Mark read/unread (single)           | ✅  | ✅ `mark_read`      | ✅ `mark_read`/`mark_unread`  | —                                 |
+| Bulk mark emails                    | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant        |
+| Bulk mark people/conversations read | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant        |
+| Patch single email flags (archive)  | ✅  | 🔶 (read flag only) | 🔶                            | MCP + WebMCP: full flag patch     |
+| Delete email                        | ✅  | ✅ `delete_email`   | 🔶 `delete_email` (confirmed) | WebMCP: autonomous per P3         |
+| Reassign email → person             | ✅  | ❌                  | ❌                            | MCP + WebMCP: `reassign_email`    |
+| Delete contact                      | ✅  | ❌                  | ❌                            | MCP + WebMCP: `delete_person`     |
+| Template create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: template CRUD       |
+| Sequence create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: sequence CRUD       |
+| Cancel enrollment                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: `cancel_enrollment` |
+| Draft save/delete                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: draft write/delete  |
+| Outbox retry / cancel               | ✅  | ❌                  | ❌                            | MCP + WebMCP: outbox actions      |
+| Notifications / web push            | ✅  | ❌                  | ❌                            | **Out of scope for agents** (D1)  |
+| Self-service API-key mgmt           | ✅  | ❌                  | ❌                            | **Excluded from agents** (D2)     |
 
 ### Admin tier (`email:admin`, admin role only)
 
@@ -169,11 +171,13 @@ It needs, in rough priority order:
 **WebMCP — the big lift is autonomy + the same management/admin breadth.** It already has the widest
 _read_ surface. It needs:
 
-1. **Autonomy (P3):** turn `compose_email`, `compose_from_template`, `reply_email`, `enroll_in_sequence`,
-   `delete_email` from staged/confirmed into autonomous, subject to R1's mitigations.
+1. **Configurable autonomy (P3):** let `compose_email`, `compose_from_template`, `reply_email`,
+   `enroll_in_sequence` run autonomously **when the user opts in per tier** (off by default);
+   `delete_email` and other destructive/admin actions stay confirm-gated regardless. Subject to
+   R1's remaining mitigations.
 2. **Attachments** on send + `get_attachment`.
-3. **Manage + admin tiers:** the same CRUD/bulk/admin breadth MCP needs, driven from the browser
-   session.
+3. **Manage tier** (browser session) — same CRUD/bulk breadth MCP needs. **Admin tier deferred**
+   (D3).
 
 **Direct API — the lift is authorization granularity, not features.** It has every capability. It
 needs P4/P5: scoped `sk_` keys, and those keys accepted as MCP bearer tokens.
@@ -209,12 +213,10 @@ Today the two pipelines are fully separate:
 **R1 — WebMCP autonomy × session-cookie auth = a prompt-injection blast radius.** An in-page agent
 that reads attacker-controlled email content _and_ can autonomously send/delete/administer, authed
 by the ambient session cookie, is a materially larger attack surface than today's confirm-gated
-design. This is an **accepted risk** per the convergence decision (P3). Suggested mitigations to
-carry into implementation: per-capability opt-in (autonomy off by default, enabled by explicit user
-setting per tier); keep destructive/admin tiers confirm-gated even when send is autonomous;
-require a recent user gesture / same-origin assertion before autonomous writes; rate-limit
-autonomous sends. **Recommendation:** revisit whether P3 should be softened to "configurable per
-capability" before the WebMCP autonomy round ships.
+design. **Resolved (P3 amended):** autonomy is off by default and opt-in per tier; destructive and
+admin capabilities stay confirm-gated on WebMCP regardless. Remaining mitigations to carry into the
+WebMCP round: require a recent user gesture / same-origin assertion before autonomous writes;
+rate-limit autonomous sends; surface a clear indicator when autonomy is enabled.
 
 **R2 — `sk_` key as MCP token bypasses the passkey gate.** See §6.3 — must be resolved explicitly,
 not inherited by accident.
@@ -224,18 +226,19 @@ scope means a leaked/injected agent can create users or edit webhooks. Mitigatio
 never granted by default; separate opt-in at key/token creation; consider keeping admin _mutations_
 confirm-gated on WebMCP even under P3.
 
-**Q1 — Are notifications / web-push in scope for agents at all?** They're SPA-oriented
-(subscription lifecycle for a browser). Proposed: **out of scope** for MCP; irrelevant to WebMCP.
-Leave on the direct API only. _Confirm._
+## 7a. Resolved decisions
 
-**Q2 — Self-service API-key management via an agent.** An agent minting or rotating its own
-credentials is a privilege-escalation footgun. Proposed: **excluded** from both MCP and WebMCP;
-key management stays session + direct-API only. _Confirm._
+**D1 (was Q1) — Notifications / web-push are out of scope for agents.** They're SPA-oriented
+(subscription lifecycle for a browser). Exposed on the direct API only; not mirrored to MCP,
+irrelevant to WebMCP.
 
-**Q3 — Does WebMCP need the admin tier at all?** Full convergence (P2/P3) says yes, but an
-in-browser agent performing instance administration is the highest-risk cell in the matrix.
-Proposed: admin tools land on **MCP first**, WebMCP admin deferred pending R1/R3 mitigations.
-_Confirm._
+**D2 (was Q2) — Self-service API-key management is excluded from both agent surfaces.** An agent
+minting or rotating its own credentials is a privilege-escalation footgun. Key management stays
+session + direct-API only.
+
+**D3 (was Q3) — WebMCP admin is deferred.** Admin tools land on **MCP first** (under `email:admin`).
+WebMCP admin is not built until the R1/R3 mitigations are in place; under P3, admin stays
+confirm-gated on WebMCP even after that.
 
 ## 8. Phased roadmap (follow-up rounds)
 
@@ -252,8 +255,9 @@ Each phase is its own spec → plan → implementation cycle.
 5. **MCP manage tier.** Template/sequence CRUD, bulk marks, reassign, delete contact, draft write,
    outbox actions, cancel enrollment.
 6. **MCP admin tier.** `email:admin` toolset, admin-role gated (R3).
-7. **WebMCP convergence.** Autonomy (P3, with R1 mitigations), then the manage/admin breadth —
-   sequenced last because it carries the most risk.
+7. **WebMCP convergence.** Configurable per-capability autonomy (P3, off by default, with R1
+   mitigations), then the manage-tier breadth. WebMCP admin deferred (D3); destructive/admin stay
+   confirm-gated. Sequenced last because it carries the most risk.
 
 ---
 

--- a/docs/specs/2026-08-30-agent-entrypoint-parity-design.md
+++ b/docs/specs/2026-08-30-agent-entrypoint-parity-design.md
@@ -1,0 +1,269 @@
+# Agent Entrypoint Parity — Capability-Tier Policy
+
+**Status:** Design / policy (this round is documentation only — no code).
+**Date:** 2026-08-30
+**Author:** i@choy.in (+ Claude)
+
+## 1. Context & goal
+
+saasmail exposes its capabilities to autonomous and semi-autonomous agents through **three
+distinct entrypoints**, each with its own auth pipeline and its own (accidentally divergent)
+subset of features:
+
+1. **Direct HTTP API** — the `/api/*` OpenAPI surface, authenticated by a better-auth session
+   cookie (the SPA) or an `sk_` API-key bearer token (integrations). This is the **superset**:
+   every capability the product has is reachable here.
+2. **Server-side MCP server** — a Streamable-HTTP MCP endpoint at `/mcp`, authenticated by OAuth
+   2.0 bearer JWTs with `email:read` / `email:send` / `email:manage` scopes. 12 tools today.
+3. **WebMCP (browser)** — in-page tools registered via `navigator.modelContext` (with the
+   `@mcp-b/global` polyfill), authenticated by the ambient logged-in session cookie. 19 tools
+   today, but every send/destructive action is staged behind a human confirmation.
+
+These three surfaces drifted apart because each was built against its own need. The result is a
+patchwork: MCP can _send_ a template but can't _discover_ which templates exist; WebMCP can
+_discover_ templates and sequences but can't _act_ on them autonomously; the direct API can do
+everything but grants an `sk_` key the full role of its owner with no scoping.
+
+**Goal (target state): full convergence.** Every `/api/*` capability has an equivalent function
+on **both** MCP and WebMCP, governed by a single four-tier scope model, with unified credentials
+across the API and MCP surfaces.
+
+This document defines that policy and maps every capability to its tier and its per-surface
+current-vs-target status. It is the reference the follow-up implementation rounds build against.
+
+## 2. Tier model
+
+Four capability tiers, reusing the scope strings already defined in
+`worker/src/auth/scopes.ts:8-12` and adding one:
+
+| Tier       | Scope string   | Authorizes                                                                                                                                                                                                                  | New?     |
+| ---------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **Read**   | `email:read`   | Discovery + reading: identity, inboxes, contacts, conversations, emails, search, templates, sequences, drafts, outbox, stats. No side effects.                                                                              | existing |
+| **Send**   | `email:send`   | Outbound effects: send raw/template email, reply, enroll in sequence.                                                                                                                                                       | existing |
+| **Manage** | `email:manage` | Mutating state without new outbound mail: mark read/unread, delete email, reassign, template CRUD, sequence CRUD, enrollment cancel, draft CRUD, outbox retry/cancel, contact delete, notifications, self-service API keys. | existing |
+| **Admin**  | `email:admin`  | Instance administration: invites, users, roles, inboxes + assignments, blocklist, suppressions, webhooks, oauth-apps, instance settings. Admin-role holders only.                                                           | **NEW**  |
+
+Scopes are cumulative in intent but enforced independently: a token/key carries an explicit set,
+and each capability requires exactly one tier. `email:admin` is only ever granted to a principal
+whose underlying user has the `admin` role — the scope is necessary but not sufficient.
+
+## 3. Governing principles
+
+Each is a stated policy with its rationale. Together they define "target state."
+
+**P1 — Four tiers, one vocabulary.** All three surfaces authorize against the same
+`email:read|send|manage|admin` scopes. The direct API stops inheriting the owner's full role;
+MCP and WebMCP stop inventing per-surface rules. _Rationale: one mental model, one place to reason
+about least privilege._
+
+**P2 — Every endpoint has an MCP function.** For every `/api/*` capability there is an equivalent
+MCP tool at the same tier, **including the admin tier** (behind `email:admin`). MCP becomes a
+complete mirror of the API, not a curated subset. _Rationale: agents shouldn't hit a capability
+cliff where they must fall back to raw HTTP._
+
+**P3 — WebMCP reaches functional + autonomous parity.** WebMCP exposes the same capability set and
+— per the target state — can send / reply / enroll / delete autonomously, matching MCP, rather
+than always staging behind a human confirmation. _Rationale: the user's decision is that all three
+surfaces converge equally. See R1 for the risk this accepts._
+
+**P4 — Credential unification.** An `sk_` API key is a valid MCP bearer token. A single credential
+authenticates against both `/api/*` and `/mcp`, carrying the same scope set on both. _Rationale:
+integrators manage one secret, not two, and the scope grant is identical wherever it's presented._
+
+**P5 — API keys honor tiers.** An `sk_` key carries an explicit scope set (`email:read|send|manage|admin`)
+chosen at creation, instead of silently inheriting its owner's entire role. Read-only and send-only
+keys become expressible. _Rationale: least privilege for integrations; today a leaked key = full
+account compromise._
+
+**P6 — Enforcement lives in the shared service layer.** Scope + inbox-scoping checks stay in the
+shared query/service functions (`lib/queries/*`, `lib/send-email.ts`, etc.) that back all surfaces,
+not re-implemented per entrypoint. _Rationale: MCP tools already call the same service functions as
+the routers (confirmed in the audit); parity must not fork that._
+
+## 4. Master capability matrix
+
+Legend — **✅** present & autonomous · **🔶** present but gated/partial · **❌** absent ·
+**→** target action. Every capability's target is "✅ on all three surfaces" unless the notes say
+otherwise; cells already ✅ need no work.
+
+### Read tier (`email:read`)
+
+| Capability                       | API | MCP                      | WebMCP                                  | Gap → target                                         |
+| -------------------------------- | --- | ------------------------ | --------------------------------------- | ---------------------------------------------------- |
+| Identity / whoami                | ✅  | ✅ `whoami`              | ✅ `whoami`                             | —                                                    |
+| List inboxes / sender identities | ✅  | 🔶 (inside `whoami`)     | ✅ `list_inboxes`                       | MCP: dedicated `list_inboxes` tool                   |
+| List contacts (grouped / search) | ✅  | ✅ `list_people`         | ✅ `list_contacts`/`list_conversations` | —                                                    |
+| Get contact + counts             | ✅  | ✅ `get_person`          | ✅ `get_contact`                        | —                                                    |
+| List emails by person            | ✅  | ✅ `list_emails`         | ✅ `list_emails`                        | —                                                    |
+| List emails by conversation      | ✅  | 🔶 (person-only)         | ✅ `list_emails(conversationId)`        | MCP: accept conversationId                           |
+| Read full email                  | ✅  | ✅ `read_email`          | ✅ `read_email`                         | —                                                    |
+| Search mail                      | ✅  | ✅ `search_emails`       | ✅ `search_emails`                      | —                                                    |
+| Download attachment bytes        | ✅  | ❌                       | ❌ (metadata only)                      | MCP + WebMCP: `get_attachment`                       |
+| Inline attachment                | ✅  | ❌                       | ❌                                      | MCP + WebMCP: expose or fold into `get_attachment`   |
+| List templates                   | ✅  | ❌                       | ✅ `list_templates`                     | **MCP: `list_templates`** (blocks `send_template`)   |
+| Get template + variables         | ✅  | ❌                       | ✅/🔶 `get_template`                    | **MCP: `get_template`**                              |
+| List sequences                   | ✅  | ❌                       | ✅ `list_sequences`                     | **MCP: `list_sequences`** (blocks `enroll_sequence`) |
+| Get sequence                     | ✅  | ❌                       | ❌                                      | MCP + WebMCP: `get_sequence`                         |
+| Get person enrollment            | ✅  | ❌                       | ❌                                      | MCP + WebMCP: `get_enrollment`                       |
+| List sequence enrollments        | ✅  | ❌                       | ❌                                      | MCP + WebMCP: `list_enrollments`                     |
+| Get draft                        | ✅  | ❌                       | ❌                                      | MCP + WebMCP: `get_draft`                            |
+| Outbox count / list              | ✅  | ❌                       | ❌                                      | MCP + WebMCP: `list_outbox`                          |
+| Instance stats                   | ✅  | 🔶 (partial in `whoami`) | ✅ (`fetchStats`)                       | MCP: `get_stats`                                     |
+
+### Send tier (`email:send`)
+
+| Capability          | API | MCP                       | WebMCP                                  | Gap → target                     |
+| ------------------- | --- | ------------------------- | --------------------------------------- | -------------------------------- |
+| Send raw email      | ✅  | ✅ `send_email`           | 🔶 `compose_email` (draft, human sends) | WebMCP: autonomous send (P3)     |
+| Reply (threaded)    | ✅  | ✅ `reply_email`          | 🔶 `reply_email` (human-confirmed)      | WebMCP: autonomous reply (P3)    |
+| Send template       | ✅  | ✅ `send_template`        | 🔶 `compose_from_template` (draft)      | WebMCP: autonomous send (P3)     |
+| Attachments on send | ✅  | ❌ (`files:[]` hardcoded) | ❌                                      | MCP + WebMCP: accept attachments |
+| Enroll in sequence  | ✅  | ✅ `enroll_sequence`      | 🔶 `enroll_in_sequence` (dialog)        | WebMCP: autonomous enroll (P3)   |
+
+### Manage tier (`email:manage`)
+
+| Capability                          | API | MCP                 | WebMCP                        | Gap → target                          |
+| ----------------------------------- | --- | ------------------- | ----------------------------- | ------------------------------------- |
+| Mark read/unread (single)           | ✅  | ✅ `mark_read`      | ✅ `mark_read`/`mark_unread`  | —                                     |
+| Bulk mark emails                    | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant            |
+| Bulk mark people/conversations read | ✅  | ❌                  | ❌                            | MCP + WebMCP: bulk variant            |
+| Patch single email flags (archive)  | ✅  | 🔶 (read flag only) | 🔶                            | MCP + WebMCP: full flag patch         |
+| Delete email                        | ✅  | ✅ `delete_email`   | 🔶 `delete_email` (confirmed) | WebMCP: autonomous per P3             |
+| Reassign email → person             | ✅  | ❌                  | ❌                            | MCP + WebMCP: `reassign_email`        |
+| Delete contact                      | ✅  | ❌                  | ❌                            | MCP + WebMCP: `delete_person`         |
+| Template create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: template CRUD           |
+| Sequence create/update/delete       | ✅  | ❌                  | ❌                            | MCP + WebMCP: sequence CRUD           |
+| Cancel enrollment                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: `cancel_enrollment`     |
+| Draft save/delete                   | ✅  | ❌                  | ❌                            | MCP + WebMCP: draft write/delete      |
+| Outbox retry / cancel               | ✅  | ❌                  | ❌                            | MCP + WebMCP: outbox actions          |
+| Notifications / web push            | ✅  | ❌                  | ❌                            | Decide: in-scope for agents? (see Q1) |
+| Self-service API-key mgmt           | ✅  | ❌                  | ❌                            | **Excluded from agents** — see Q2     |
+
+### Admin tier (`email:admin`, admin role only)
+
+| Capability                 | API | MCP | WebMCP | Gap → target              |
+| -------------------------- | --- | --- | ------ | ------------------------- |
+| Invites create/list/revoke | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Users list / role / delete | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Instance settings patch    | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Inboxes CRUD + assignments | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Blocklist CRUD + purge     | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Suppressions CRUD          | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| Webhooks get/set/test      | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+| OAuth-apps list/revoke     | ✅  | ❌  | ❌     | MCP + WebMCP: admin tools |
+
+## 5. Gap summary per surface
+
+**MCP — the big lift is discovery + management + admin.** It already has autonomous read/send.
+It needs, in rough priority order:
+
+1. **Read/discovery gaps that block existing tools:** `list_templates`, `get_template`,
+   `list_sequences`, `get_sequence` — today `send_template` and `enroll_sequence` require the agent
+   to guess slugs/ids.
+2. **Attachments:** unblock `files:[]` on send; add `get_attachment` for reading bytes.
+3. **Remaining read:** enrollments, drafts, outbox, dedicated inboxes/stats.
+4. **Manage tier:** template/sequence CRUD, bulk marks, reassign, delete contact, draft write,
+   outbox retry/cancel, enrollment cancel.
+5. **Admin tier:** new `email:admin` scope + a full admin toolset, admin-role gated.
+
+**WebMCP — the big lift is autonomy + the same management/admin breadth.** It already has the widest
+_read_ surface. It needs:
+
+1. **Autonomy (P3):** turn `compose_email`, `compose_from_template`, `reply_email`, `enroll_in_sequence`,
+   `delete_email` from staged/confirmed into autonomous, subject to R1's mitigations.
+2. **Attachments** on send + `get_attachment`.
+3. **Manage + admin tiers:** the same CRUD/bulk/admin breadth MCP needs, driven from the browser
+   session.
+
+**Direct API — the lift is authorization granularity, not features.** It has every capability. It
+needs P4/P5: scoped `sk_` keys, and those keys accepted as MCP bearer tokens.
+
+## 6. Credential-unification design (P4 + P5)
+
+Today the two pipelines are fully separate:
+
+- **API keys:** `Authorization: Bearer sk_…` → SHA-hashed → matched against `apiKeys.keyHash` →
+  resolves owning user, `authMethod="apiKey"`, **no scopes, full owner role**
+  (`worker/src/index.ts:174-199`).
+- **MCP tokens:** `Authorization: Bearer <JWT>` → offline JWS verification against better-auth JWKS,
+  issuer/audience checks, live revocation checks, **passkey required**, scopes parsed from the JWT
+  (`worker/src/mcp/http.ts:87-171`).
+
+**Target design (to be detailed in the implementation round):**
+
+1. The `/mcp` auth middleware detects credential shape. A token beginning `sk_` is resolved via the
+   API-key path; a JWT continues through the OAuth path.
+2. **Scopes for `sk_` keys:** stored on the `apiKeys` row (P5), read directly — no JWT claims. The
+   same scope set gates `/api/*` and `/mcp`.
+3. **Passkey-gate reconciliation (R2):** MCP currently rejects any principal without a passkey
+   because it grants more than the web API. Once the API grants the _same_ capabilities under the
+   same scopes, that asymmetry is gone — but the gate must be resolved _deliberately_. Options to
+   decide in implementation: (a) require the key's owner to have a passkey at key-creation time;
+   (b) drop the MCP passkey gate now that scopes bound the grant; (c) mark keys as
+   "MCP-eligible" only when minted under a passkey session. **Not decided here — flagged.**
+4. Inbox-scoping (`resolveAllowedInboxes`) and live revocation (disabled key, banned/deleted user)
+   apply identically regardless of credential shape.
+
+## 7. Risks & open questions
+
+**R1 — WebMCP autonomy × session-cookie auth = a prompt-injection blast radius.** An in-page agent
+that reads attacker-controlled email content _and_ can autonomously send/delete/administer, authed
+by the ambient session cookie, is a materially larger attack surface than today's confirm-gated
+design. This is an **accepted risk** per the convergence decision (P3). Suggested mitigations to
+carry into implementation: per-capability opt-in (autonomy off by default, enabled by explicit user
+setting per tier); keep destructive/admin tiers confirm-gated even when send is autonomous;
+require a recent user gesture / same-origin assertion before autonomous writes; rate-limit
+autonomous sends. **Recommendation:** revisit whether P3 should be softened to "configurable per
+capability" before the WebMCP autonomy round ships.
+
+**R2 — `sk_` key as MCP token bypasses the passkey gate.** See §6.3 — must be resolved explicitly,
+not inherited by accident.
+
+**R3 — Admin capabilities on agent surfaces widen impact of any credential leak.** An `email:admin`
+scope means a leaked/injected agent can create users or edit webhooks. Mitigation: `email:admin`
+never granted by default; separate opt-in at key/token creation; consider keeping admin _mutations_
+confirm-gated on WebMCP even under P3.
+
+**Q1 — Are notifications / web-push in scope for agents at all?** They're SPA-oriented
+(subscription lifecycle for a browser). Proposed: **out of scope** for MCP; irrelevant to WebMCP.
+Leave on the direct API only. _Confirm._
+
+**Q2 — Self-service API-key management via an agent.** An agent minting or rotating its own
+credentials is a privilege-escalation footgun. Proposed: **excluded** from both MCP and WebMCP;
+key management stays session + direct-API only. _Confirm._
+
+**Q3 — Does WebMCP need the admin tier at all?** Full convergence (P2/P3) says yes, but an
+in-browser agent performing instance administration is the highest-risk cell in the matrix.
+Proposed: admin tools land on **MCP first**, WebMCP admin deferred pending R1/R3 mitigations.
+_Confirm._
+
+## 8. Phased roadmap (follow-up rounds)
+
+Each phase is its own spec → plan → implementation cycle.
+
+1. **Tier foundation.** Add `email:admin` to `scopes.ts` and `OAUTH_SCOPES`; add a scope column to
+   `apiKeys`; scope enforcement plumbed through the shared service layer (P1, P6). No new tools yet.
+2. **MCP read/discovery parity.** `list_templates`, `get_template`, `list_sequences`,
+   `get_sequence`, enrollments, drafts, outbox, `get_stats`, `list_inboxes` — closes the cliffs
+   that block today's `send_template` / `enroll_sequence`.
+3. **Attachments everywhere.** Unblock `files:[]` on MCP send; `get_attachment` on MCP + WebMCP.
+4. **Credential unification.** `sk_` keys carry scopes (P5); `/mcp` accepts `sk_` keys (P4);
+   resolve R2. Scoped-key creation UI.
+5. **MCP manage tier.** Template/sequence CRUD, bulk marks, reassign, delete contact, draft write,
+   outbox actions, cancel enrollment.
+6. **MCP admin tier.** `email:admin` toolset, admin-role gated (R3).
+7. **WebMCP convergence.** Autonomy (P3, with R1 mitigations), then the manage/admin breadth —
+   sequenced last because it carries the most risk.
+
+---
+
+### Appendix — source references
+
+- Direct API routes & auth: `worker/src/index.ts` (mounts 231-282; auth 159-228), routers under
+  `worker/src/routers/`.
+- MCP server & tools: `worker/src/mcp/server.ts` (tools), `worker/src/mcp/http.ts` (auth/transport),
+  `worker/src/mcp/resource.ts` (`/mcp` path, audiences).
+- Scopes: `worker/src/auth/scopes.ts:8-12`; OAuth provider `worker/src/auth/index.ts:60-75`.
+- WebMCP: `src/webmcp/` — `registerTools.tsx` (assembly), `tools/read.ts`, `tools/actions.ts`,
+  `bridge.tsx` (confirmation staging), `runtime.ts` (polyfill); mounted in
+  `src/components/DashboardLayout.tsx:36-37`; feature flag `worker/src/routers/bootstrap-router.ts:64-73`.

--- a/src/webmcp/__tests__/read-tools.test.ts
+++ b/src/webmcp/__tests__/read-tools.test.ts
@@ -11,6 +11,9 @@ function makeDeps(overrides: any = {}) {
     fetchTemplates: vi.fn().mockResolvedValue([]),
     fetchTemplate: vi.fn().mockResolvedValue({ slug: "welcome" }),
     fetchSequences: vi.fn().mockResolvedValue([]),
+    fetchSequence: vi
+      .fn()
+      .mockResolvedValue({ id: "seq-1", name: "Onboarding", steps: [] }),
     fetchStats: vi
       .fn()
       .mockResolvedValue({ recipients: ["a@x.com"], senderIdentities: [] }),
@@ -45,9 +48,21 @@ describe("read tools", () => {
       "list_templates",
       "get_template",
       "list_sequences",
+      "get_sequence",
     ]) {
       expect(byName(tools, n)).toBeTruthy();
     }
+  });
+
+  it("get_sequence reads one sequence by id", async () => {
+    const deps = makeDeps();
+    const tools = createReadTools(deps);
+    const res = await byName(tools, "get_sequence").execute(
+      { sequenceId: "seq-1" },
+      { signal: new AbortController().signal },
+    );
+    expect(deps.fetchSequence).toHaveBeenCalledWith("seq-1");
+    expect(res.content[0].text).toContain("Onboarding");
   });
 
   it("search_emails calls the api and returns JSON", async () => {

--- a/src/webmcp/registerTools.tsx
+++ b/src/webmcp/registerTools.tsx
@@ -11,6 +11,7 @@ import {
   fetchTemplates,
   fetchTemplate,
   fetchSequences,
+  fetchSequence,
   fetchStats,
   searchEmails,
   markEmailRead,
@@ -22,10 +23,10 @@ import { useWebMcpBridge } from "./bridge";
 import { createReadTools } from "./tools/read";
 import { createActionTools } from "./tools/actions";
 
-// 11 read tools + 8 action tools. Pinned by
+// 12 read tools + 8 action tools. Pinned by
 // src/webmcp/__tests__/registerTools.test.tsx so this can't silently drift
 // from the tool factories it's built from.
-export const WEBMCP_TOOL_COUNT = 19;
+export const WEBMCP_TOOL_COUNT = 20;
 
 /**
  * Registers every WebMCP read + action tool with the runtime for the
@@ -48,6 +49,7 @@ export function WebMcpTools({ enabled = true }: { enabled?: boolean }) {
       fetchTemplates,
       fetchTemplate,
       fetchSequences,
+      fetchSequence,
       fetchStats,
       searchEmails,
       getSession: () => authClient.getSession(),

--- a/src/webmcp/tools/read.ts
+++ b/src/webmcp/tools/read.ts
@@ -10,6 +10,7 @@ export interface ReadDeps {
   fetchTemplates: () => Promise<any>;
   fetchTemplate: (slug: string) => Promise<any>;
   fetchSequences: () => Promise<any>;
+  fetchSequence: (id: string) => Promise<any>;
   fetchStats: (recipient?: string) => Promise<any>;
   searchEmails: (p: { q: string; [k: string]: any }) => Promise<any>;
   getSession: () => Promise<any>;
@@ -193,6 +194,18 @@ export function createReadTools(deps: ReadDeps): WebMcpToolDescriptor[] {
       description: "List drip sequences the user can enroll contacts into.",
       inputSchema: { type: "object", properties: {} },
       execute: async () => okJson(await deps.fetchSequences()),
+    },
+    {
+      name: "get_sequence",
+      description:
+        "Get one drip sequence by id, including its ordered steps (template slug and delay per step).",
+      inputSchema: {
+        type: "object",
+        properties: { sequenceId: { type: "string" } },
+        required: ["sequenceId"],
+      },
+      execute: async (args) =>
+        okJson(await deps.fetchSequence(args.sequenceId)),
     },
   ];
 }

--- a/worker/src/__tests__/mcp-tools.test.ts
+++ b/worker/src/__tests__/mcp-tools.test.ts
@@ -10,6 +10,7 @@ import {
   getDb,
 } from "./helpers";
 import { sequences } from "../db/sequences.schema";
+import { emailTemplates } from "../db/email-templates.schema";
 import { sequenceEnrollments } from "../db/sequence-enrollments.schema";
 import { users } from "../db/auth.schema";
 import { emails } from "../db/emails.schema";
@@ -129,8 +130,12 @@ describe("MCP tools", () => {
           "delete_email",
           "enroll_sequence",
           "get_person",
+          "get_sequence",
+          "get_template",
           "list_emails",
           "list_people",
+          "list_sequences",
+          "list_templates",
           "mark_read",
           "read_email",
           "reply_email",
@@ -458,6 +463,104 @@ describe("MCP tools", () => {
         after: Math.floor(Date.now() / 1000) + 3600,
       });
       expect(out.data.hits).toEqual([]);
+    });
+  });
+
+  describe("list_templates / get_template", () => {
+    beforeEach(async () => {
+      // A global template (no fromAddress) any inbox may use...
+      await createTestTemplate({ slug: "welcome", subject: "Hi {{name}}" });
+      // ...and one bound to an inbox the member cannot see.
+      const now = Math.floor(Date.now() / 1000);
+      await getDb().insert(emailTemplates).values({
+        id: "tmpl-other-only",
+        slug: "other-only",
+        name: "Other only",
+        subject: "Secret",
+        bodyHtml: "<p>secret</p>",
+        fromAddress: OTHER,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    it("lists global templates but hides another inbox's bound templates", async () => {
+      const out = await callTool(memberToken, "list_templates");
+      expect(out.isError, out.text).toBe(false);
+      const slugs = out.data.map((t: any) => t.slug).sort();
+      expect(slugs).toEqual(["welcome"]);
+    });
+
+    it("lets an admin see every template", async () => {
+      const out = await callTool(adminToken, "list_templates");
+      const slugs = out.data.map((t: any) => t.slug).sort();
+      expect(slugs).toEqual(["other-only", "welcome"]);
+    });
+
+    it("gets a global template by slug", async () => {
+      const out = await callTool(memberToken, "get_template", {
+        slug: "welcome",
+      });
+      expect(out.isError).toBe(false);
+      expect(out.data.subject).toBe("Hi {{name}}");
+    });
+
+    it("reports a template bound to another inbox as not found", async () => {
+      const out = await callTool(memberToken, "get_template", {
+        slug: "other-only",
+      });
+      expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
+    });
+
+    it("requires the read scope", async () => {
+      const bare = await getAccessToken(ADMIN, "openid");
+      const out = await callTool(bare, "list_templates");
+      expect(out.isError).toBe(true);
+      expect(out.text).toContain("email:read");
+    });
+  });
+
+  describe("list_sequences / get_sequence", () => {
+    beforeEach(async () => {
+      await createTestTemplate({ slug: "step-1", subject: "One" });
+      const now = Math.floor(Date.now() / 1000);
+      await getDb()
+        .insert(sequences)
+        .values({
+          id: "seq-1",
+          name: "Onboarding",
+          steps: JSON.stringify([
+            { order: 1, templateSlug: "step-1", delayHours: 0 },
+          ]),
+          createdAt: now,
+          updatedAt: now,
+        });
+    });
+
+    it("lists sequences with parsed steps", async () => {
+      const out = await callTool(memberToken, "list_sequences");
+      expect(out.isError, out.text).toBe(false);
+      expect(out.data).toHaveLength(1);
+      expect(out.data[0].id).toBe("seq-1");
+      expect(out.data[0].steps[0].templateSlug).toBe("step-1");
+    });
+
+    it("gets a sequence by id with parsed steps", async () => {
+      const out = await callTool(memberToken, "get_sequence", {
+        sequenceId: "seq-1",
+      });
+      expect(out.isError).toBe(false);
+      expect(out.data.name).toBe("Onboarding");
+      expect(Array.isArray(out.data.steps)).toBe(true);
+    });
+
+    it("reports an unknown sequence as not found", async () => {
+      const out = await callTool(memberToken, "get_sequence", {
+        sequenceId: "nope",
+      });
+      expect(out.isError).toBe(true);
+      expect(out.text).toContain("Not found");
     });
   });
 

--- a/worker/src/lib/queries/sequences.ts
+++ b/worker/src/lib/queries/sequences.ts
@@ -1,0 +1,37 @@
+import { eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { sequences } from "../../db/sequences.schema";
+
+type SequenceRow = typeof sequences.$inferSelect;
+
+/** A sequence with its `steps` JSON column parsed into an array. */
+export type SequenceWithSteps = Omit<SequenceRow, "steps"> & { steps: unknown };
+
+function parseSteps(row: SequenceRow): SequenceWithSteps {
+  return { ...row, steps: JSON.parse(row.steps) };
+}
+
+/**
+ * List every sequence, oldest first, with steps parsed. Sequences are global
+ * (not inbox-scoped) — the same set the HTTP list route returns. Shared so the
+ * MCP `list_sequences` tool stays in lockstep with the route.
+ */
+export async function listSequences(
+  db: DrizzleD1Database<any>,
+): Promise<SequenceWithSteps[]> {
+  const rows = await db.select().from(sequences).orderBy(sequences.createdAt);
+  return rows.map(parseSteps);
+}
+
+/** Fetch a sequence by id with steps parsed, or null when it does not exist. */
+export async function getSequenceById(
+  db: DrizzleD1Database<any>,
+  id: string,
+): Promise<SequenceWithSteps | null> {
+  const rows = await db
+    .select()
+    .from(sequences)
+    .where(eq(sequences.id, id))
+    .limit(1);
+  return rows.length === 0 ? null : parseSteps(rows[0]);
+}

--- a/worker/src/lib/queries/templates.ts
+++ b/worker/src/lib/queries/templates.ts
@@ -1,0 +1,68 @@
+import { eq, inArray, isNull, or } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { emailTemplates } from "../../db/email-templates.schema";
+import { isInboxAllowed, type AllowedInboxes } from "../inbox-permissions";
+
+export type TemplateRow = typeof emailTemplates.$inferSelect;
+
+/**
+ * List email templates visible to the caller. A template with a null
+ * `fromAddress` is global (visible to everyone); one bound to an inbox is only
+ * visible to callers allowed on that inbox. Admins see all.
+ *
+ * Shared by the HTTP list route and the MCP `list_templates` tool so both
+ * enforce the same visibility rule.
+ */
+export async function listTemplates(
+  db: DrizzleD1Database<any>,
+  allowed: AllowedInboxes,
+): Promise<TemplateRow[]> {
+  if (allowed.isAdmin) {
+    return db.select().from(emailTemplates);
+  }
+  if (allowed.inboxes.length === 0) {
+    return db
+      .select()
+      .from(emailTemplates)
+      .where(isNull(emailTemplates.fromAddress));
+  }
+  return db
+    .select()
+    .from(emailTemplates)
+    .where(
+      or(
+        isNull(emailTemplates.fromAddress),
+        inArray(emailTemplates.fromAddress, allowed.inboxes),
+      ),
+    );
+}
+
+/**
+ * Fetch a template by slug, or null when it does not exist OR the caller may
+ * not see it (a template bound to an inbox they are not allowed on). Collapsing
+ * both cases to null keeps callers from probing which slugs exist behind
+ * inboxes they cannot access.
+ */
+export async function getTemplateBySlug(
+  db: DrizzleD1Database<any>,
+  slug: string,
+  allowed: AllowedInboxes,
+): Promise<TemplateRow | null> {
+  const rows = await db
+    .select()
+    .from(emailTemplates)
+    .where(eq(emailTemplates.slug, slug))
+    .limit(1);
+  if (rows.length === 0) {
+    return null;
+  }
+  const template = rows[0];
+  if (
+    !allowed.isAdmin &&
+    template.fromAddress !== null &&
+    !isInboxAllowed(allowed, template.fromAddress)
+  ) {
+    return null;
+  }
+  return template;
+}

--- a/worker/src/mcp/server.ts
+++ b/worker/src/mcp/server.ts
@@ -20,6 +20,8 @@ import {
 import { templateVariablesSchema } from "../lib/template-variables-schema";
 import { deleteEmailWithAttachments } from "../lib/delete-email";
 import { searchEmails } from "../lib/queries/search";
+import { listTemplates, getTemplateBySlug } from "../lib/queries/templates";
+import { listSequences, getSequenceById } from "../lib/queries/sequences";
 
 export interface McpUser {
   id: string;
@@ -277,6 +279,60 @@ export function buildMcpServer(ctx: McpContext): McpServer {
           allowed,
         ),
       );
+    }),
+  );
+
+  server.registerTool(
+    "list_templates",
+    {
+      description:
+        "List the email templates you may use, with their slug, subject, and body. Call this to discover a valid slug before send_template — the slug is what send_template and sequence steps refer to.",
+      annotations: { readOnlyHint: true, title: "List Templates" },
+      inputSchema: {},
+    },
+    guard(ctx, SCOPE_READ, async () => ok(await listTemplates(db, allowed))),
+  );
+
+  server.registerTool(
+    "get_template",
+    {
+      description:
+        "Fetch one email template by slug, including its subject and HTML body so you can inspect the {{variables}} it expects before sending.",
+      annotations: { readOnlyHint: true, title: "Get Template" },
+      inputSchema: {
+        slug: z.string().describe("Template slug, from list_templates."),
+      },
+    },
+    guard(ctx, SCOPE_READ, async ({ slug }) => {
+      const template = await getTemplateBySlug(db, slug, allowed);
+      return template ? ok(template) : fail(NOT_FOUND);
+    }),
+  );
+
+  server.registerTool(
+    "list_sequences",
+    {
+      description:
+        "List the drip sequences available for enrollment, with their steps. Call this to discover a valid sequenceId before enroll_sequence.",
+      annotations: { readOnlyHint: true, title: "List Sequences" },
+      inputSchema: {},
+    },
+    guard(ctx, SCOPE_READ, async () => ok(await listSequences(db))),
+  );
+
+  server.registerTool(
+    "get_sequence",
+    {
+      description:
+        "Fetch one drip sequence by id, including its ordered steps (template slug and delay per step).",
+      annotations: { readOnlyHint: true, title: "Get Sequence" },
+      inputSchema: {
+        sequenceId: z.string().describe("Sequence id, from list_sequences."),
+      },
+    },
+    guard(ctx, SCOPE_READ, async ({ sequenceId }) => {
+      const sequence = await getSequenceById(db, sequenceId);
+      return sequence ? ok(sequence) : fail(NOT_FOUND);
     }),
   );
 

--- a/worker/src/routers/email-templates-router.ts
+++ b/worker/src/routers/email-templates-router.ts
@@ -1,7 +1,8 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { eq, inArray, isNull, or } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { assertInboxAllowed, isInboxAllowed } from "../lib/inbox-permissions";
+import { assertInboxAllowed } from "../lib/inbox-permissions";
+import { listTemplates, getTemplateBySlug } from "../lib/queries/templates";
 import { emailTemplates } from "../db/email-templates.schema";
 import { json200Response, json201Response } from "../lib/helpers";
 import { analyzeTemplate, TemplateParseError } from "../lib/interpolate";
@@ -131,25 +132,7 @@ const listTemplatesRoute = createRoute({
 emailTemplatesRouter.openapi(listTemplatesRoute, async (c) => {
   const db = c.get("db");
   const allowed = c.get("allowedInboxes")!;
-  let rows;
-  if (allowed.isAdmin) {
-    rows = await db.select().from(emailTemplates);
-  } else if (allowed.inboxes.length === 0) {
-    rows = await db
-      .select()
-      .from(emailTemplates)
-      .where(isNull(emailTemplates.fromAddress));
-  } else {
-    rows = await db
-      .select()
-      .from(emailTemplates)
-      .where(
-        or(
-          isNull(emailTemplates.fromAddress),
-          inArray(emailTemplates.fromAddress, allowed.inboxes),
-        ),
-      );
-  }
+  const rows = await listTemplates(db, allowed);
   return c.json(rows, 200);
 });
 
@@ -171,21 +154,12 @@ const getTemplateRoute = createRoute({
 emailTemplatesRouter.openapi(getTemplateRoute, async (c) => {
   const db = c.get("db");
   const { slug } = c.req.valid("param");
-  const rows = await db
-    .select()
-    .from(emailTemplates)
-    .where(eq(emailTemplates.slug, slug))
-    .limit(1);
-  if (rows.length === 0) {
+  const allowed = c.get("allowedInboxes")!;
+  const template = await getTemplateBySlug(db, slug, allowed);
+  if (!template) {
     return c.json({ error: "Template not found" }, 404);
   }
-  const allowed = c.get("allowedInboxes")!;
-  if (!allowed.isAdmin && rows[0].fromAddress !== null) {
-    if (!isInboxAllowed(allowed, rows[0].fromAddress)) {
-      return c.json({ error: "Template not found" }, 404);
-    }
-  }
-  return c.json(rows[0], 200);
+  return c.json(template, 200);
 });
 
 const updateTemplateRoute = createRoute({

--- a/worker/src/routers/sequences-router.ts
+++ b/worker/src/routers/sequences-router.ts
@@ -9,6 +9,7 @@ import { emailTemplates } from "../db/email-templates.schema";
 import { people } from "../db/people.schema";
 import { json200Response, json201Response } from "../lib/helpers";
 import { enrollPersonInSequence } from "../lib/enroll-sequence";
+import { listSequences, getSequenceById } from "../lib/queries/sequences";
 import type { Variables } from "../variables";
 import { bearerSecurity } from "../lib/openapi-auth";
 import {
@@ -100,11 +101,7 @@ const listRoute = createRoute({
 
 sequencesRouter.openapi(listRoute, async (c) => {
   const db = c.get("db");
-  const rows = await db.select().from(sequences).orderBy(sequences.createdAt);
-  const result = rows.map((r) => ({
-    ...r,
-    steps: JSON.parse(r.steps),
-  }));
+  const result = await listSequences(db);
   return c.json(result, 200);
 });
 
@@ -125,17 +122,13 @@ const getRoute = createRoute({
 sequencesRouter.openapi(getRoute, async (c) => {
   const db = c.get("db");
   const { id } = c.req.valid("param");
-  const rows = await db
-    .select()
-    .from(sequences)
-    .where(eq(sequences.id, id))
-    .limit(1);
+  const sequence = await getSequenceById(db, id);
 
-  if (rows.length === 0) {
+  if (!sequence) {
     return c.json({ error: "Sequence not found" }, 404);
   }
 
-  return c.json({ ...rows[0], steps: JSON.parse(rows[0].steps) }, 200);
+  return c.json(sequence, 200);
 });
 
 // --- CREATE sequence ---


### PR DESCRIPTION
Reconciles the three agent entrypoints — direct HTTP API, server-side MCP, and WebMCP — starting with a governing policy and the first implementation slice.

## 1. Policy (docs)

`docs/specs/2026-08-30-agent-entrypoint-parity-design.md` — an audit of all three surfaces plus a capability×tier×surface matrix and the governing policy. Four tiers reusing the existing scope strings (`email:read|send|manage`) + a new `email:admin`. Target state: every `/api/*` capability has an MCP equivalent, credentials unify (an `sk_` key doubles as an MCP token), API keys honor tiers, and WebMCP reaches functional parity with **configurable per-capability autonomy** (off by default). Decisions D1–D3 and risks R1–R3 recorded. §8 sequences the rollout into 7 phases, one PR each.

## 2. First slice: templates & sequences discovery

The audit's highest-impact functional gap: MCP could `send_template` / `enroll_sequence` but had **no way to discover** which templates/sequences exist — agents had to guess slugs and ids. WebMCP could discover templates/sequences but lacked `get_sequence`.

- **Shared query layer (P6):** extracted `lib/queries/templates.ts` and `lib/queries/sequences.ts`; refactored the HTTP routers to use them so the MCP tools enforce the **same inbox-scoping** (a template bound to an inbox stays hidden from callers not on it) instead of re-implementing it. Router behavior is unchanged (existing 47 router tests pass as-is).
- **MCP** (`email:read`): `list_templates`, `get_template`, `list_sequences`, `get_sequence`. Denials surface as `NOT_FOUND`, matching the other read tools.
- **WebMCP:** `get_sequence` (its `fetchSequence` client already existed); tool count 19 → 20.

## Tests

- MCP: discovery coverage including template inbox-scoping (member sees global but not another inbox's bound template; admin sees all) and read-scope enforcement. `tools/list` pin updated. `mcp-tools.test.ts` → 55 pass.
- WebMCP web suite (22) green; `get_sequence` asserted.
- `tsc -b` clean on all changed files.

Note: the full local `yarn test` run showed timeouts under load (many unrelated files); each affected file passes in isolation — it's parallel-run contention, not a regression.

## Not in this PR (per the roadmap)
Tier foundation (`email:admin` + scoped keys), credential unification, attachments, manage/admin tiers, and WebMCP autonomy — each lands as its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtTMzcB7PvzyCN3fqohjsf